### PR TITLE
PolygonGeography default constructor: create empty S2Polygon

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup mambaforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Miniforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
           activate-environment: s2geography-dev
           use-mamba: true

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -19,12 +19,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup mambaforge
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Miniforge
           miniforge-version: latest
           activate-environment: s2geography-dev
           use-mamba: true
+          mamba-version: "*"
 
       - name: Get Date
         id: get-date

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup mambaforge
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge
           miniforge-version: latest
           activate-environment: s2geography-dev
           use-mamba: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ if(S2GEOGRAPHY_BUILD_TESTS)
 
   add_executable(distance_test src/s2geography/distance_test.cc)
   add_executable(geoarrow_test src/s2geography/geoarrow_test.cc)
+  add_executable(geography_test src/s2geography/geography_test.cc)
   add_executable(wkt_writer_test src/s2geography/wkt-writer_test.cc)
 
   if (S2GEOGRAPHY_CODE_COVERAGE)
@@ -266,11 +267,13 @@ if(S2GEOGRAPHY_BUILD_TESTS)
 
   target_link_libraries(distance_test s2geography GTest::gtest_main)
   target_link_libraries(geoarrow_test s2geography nanoarrow GTest::gtest_main)
+  target_link_libraries(geography_test s2geography nanoarrow GTest::gtest_main)
   target_link_libraries(wkt_writer_test s2geography GTest::gtest_main)
 
   include(GoogleTest)
   gtest_discover_tests(distance_test)
   gtest_discover_tests(geoarrow_test)
+  gtest_discover_tests(geography_test)
   gtest_discover_tests(wkt_writer_test)
 endif()
 

--- a/src/s2geography/geography.h
+++ b/src/s2geography/geography.h
@@ -117,7 +117,7 @@ class PolylineGeography : public Geography {
 // perspective).
 class PolygonGeography : public Geography {
  public:
-  PolygonGeography() {}
+  PolygonGeography() : polygon_(std::make_unique<S2Polygon>()) {}
   PolygonGeography(std::unique_ptr<S2Polygon> polygon)
       : polygon_(std::move(polygon)) {}
 

--- a/src/s2geography/geography_test.cc
+++ b/src/s2geography/geography_test.cc
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+#include "s2geography.h"
+#include "s2geography/geography.h"
+
+using namespace s2geography;
+
+TEST(Geography, EmptyPolygon) {
+  PolygonGeography geog;
+
+  EXPECT_TRUE(geog.Polygon()->is_empty());
+}


### PR DESCRIPTION
I've been struggling a bit with segmentation faults before realizing that the `PolygonGeography()` default constructor was creating a new object with an empty `polygon_` pointer.

This PR now creates a Polygon geography by default with an empty S2Polygon object, which I think is more predictable and more consistent with other geography types returning an empty container (vector) by default. However, I'm not sure how empty polygons are checked elsewhere here or in downstream libraries (R's s2?) ; if they explicitly check for `std::nullptr_t` then this is a breaking change.



