### PR TITLE
Implement s2_touches predicate

### DIFF
--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -35,19 +35,25 @@ bool s2_contains(const ShapeIndexGeography& geog1,
   }
 }
 
-// Note that 'touches' can be implemented using:
-//
-// S2BooleanOperation::Options closedOptions = options;
-// closedOptions.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
-// closedOptions.set_polyline_model(S2BooleanOperation::PolylineModel::CLOSED);
-// S2BooleanOperation::Options openOptions = options;
-// openOptions.set_polygon_model(S2BooleanOperation::PolygonModel::OPEN);
-// openOptions.set_polyline_model(S2BooleanOperation::PolylineModel::OPEN);
-// s2_intersects(geog1, geog2, closed_options) &&
-//   !s2_intersects(geog1, geog2, open_options);
-//
-// ...it isn't implemented here because the options creation should be done
-// outside of any loop.
+TouchesPredicate::TouchesPredicate(const S2BooleanOperation::Options& options)
+    : closed_options_(options), open_options_(options) {
+  closed_options_.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
+  closed_options_.set_polyline_model(S2BooleanOperation::PolylineModel::CLOSED);
+  open_options_.set_polygon_model(S2BooleanOperation::PolygonModel::OPEN);
+  open_options_.set_polyline_model(S2BooleanOperation::PolylineModel::OPEN);
+}
+
+bool TouchesPredicate::operator()(const ShapeIndexGeography& geog1,
+                                  const ShapeIndexGeography& geog2) const {
+  return s2_intersects(geog1, geog2, closed_options_) &&
+         !s2_intersects(geog1, geog2, open_options_);
+}
+
+bool s2_touches(const ShapeIndexGeography& geog1,
+                const ShapeIndexGeography& geog2,
+                const S2BooleanOperation::Options& options) {
+  return TouchesPredicate(options)(geog1, geog2);
+}
 
 bool s2_intersects_box(const ShapeIndexGeography& geog1,
                        const S2LatLngRect& rect,

--- a/src/s2geography/predicates.h
+++ b/src/s2geography/predicates.h
@@ -20,6 +20,20 @@ bool s2_contains(const ShapeIndexGeography& geog1,
                  const ShapeIndexGeography& geog2,
                  const S2BooleanOperation::Options& options);
 
+/// Pre-computes closed/open boundary options for efficient repeated
+/// s2_touches() evaluation in a loop.
+class TouchesPredicate {
+ public:
+  explicit TouchesPredicate(const S2BooleanOperation::Options& options);
+
+  bool operator()(const ShapeIndexGeography& geog1,
+                  const ShapeIndexGeography& geog2) const;
+
+ private:
+  S2BooleanOperation::Options closed_options_;
+  S2BooleanOperation::Options open_options_;
+};
+
 bool s2_touches(const ShapeIndexGeography& geog1,
                 const ShapeIndexGeography& geog2,
                 const S2BooleanOperation::Options& options);


### PR DESCRIPTION
## Summary
- Implements `s2_touches()` which was declared in `predicates.h` but had no function body (only a comment describing the algorithm)
- Adds a `TouchesPredicate` class that pre-computes closed/open boundary options, addressing the original comment's concern about options creation in loops
- The convenience `s2_touches()` function delegates to `TouchesPredicate` for single-call usage

Human note:

Not sure if this is the desired approach.  But I'm not particularly sure if the touches options can somehow be a module level constant or something...

🤖 Generated with [Claude Code](https://claude.com/claude-code)