### PR TITLE
cmake: exclude nanoarrow from all install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,9 @@ if(S2GEOGRAPHY_BUILD_TESTS)
 
   FetchContent_MakeAvailable(nanoarrow)
 
+  # do not install nanoarrow by default when running cmake --install
+  set_property(DIRECTORY ${nanoarrow_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL YES)
+
   if(S2GEOGRAPHY_CODE_COVERAGE)
     add_library(coverage_config INTERFACE)
   endif()


### PR DESCRIPTION
I noticed that in https://github.com/conda-forge/s2geography-feedstock/pull/9.

IIUC nanoarrow is only required for building and running the tests?