### PR TITLE
Hide ArrowArray/Schema from public geoarrow API

### DIFF
--- a/src/s2geography/geoarrow.cc
+++ b/src/s2geography/geoarrow.cc
@@ -1,13 +1,13 @@
 
 #include <sstream>
 
-#include "geoarrow/geoarrow.h"
-
 #include "s2/s1angle.h"
 #include "s2/s2edge_tessellator.h"
 #include "s2/s2projections.h"
 #include "s2geography/geoarrow.h"
 #include "s2geography/geography.h"
+
+#include "vendored/geoarrow/geoarrow.h"
 
 namespace s2geography {
 
@@ -591,7 +591,7 @@ class ReaderImpl {
     }
   }
 
-  void Init(const ArrowSchema* schema, const ImportOptions& options) {
+  void Init(const struct ArrowSchema* schema, const ImportOptions& options) {
     options_ = options;
 
     int code = GeoArrowArrayViewInitFromSchema(&array_view_, schema, &error_);
@@ -621,7 +621,7 @@ class ReaderImpl {
     }
   }
 
-  void ReadGeography(const ArrowArray* array, int64_t offset, int64_t length,
+  void ReadGeography(const struct ArrowArray* array, int64_t offset, int64_t length,
                      std::vector<std::unique_ptr<Geography>>* out) {
     int code = GeoArrowArrayViewSetArray(&array_view_, array, &error_);
     ThrowNotOk(code);
@@ -719,8 +719,8 @@ Reader::Reader() : impl_(new ReaderImpl()) {}
 
 Reader::~Reader() { impl_.reset(); }
 
-void Reader::Init(const ArrowSchema* schema, const ImportOptions& options) {
-  impl_->Init(schema, options);
+void Reader::Init(const void* schema, const ImportOptions& options) {
+  impl_->Init(static_cast<const struct ArrowSchema*>(schema), options);
 }
 
 void Reader::Init(InputType input_type, const ImportOptions& options) {
@@ -736,10 +736,10 @@ void Reader::Init(InputType input_type, const ImportOptions& options) {
   }
 }
 
-void Reader::ReadGeography(const ArrowArray* array, int64_t offset,
+void Reader::ReadGeography(const void* array, int64_t offset,
                            int64_t length,
                            std::vector<std::unique_ptr<Geography>>* out) {
-  impl_->ReadGeography(array, offset, length, out);
+  impl_->ReadGeography(static_cast<const struct ArrowArray*>(array), offset, length, out);
 }
 
 }  // namespace geoarrow

--- a/src/s2geography/geoarrow.h
+++ b/src/s2geography/geoarrow.h
@@ -8,103 +8,6 @@
 #include "s2/s2projections.h"
 #include "s2geography/geography.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-// Extra guard for versions of Arrow without the canonical guard
-#ifndef ARROW_FLAG_DICTIONARY_ORDERED
-
-#ifndef ARROW_C_DATA_INTERFACE
-#define ARROW_C_DATA_INTERFACE
-
-#define ARROW_FLAG_DICTIONARY_ORDERED 1
-#define ARROW_FLAG_NULLABLE 2
-#define ARROW_FLAG_MAP_KEYS_SORTED 4
-
-struct ArrowSchema {
-  // Array type description
-  const char* format;
-  const char* name;
-  const char* metadata;
-  int64_t flags;
-  int64_t n_children;
-  struct ArrowSchema** children;
-  struct ArrowSchema* dictionary;
-
-  // Release callback
-  void (*release)(struct ArrowSchema*);
-  // Opaque producer-specific data
-  void* private_data;
-};
-
-struct ArrowArray {
-  // Array data description
-  int64_t length;
-  int64_t null_count;
-  int64_t offset;
-  int64_t n_buffers;
-  int64_t n_children;
-  const void** buffers;
-  struct ArrowArray** children;
-  struct ArrowArray* dictionary;
-
-  // Release callback
-  void (*release)(struct ArrowArray*);
-  // Opaque producer-specific data
-  void* private_data;
-};
-
-#endif  // ARROW_C_DATA_INTERFACE
-
-#ifndef ARROW_C_STREAM_INTERFACE
-#define ARROW_C_STREAM_INTERFACE
-
-struct ArrowArrayStream {
-  // Callback to get the stream type
-  // (will be the same for all arrays in the stream).
-  //
-  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
-  //
-  // If successful, the ArrowSchema must be released independently from the
-  // stream.
-  int (*get_schema)(struct ArrowArrayStream*, struct ArrowSchema* out);
-
-  // Callback to get the next array
-  // (if no error and the array is released, the stream has ended)
-  //
-  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
-  //
-  // If successful, the ArrowArray must be released independently from the
-  // stream.
-  int (*get_next)(struct ArrowArrayStream*, struct ArrowArray* out);
-
-  // Callback to get optional detailed error information.
-  // This must only be called if the last stream operation failed
-  // with a non-0 return code.
-  //
-  // Return value: pointer to a null-terminated character array describing
-  // the last error, or NULL if no description is available.
-  //
-  // The returned pointer is only valid until the next operation on this stream
-  // (including release).
-  const char* (*get_last_error)(struct ArrowArrayStream*);
-
-  // Release callback: release the stream's own resources.
-  // Note that arrays returned by `get_next` must be individually released.
-  void (*release)(struct ArrowArrayStream*);
-
-  // Opaque producer-specific data
-  void* private_data;
-};
-
-#endif  // ARROW_C_STREAM_INTERFACE
-#endif  // ARROW_FLAG_DICTIONARY_ORDERED
-
-#ifdef __cplusplus
-}
-#endif
-
 namespace s2geography {
 
 namespace geoarrow {
@@ -148,13 +51,13 @@ class Reader {
   Reader();
   ~Reader();
 
-  void Init(const ArrowSchema* schema) { Init(schema, ImportOptions()); }
+  void Init(const void* schema) { Init(schema, ImportOptions()); }
 
-  void Init(const ArrowSchema* schema, const ImportOptions& options);
+  void Init(const void* schema, const ImportOptions& options);
 
   void Init(InputType input_type, const ImportOptions& options);
 
-  void ReadGeography(const ArrowArray* array, int64_t offset, int64_t length,
+  void ReadGeography(const void* array, int64_t offset, int64_t length,
                      std::vector<std::unique_ptr<Geography>>* out);
 
  private:

--- a/src/s2geography/wkt-reader.cc
+++ b/src/s2geography/wkt-reader.cc
@@ -8,6 +8,8 @@
 #include "s2geography/geoarrow.h"
 #include "s2geography/geography.h"
 
+#include "vendored/geoarrow/geoarrow.h"
+
 namespace s2geography {
 
 WKTReader::WKTReader(const geoarrow::ImportOptions& options) {


### PR DESCRIPTION
Not entirely sure this is the best solution, but with those changes I manage to get working bindings in spherely using the new `s2geography::geoarrow:Reader`