### PR TITLE
fix: Allow invalid polylines and polygons to be constructed and decoded

### DIFF
--- a/src/s2geography/geoarrow.cc
+++ b/src/s2geography/geoarrow.cc
@@ -287,11 +287,9 @@ class PolylineConstructor : public Constructor {
 
     if (!points_.empty()) {
       auto polyline = absl::make_unique<S2Polyline>();
+      polyline->set_s2debug_override(S2Debug::DISABLE);
       polyline->Init(std::move(points_));
 
-      // Previous version of s2 didn't check for this, so in
-      // this check is temporarily disabled to avoid mayhem in
-      // reverse dependency checks.
       if (options_.check() && !polyline->IsValid()) {
         polyline->FindValidationError(&error_);
         throw Exception(error_.text());

--- a/src/s2geography/geography.cc
+++ b/src/s2geography/geography.cc
@@ -346,6 +346,7 @@ void PolylineGeography::Decode(Decoder* decoder, const EncodeTag& tag) {
   uint32_t n_polylines = decoder->get32();
   for (uint32_t i = 0; i < n_polylines; i++) {
     auto polyline = absl::make_unique<S2Polyline>();
+    polyline->set_s2debug_override(S2Debug::DISABLE);
     if (!polyline->Decode(decoder)) {
       throw Exception("PolylineGeography::Decode error at item " +
                       std::to_string(i));
@@ -366,6 +367,7 @@ void PolygonGeography::Decode(Decoder* decoder, const EncodeTag& tag) {
   }
 
   tag.SkipCovering(decoder);
+  polygon_->set_s2debug_override(S2Debug::DISABLE);
   polygon_->Decode(decoder);
 }
 

--- a/src/s2geography/geography_test.cc
+++ b/src/s2geography/geography_test.cc
@@ -277,7 +277,9 @@ TEST(Geography, EncodedShapeIndex) {
 void TestEncodeWKTRoundtrip(const std::string& wkt,
                             const EncodeOptions& options) {
   SCOPED_TRACE(wkt + " / " + ::testing::PrintToString(options) + " (WKT)");
-  WKTReader reader;
+  geoarrow::ImportOptions import_options;
+  import_options.set_check(false);
+  WKTReader reader(import_options);
   std::unique_ptr<Geography> original_geog = reader.read_feature(wkt);
   // Make sure the original geography matches the given WKT
   ASSERT_THAT(*original_geog, WktEquals6(wkt));
@@ -368,6 +370,13 @@ TEST(Geography, EncodeRoundtrip) {
       }
     }
   }
+}
+
+TEST(Geography, EncodeRoundtripInvalid) {
+  EncodeOptions opt;
+  ASSERT_NO_FATAL_FAILURE(
+      TestEncodeWKTRoundtrip("LINESTRING (0 0, 0 0, 1 1)", opt));
+  ASSERT_NO_FATAL_FAILURE(TestEncodeWKTRoundtrip("POLYGON ((0 0, 0 0))", opt));
 }
 
 }  // namespace s2geography

--- a/src/s2geography/wkt-writer_test.cc
+++ b/src/s2geography/wkt-writer_test.cc
@@ -96,6 +96,15 @@ TEST(WKTWriter, MixedCollection) {
   EXPECT_EQ(wktRoundTrip(wkt), wkt);
 }
 
+TEST(WKTWriter, InvalidPolyline) {
+  WKTReader reader;
+  try {
+    auto geog = reader.read_feature("LINESTRING (0 0, 0 0, 1 1)");
+  } catch (std::exception &e) {
+    EXPECT_EQ(std::string(e.what()), "Vertices 0 and 1 are identical");
+  }
+}
+
 TEST(WKTWriter, InvalidPolygon) {
   WKTReader reader;
   try {


### PR DESCRIPTION
In general it's a good idea to make leave validation on when importing from a foreign source; however, it's annoying to have debug builds crash whenever invalid input happens (so that we can test the behaviour of invalid things or check for their existence).

Superceeds #58.