### PR TITLE
feat: add projections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ add_library(s2geography
     src/s2geography/accessors.cc
     src/s2geography/distance.cc
     src/s2geography/predicates.cc
+    src/s2geography/projections.cc
     src/s2geography/build.cc
     src/s2geography/geography.cc
     src/s2geography/geoarrow.cc

--- a/src/s2geography.h
+++ b/src/s2geography.h
@@ -15,5 +15,6 @@
 #include "s2geography/index.h"
 #include "s2geography/linear-referencing.h"
 #include "s2geography/predicates.h"
+#include "s2geography/projections.h"
 #include "s2geography/wkt-reader.h"
 #include "s2geography/wkt-writer.h"

--- a/src/s2geography/geoarrow.cc
+++ b/src/s2geography/geoarrow.cc
@@ -6,7 +6,6 @@
 #include "geoarrow/geoarrow.h"
 #include "s2/s1angle.h"
 #include "s2/s2edge_tessellator.h"
-#include "s2/s2projections.h"
 #include "s2geography/geography.h"
 
 namespace s2geography {
@@ -15,10 +14,6 @@ namespace geoarrow {
 
 const char* version() { return GeoArrowVersion(); }
 
-S2::Projection* lnglat() {
-  static S2::PlateCarreeProjection projection(180);
-  return &projection;
-}
 
 // This should really be in nanoarrow or geoarrow
 // https://github.com/geoarrow/geoarrow-c-geos/blob/33ad0ba21c76c09e9d72fc4e4ae0b9ff9da61848/src/geoarrow_geos/geoarrow_geos.c#L323-L360

--- a/src/s2geography/geoarrow.h
+++ b/src/s2geography/geoarrow.h
@@ -24,15 +24,15 @@ class TessellationOptions {
   TessellationOptions()
       : projection_(lnglat()),
         tessellate_tolerance_(S1Angle::Infinity()) {}
-  S2::Projection* projection() const { return projection_; }
-  void set_projection(S2::Projection* projection) { projection_ = projection; }
+  S2::Projection* projection() const { return projection_.get(); }
+  void set_projection(std::shared_ptr<S2::Projection>& projection) { projection_ = std::move(projection); }
   S1Angle tessellate_tolerance() const { return tessellate_tolerance_; }
   void set_tessellate_tolerance(S1Angle tessellate_tolerance) {
     tessellate_tolerance_ = tessellate_tolerance;
   }
 
  protected:
-  S2::Projection* projection_;
+  std::shared_ptr<S2::Projection> projection_;
   S1Angle tessellate_tolerance_;
 };
 

--- a/src/s2geography/geoarrow.h
+++ b/src/s2geography/geoarrow.h
@@ -8,6 +8,7 @@
 #include "s2/s2projections.h"
 #include "s2geography/arrow_abi.h"
 #include "s2geography/geography.h"
+#include "s2geography/projections.h"
 
 namespace s2geography {
 
@@ -15,8 +16,6 @@ namespace geoarrow {
 
 /// \brief Inspect the underlying GeoArrow implementation version
 const char* version();
-
-S2::Projection* lnglat();
 
 /// \brief Options used to build Geography objects from GeoArrow arrays
 

--- a/src/s2geography/geoarrow.h
+++ b/src/s2geography/geoarrow.h
@@ -22,10 +22,10 @@ const char* version();
 class TessellationOptions {
  public:
   TessellationOptions()
-      : projection_(lnglat()),
+      : projection_(std::move(lnglat())),
         tessellate_tolerance_(S1Angle::Infinity()) {}
   S2::Projection* projection() const { return projection_.get(); }
-  void set_projection(std::shared_ptr<S2::Projection>& projection) { projection_ = std::move(projection); }
+  void set_projection(std::shared_ptr<S2::Projection> projection) { projection_ = std::move(projection); }
   S1Angle tessellate_tolerance() const { return tessellate_tolerance_; }
   void set_tessellate_tolerance(S1Angle tessellate_tolerance) {
     tessellate_tolerance_ = tessellate_tolerance;

--- a/src/s2geography/projections.cc
+++ b/src/s2geography/projections.cc
@@ -8,14 +8,14 @@
 
 namespace s2geography {
 
-S2::Projection* lnglat() {
-  static S2::PlateCarreeProjection projection(180);
-  return &projection;
+std::shared_ptr<S2::Projection> lnglat() {
+  std::shared_ptr<S2::Projection> projection = std::make_shared<S2::PlateCarreeProjection>(180);
+  return projection;
 }
 
-S2::Projection* mercator() {
-  static S2::MercatorProjection projection(20037508.3427892);
-  return &projection;
+std::shared_ptr<S2::Projection> mercator() {
+  std::shared_ptr<S2::Projection> projection = std::make_shared<S2::MercatorProjection>(20037508.3427892);
+  return projection;
 }
 
 class OrthographicProjection: public S2::Projection {
@@ -60,9 +60,9 @@ private:
   S2Point y_axis_;
 };
 
-S2::Projection* orthographic(const S2LatLng& centre) {
-  static OrthographicProjection projection(centre);
-  return &projection;
+std::shared_ptr<S2::Projection> orthographic(const S2LatLng& centre) {
+  std::shared_ptr<S2::Projection> projection = std::make_shared<OrthographicProjection>(centre);
+  return projection;
 }
 
 }  // namespace s2geography

--- a/src/s2geography/projections.cc
+++ b/src/s2geography/projections.cc
@@ -1,0 +1,11 @@
+
+#include "s2/s2projections.h"
+
+namespace s2geography {
+
+S2::Projection* lnglat() {
+  static S2::PlateCarreeProjection projection(180);
+  return &projection;
+}
+
+}  // namespace s2geography

--- a/src/s2geography/projections.cc
+++ b/src/s2geography/projections.cc
@@ -10,14 +10,14 @@ namespace s2geography {
 
 std::shared_ptr<S2::Projection> lnglat() {
   std::shared_ptr<S2::Projection> projection = std::make_shared<S2::PlateCarreeProjection>(180);
-  return projection;
+  return std::move(projection);
 }
 
 std::shared_ptr<S2::Projection> pseudo_mercator() {
   // the semi-major axis of the WGS 84 ellipsoid is 6378137 meters
   // -> half of the circumference of the sphere is PI * 6378137 = 20037508.3427892
   std::shared_ptr<S2::Projection> projection = std::make_shared<S2::MercatorProjection>(20037508.3427892);
-  return projection;
+  return std::move(projection);
 }
 
 class OrthographicProjection: public S2::Projection {
@@ -64,7 +64,7 @@ private:
 
 std::shared_ptr<S2::Projection> orthographic(const S2LatLng& centre) {
   std::shared_ptr<S2::Projection> projection = std::make_shared<OrthographicProjection>(centre);
-  return projection;
+  return std::move(projection);
 }
 
 }  // namespace s2geography

--- a/src/s2geography/projections.cc
+++ b/src/s2geography/projections.cc
@@ -8,4 +8,9 @@ S2::Projection* lnglat() {
   return &projection;
 }
 
+S2::Projection* mercator() {
+  static S2::MercatorProjection projection(20037508.3427892);
+  return &projection;
+}
+
 }  // namespace s2geography

--- a/src/s2geography/projections.cc
+++ b/src/s2geography/projections.cc
@@ -1,6 +1,11 @@
 
 #include "s2/s2projections.h"
 
+#include <s2/r2.h>
+#include <s2/s2latlng.h>
+#include <s2/s2point.h>
+#include <s2/s2pointutil.h>
+
 namespace s2geography {
 
 S2::Projection* lnglat() {
@@ -10,6 +15,53 @@ S2::Projection* lnglat() {
 
 S2::Projection* mercator() {
   static S2::MercatorProjection projection(20037508.3427892);
+  return &projection;
+}
+
+class OrthographicProjection: public S2::Projection {
+public:
+  OrthographicProjection(const S2LatLng& centre):
+      centre_(centre) {
+    z_axis_ = S2Point(0, 0, 1);
+    y_axis_ = S2Point(0, 1, 0);
+  }
+
+  // Converts a point on the sphere to a projected 2D point.
+  R2Point Project(const S2Point& p) const {
+    S2Point out = S2::Rotate(p, z_axis_, -centre_.lng());
+    out = S2::Rotate(out, y_axis_, centre_.lat());
+    return R2Point(out.y(), out.z());
+  }
+
+  // Converts a projected 2D point to a point on the sphere.
+  S2Point Unproject(const R2Point& p) const {
+    double y = p.x();
+    double z = p.y();
+    double x = sqrt(1.0 - y * y - z * z);
+    S2Point pp(x, y, z);
+    S2Point out = S2::Rotate(pp, y_axis_, -centre_.lat());
+    out = S2::Rotate(out, z_axis_, centre_.lng());
+    return out;
+  }
+
+  R2Point FromLatLng(const S2LatLng& ll) const {
+    return Project(ll.ToPoint());
+  }
+
+  S2LatLng ToLatLng(const R2Point& p) const {
+    return S2LatLng(Unproject(p));
+  }
+
+  R2Point wrap_distance() const {return R2Point(0, 0); }
+
+private:
+  S2LatLng centre_;
+  S2Point z_axis_;
+  S2Point y_axis_;
+};
+
+S2::Projection* orthographic(const S2LatLng& centre) {
+  static OrthographicProjection projection(centre);
   return &projection;
 }
 

--- a/src/s2geography/projections.cc
+++ b/src/s2geography/projections.cc
@@ -13,7 +13,9 @@ std::shared_ptr<S2::Projection> lnglat() {
   return projection;
 }
 
-std::shared_ptr<S2::Projection> mercator() {
+std::shared_ptr<S2::Projection> pseudo_mercator() {
+  // the semi-major axis of the WGS 84 ellipsoid is 6378137 meters
+  // -> half of the circumference of the sphere is PI * 6378137 = 20037508.3427892
   std::shared_ptr<S2::Projection> projection = std::make_shared<S2::MercatorProjection>(20037508.3427892);
   return projection;
 }

--- a/src/s2geography/projections.h
+++ b/src/s2geography/projections.h
@@ -5,6 +5,14 @@
 
 namespace s2geography {
 
+// Constructs the "plate carree" projection which maps coordinates on the sphere
+// to (longitude, latitude) pairs.
+// The x coordinates (longitude) span [-180, 180] and the y coordinates (latitude)
+// span [-90, 90].
 S2::Projection* lnglat();
+
+// Constructs the spherical Mercator projection. When used together with WGS84
+// coordinates, known as the "Web Mercator" projection.
+S2::Projection* mercator();
 
 }  // namespace s2geography

--- a/src/s2geography/projections.h
+++ b/src/s2geography/projections.h
@@ -9,15 +9,15 @@ namespace s2geography {
 // to (longitude, latitude) pairs.
 // The x coordinates (longitude) span [-180, 180] and the y coordinates (latitude)
 // span [-90, 90].
-S2::Projection* lnglat();
+std::shared_ptr<S2::Projection> lnglat();
 
 // Constructs the spherical Mercator projection. When used together with WGS84
 // coordinates, known as the "Web Mercator" projection.
-S2::Projection* mercator();
+std::shared_ptr<S2::Projection> mercator();
 
 // Constructs an orthographic projection with the given centre point. The
 // resulting coordinates depict a single hemisphere of the globe as it appears
 // from outer space, centred on the given point.
-S2::Projection* orthographic(const S2LatLng& centre);
+std::shared_ptr<S2::Projection> orthographic(const S2LatLng& centre);
 
 }  // namespace s2geography

--- a/src/s2geography/projections.h
+++ b/src/s2geography/projections.h
@@ -1,0 +1,10 @@
+
+#pragma once
+
+#include "s2/s2projections.h"
+
+namespace s2geography {
+
+S2::Projection* lnglat();
+
+}  // namespace s2geography

--- a/src/s2geography/projections.h
+++ b/src/s2geography/projections.h
@@ -12,8 +12,8 @@ namespace s2geography {
 std::shared_ptr<S2::Projection> lnglat();
 
 // Constructs the spherical Mercator projection. When used together with WGS84
-// coordinates, known as the "Web Mercator" projection.
-std::shared_ptr<S2::Projection> mercator();
+// coordinates, known as the "Web Mercator" or "WGS84/Pseudo-Mercator" projection.
+std::shared_ptr<S2::Projection> pseudo_mercator();
 
 // Constructs an orthographic projection with the given centre point. The
 // resulting coordinates depict a single hemisphere of the globe as it appears

--- a/src/s2geography/projections.h
+++ b/src/s2geography/projections.h
@@ -15,4 +15,9 @@ S2::Projection* lnglat();
 // coordinates, known as the "Web Mercator" projection.
 S2::Projection* mercator();
 
+// Constructs an orthographic projection with the given centre point. The
+// resulting coordinates depict a single hemisphere of the globe as it appears
+// from outer space, centred on the given point.
+S2::Projection* orthographic(const S2LatLng& centre);
+
 }  // namespace s2geography


### PR DESCRIPTION
Moving the `lnglat()` projection definition (which is currently already used in the geoarrow import/export) to its own file, so we can easily add more (without making geoarrow.cc unwieldy large).

Will add additional ones in a next commit.