### PR TITLE
chore: Enable more compiler warnings in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,9 @@ project(
 include(FetchContent)
 message(STATUS "Building using CMake version: ${CMAKE_VERSION}")
 
-# We need at least C++17 for recent s2 but if this value is already
-# set (e.g., to a higher standard) it should be respected.
-if (NOT DEFINED CMAKE_CXX_STANDARD)
+# We need at least C++17 for recent s2 but if this value is already set (e.g.,
+# to a higher standard) it should be respected.
+if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD
       17
       CACHE STRING "The C++ standard to build with")
@@ -267,26 +267,28 @@ target_link_libraries(s2geography PUBLIC s2::s2 absl::memory absl::str_format)
 
 # Set somewhat aggressive compiler warning flags
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-  target_compile_options(s2geography
-                          PRIVATE $<$<CONFIG:Debug>:-Wall
-                                  -Werror
-                                  -Wextra
-                                  -Wpedantic
-                                  -Wno-type-limits
-                                  -Wmaybe-uninitialized
-                                  -Wunused-result
-                                  -Wconversion
-                                  -Wno-sign-conversion>)
-elseif(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID STREQUAL
-                                                    "Clang")
-  target_compile_options(s2geography
-                          PRIVATE $<$<CONFIG:Debug>:-Wall
-                                  -Werror
-                                  -Wextra
-                                  -Wpedantic
-                                  -Wdocumentation
-                                  -Wconversion
-                                  -Wno-sign-conversion>)
+  target_compile_options(
+    s2geography
+    PRIVATE $<$<CONFIG:Debug>:-Wall
+            -Werror
+            -Wextra
+            -Wpedantic
+            -Wno-type-limits
+            -Wmaybe-uninitialized
+            -Wunused-result
+            -Wconversion
+            -Wno-sign-conversion>)
+elseif(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID
+                                                    STREQUAL "Clang")
+  target_compile_options(
+    s2geography
+    PRIVATE $<$<CONFIG:Debug>:-Wall
+            -Werror
+            -Wextra
+            -Wpedantic
+            -Wdocumentation
+            -Wconversion
+            -Wno-sign-conversion>)
 endif()
 
 if(S2GEOGRAPHY_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,15 @@ project(
 include(FetchContent)
 message(STATUS "Building using CMake version: ${CMAKE_VERSION}")
 
-set(CMAKE_CXX_STANDARD
-    17
-    CACHE STRING "The C++ standard to build with")
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# We need at least C++17 for recent s2 but if this value is already
+# set (e.g., to a higher standard) it should be respected.
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD
+      17
+      CACHE STRING "The C++ standard to build with")
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -259,6 +264,30 @@ if(MSVC)
 endif()
 
 target_link_libraries(s2geography PUBLIC s2::s2 absl::memory absl::str_format)
+
+# Set somewhat aggressive compiler warning flags
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(s2geography
+                          PRIVATE $<$<CONFIG:Debug>:-Wall
+                                  -Werror
+                                  -Wextra
+                                  -Wpedantic
+                                  -Wno-type-limits
+                                  -Wmaybe-uninitialized
+                                  -Wunused-result
+                                  -Wconversion
+                                  -Wno-sign-conversion>)
+elseif(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID STREQUAL
+                                                    "Clang")
+  target_compile_options(s2geography
+                          PRIVATE $<$<CONFIG:Debug>:-Wall
+                                  -Werror
+                                  -Wextra
+                                  -Wpedantic
+                                  -Wdocumentation
+                                  -Wconversion
+                                  -Wno-sign-conversion>)
+endif()
 
 if(S2GEOGRAPHY_BUILD_TESTS)
 

--- a/src/s2geography/geography.cc
+++ b/src/s2geography/geography.cc
@@ -15,6 +15,8 @@
 #include <s2/s2shape_index_region.h>
 #include <s2/s2shapeutil_coding.h>
 
+#include "s2geography/macros.h"
+
 using namespace s2geography;
 
 // This class is a shim to allow a class to return a std::unique_ptr<S2Shape>(),
@@ -83,6 +85,7 @@ void Geography::GetCellUnionBound(std::vector<S2CellId>* cell_ids) const {
 }
 
 std::unique_ptr<S2Shape> PointGeography::Shape(int id) const {
+  S2GEOGRAPHY_UNUSED(id);
   return absl::make_unique<S2PointVectorShape>(points_);
 }
 
@@ -452,6 +455,8 @@ void ShapeIndexGeography::Encode(Encoder* encoder,
 
 void EncodedShapeIndexGeography::Encode(Encoder* encoder,
                                         const EncodeOptions& options) const {
+  S2GEOGRAPHY_UNUSED(encoder);
+  S2GEOGRAPHY_UNUSED(options);
   throw Exception("Encode() not implemented for EncodedShapeIndexGeography()");
 }
 

--- a/src/s2geography/macros.h
+++ b/src/s2geography/macros.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <s2/base/logging.h>
+
+#define S2GEOGRAPHY_DCHECK S2_DCHECK
+
+#define S2GEOGRAPHY_UNUSED(x) (void)(x)

--- a/src/s2geography/op/cell.cc
+++ b/src/s2geography/op/cell.cc
@@ -79,7 +79,7 @@ int8_t Level::ExecuteScalar(const uint64_t cell_id) {
     return -1;
   }
 
-  return cell.level();
+  return static_cast<int8_t>(cell.level());
 }
 
 double Area::ExecuteScalar(const uint64_t cell_id) {
@@ -108,9 +108,9 @@ uint64_t Parent::ExecuteScalar(const uint64_t cell_id, const int8_t level) {
   }
 
   int8_t level_final;
-  int8_t cell_level = cell.level();
+  int8_t cell_level = static_cast<int8_t>(cell.level());
   if (level < 0) {
-    level_final = cell.level() + level;
+    level_final = cell_level + level;
   } else {
     level_final = level;
   }
@@ -193,7 +193,7 @@ int8_t CommonAncestorLevel::ExecuteScalar(const uint64_t cell_id,
     return -1;
   }
 
-  return cell.GetCommonAncestorLevel(cell_test);
+  return static_cast<int8_t>(cell.GetCommonAncestorLevel(cell_test));
 }
 
 }  // namespace s2geography::op::cell

