### PR TITLE
Make `static_assert(false, ...)` well formed

### DIFF
--- a/src/s2geography/arrow_udf/arrow_udf_internal.h
+++ b/src/s2geography/arrow_udf/arrow_udf_internal.h
@@ -13,7 +13,8 @@ namespace s2geography {
 namespace arrow_udf {
 
 /// \brief Helper to detect unreachable code, for use in static_assert
-template <class... T> struct always_false : std::false_type {};
+template <class... T>
+struct always_false : std::false_type {};
 
 /// \brief Friendlier UDF wrapper
 ///


### PR DESCRIPTION
Hello!
When trying to update duckdb-geography to DuckDB v1.3.2 I got [hit with this in my CI](https://github.com/Maxxen/duckdb-geography/actions/runs/17047603471/job/48327336388). Turns out C++17 have a special case for `constexpr` conditionals that make instantiating `static_assert(false, ...)` always ill-formed, even if it's in a constexpr false branch. This PR adds the commonly occurring "always_false<T>" helper trait work around this by making the assert dependent on the template.