### PR TITLE
CMake: re-add OpenSSL as explicit requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,10 +173,11 @@ elseif(${S2_SOURCE} STREQUAL "SYSTEM")
   endif()
 endif()
 
-# this might be needed since s2geometry includes it in general
-# but not for any target explicilty?
+# this might be needed since s2geometry includes it in general but not for any
+# target explicilty?
 find_package(OpenSSL REQUIRED)
-target_include_directories(${s2_NOALIAS_TARGET} INTERFACE ${OPENSSL_INCLUDE_DIR})
+target_include_directories(${s2_NOALIAS_TARGET}
+                           INTERFACE ${OPENSSL_INCLUDE_DIR})
 
 # --- Abseil (bundled build not supported)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,11 @@ elseif(${S2_SOURCE} STREQUAL "SYSTEM")
   endif()
 endif()
 
+# this might be needed since s2geometry includes it in general
+# but not for any target explicilty?
+find_package(OpenSSL REQUIRED)
+target_include_directories(${s2_NOALIAS_TARGET} INTERFACE ${OPENSSL_INCLUDE_DIR})
+
 # --- Abseil (bundled build not supported)
 
 find_package(absl REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,9 +173,9 @@ elseif(${S2_SOURCE} STREQUAL "SYSTEM")
   endif()
 endif()
 
-# This is needed so the openssl header files included via s2geometry
-# are found even when s2geometry is installed in another prefix path
-# (e.g., current CI builds of spherely python wheels).
+# This is needed so the openssl header files included via s2geometry are found
+# even when s2geometry is installed in another prefix path (e.g., current CI
+# builds of spherely python wheels).
 find_package(OpenSSL REQUIRED)
 target_include_directories(${s2_NOALIAS_TARGET}
                            INTERFACE ${OPENSSL_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,8 +173,9 @@ elseif(${S2_SOURCE} STREQUAL "SYSTEM")
   endif()
 endif()
 
-# this might be needed since s2geometry includes it in general but not for any
-# target explicilty?
+# This is needed so the openssl header files included via s2geometry
+# are found even when s2geometry is installed in another prefix path
+# (e.g., current CI builds of spherely python wheels).
 find_package(OpenSSL REQUIRED)
 target_include_directories(${s2_NOALIAS_TARGET}
                            INTERFACE ${OPENSSL_INCLUDE_DIR})


### PR DESCRIPTION
For more context:

- https://github.com/paleolimbot/s2geography/pull/32/files#r1865998806
- #22 (original PR)

I'm not sure exactly what would be a proper fix, but at least this solves Spherely package builds (https://github.com/benbovy/spherely/pull/81) and hopefully doesn't introduce regressions in other build configurations.