--- a/src/s2geography/op/op.h
+++ b/src/s2geography/op/op.h
@@ -35,7 +35,7 @@ class UnaryOp {
 
   UnaryOp(const OptT& options = OptT()) : options_(options) {}
   virtual void Init() {}
-  virtual ReturnT ExecuteScalar(const ArgType0 arg0) { return ReturnT(); }
+  virtual ReturnT ExecuteScalar(const ArgType0) { return ReturnT{}; }
 
  protected:
   OptT options_;
@@ -52,7 +52,7 @@ class BinaryOp {
 
   BinaryOp(const OptionsT& options = OptionsT()) : options_(options) {}
   virtual void Init() {}
-  virtual ReturnT ExecuteScalar(const ArgType0 arg0, const ArgType1 arg1) {
+  virtual ReturnT ExecuteScalar(const ArgType0, const ArgType1) {
     return ReturnT{};
   }
 

--- a/src/s2geography/projections.cc
+++ b/src/s2geography/projections.cc
@@ -11,18 +11,14 @@
 namespace s2geography {
 
 std::shared_ptr<S2::Projection> lnglat() {
-  std::shared_ptr<S2::Projection> projection =
-      std::make_shared<S2::PlateCarreeProjection>(180);
-  return std::move(projection);
+  return std::make_shared<S2::PlateCarreeProjection>(180);
 }
 
 std::shared_ptr<S2::Projection> pseudo_mercator() {
   // the semi-major axis of the WGS 84 ellipsoid is 6378137 meters
   // -> half of the circumference of the sphere is PI * 6378137 =
   // 20037508.3427892
-  std::shared_ptr<S2::Projection> projection =
-      std::make_shared<S2::MercatorProjection>(20037508.3427892);
-  return std::move(projection);
+  return std::make_shared<S2::MercatorProjection>(20037508.3427892);
 }
 
 class OrthographicProjection : public S2::Projection {
@@ -71,9 +67,7 @@ class OrthographicProjection : public S2::Projection {
 };
 
 std::shared_ptr<S2::Projection> orthographic(const S2LatLng& centre) {
-  std::shared_ptr<S2::Projection> projection =
-      std::make_shared<OrthographicProjection>(centre);
-  return std::move(projection);
+  return std::make_shared<OrthographicProjection>(centre);
 }
 
 }  // namespace s2geography


### PR DESCRIPTION
This PR fixes some compiler warnings and enables more of them in a normal debug build such that they are spotted early.