### PR TITLE
Allow setting of WKT precision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ if(S2GEOGRAPHY_BUILD_TESTS)
   enable_testing()
 
   add_executable(distance_test src/s2geography/distance_test.cc)
+  add_executable(wkt_writer_test src/s2geography/wkt-writer_test.cc)
 
   if (S2GEOGRAPHY_CODE_COVERAGE)
     target_compile_options(coverage_config INTERFACE -O0 -g --coverage)
@@ -194,9 +195,11 @@ if(S2GEOGRAPHY_BUILD_TESTS)
   endif()
 
   target_link_libraries(distance_test s2geography GTest::gtest_main)
+  target_link_libraries(wkt_writer_test s2geography GTest::gtest_main)
 
   include(GoogleTest)
   gtest_discover_tests(distance_test)
+  gtest_discover_tests(wkt_writer_test)
 endif()
 
 if(S2GEOGRAPHY_BUILD_EXAMPLES)

--- a/src/s2geography/wkt-writer.cc
+++ b/src/s2geography/wkt-writer.cc
@@ -17,8 +17,8 @@ namespace s2geography {
 
 class WKTStreamWriter : public Handler {
  public:
-  WKTStreamWriter(std::ostream& stream)
-      : significant_digits_(16),
+  WKTStreamWriter(std::ostream& stream, int significant_digits = 16)
+      : significant_digits_(significant_digits),
         is_first_ring_(true),
         is_first_coord_(true),
         dimensions_(util::Dimensions::XY),
@@ -182,9 +182,12 @@ class WKTStreamWriter : public Handler {
   void write_char(char value) { stream_ << std::string(&value, 1); }
 };
 
-WKTWriter::WKTWriter()
+WKTWriter::WKTWriter() : WKTWriter(16) {}
+
+WKTWriter::WKTWriter(int significant_digits)
     : geometry_type_(util::GeometryType::GEOMETRY_TYPE_UNKNOWN) {
-  this->exporter_ = absl::make_unique<WKTStreamWriter>(stream_);
+  this->exporter_ =
+      absl::make_unique<WKTStreamWriter>(stream_, significant_digits);
   exporter_->new_dimensions(util::Dimensions::XY);
   exporter_->new_geometry_type(util::GeometryType::GEOMETRY_TYPE_UNKNOWN);
 }

--- a/src/s2geography/wkt-writer.h
+++ b/src/s2geography/wkt-writer.h
@@ -12,6 +12,8 @@ namespace s2geography {
 class WKTWriter {
  public:
   WKTWriter();
+  WKTWriter(int significant_digits);
+
   std::string write_feature(const Geography& geog);
 
  private:

--- a/src/s2geography/wkt-writer_test.cc
+++ b/src/s2geography/wkt-writer_test.cc
@@ -1,0 +1,19 @@
+
+#include <gtest/gtest.h>
+
+#include "s2geography.h"
+
+using namespace s2geography;
+
+TEST(WKTWriter, SignificantDigits) {
+  WKTReader reader;
+  // Lat/lon is converted to XYZ here for the internals, so
+  // we need to pick a value that will roundtrip with 16 digits of precision
+  auto geog = reader.read_feature("POINT (0 3.333333333333334)");
+
+  WKTWriter writer_default;
+  EXPECT_EQ(writer_default.write_feature(*geog), "POINT (0 3.333333333333334)");
+
+  WKTWriter writer_6digits(6);
+  EXPECT_EQ(writer_6digits.write_feature(*geog), "POINT (0 3.33333)");
+}


### PR DESCRIPTION
For https://github.com/benbovy/spherely/issues/8 .

(Because the internal representation is XYZ on the unit sphere, roundtripping problems like this frequently happen at the default of 16 digits of precision.)