### PR TITLE
refactor: Reuse GeoArrowArrayReader in ReaderImpl

### DIFF
--- a/src/s2geography/geoarrow.h
+++ b/src/s2geography/geoarrow.h
@@ -46,6 +46,10 @@ class ImportOptions {
 
 class ReaderImpl;
 
+/// \brief Array reader for any GeoArrow extension array
+///
+/// This class is used to convert an ArrowArray with geoarrow data (serialized
+/// or native) into a vector of Geography objects.
 class Reader {
  public:
   enum class InputType { kWKT, kWKB };


### PR DESCRIPTION
I am not entirely sure this is desired (it gives a bit of overhead), but while trying to understand the reader/writer/builder/visitor hierarchy in geoarrow-c, I noticed that here we were not using `GeoArrowArrayReader`, but the separate readers for WKT/WKB (`GeoArrowWKTReader`/`GeoArrowWKBReader`) and `GeoArrowArrayViewVisit` for native coords, duplicating the iteration function for WKT/WKB.
While the `GeoArrowArrayReader` already abstracts away those three options behind a single interface.

This gives a bit more overhead for the scalar `WKTReader` (I assume because this constructs a `geoarrow::Reader` every time, and this now not just initializes the `GeoArrowWKTReader`, but also the other structs for WKB and native). 
Given this is the scalar version (and you can always ensure to start from arrow input for optimal performance), I think that overhead is acceptable. But alternatively, we could also update `GeoArrowArrayReader` to only initialize the WKT/WKB readers if needed (when it gets data passed with that type), instead of upfront. Or another option is to expose the `GeoArrowArrayViewVisitWKT/WKB` functions in geoarrow.h, so that we can at least avoid reimplementing those.

Also added some brief doc comments.