### PR TITLE
Try find_package(nanoarrow) before FetchContent fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,9 +199,10 @@ endif()
 if(NOT TARGET nanoarrow)
   find_package(nanoarrow QUIET)
   if(nanoarrow_FOUND)
-    # nanoarrow::nanoarrow may be an ALIAS target (e.g., to nanoarrow::nanoarrow_shared
-    # or nanoarrow::nanoarrow_static), and CMake does not allow creating an alias of an
-    # alias. Resolve to the underlying IMPORTED target.
+    # nanoarrow::nanoarrow may be an ALIAS target (e.g., to
+    # nanoarrow::nanoarrow_shared or nanoarrow::nanoarrow_static), and CMake
+    # does not allow creating an alias of an alias. Resolve to the underlying
+    # IMPORTED target.
     if(TARGET nanoarrow::nanoarrow_shared)
       add_library(nanoarrow ALIAS nanoarrow::nanoarrow_shared)
     elseif(TARGET nanoarrow::nanoarrow_static)


### PR DESCRIPTION
## Summary

- Try `find_package(nanoarrow QUIET)` before falling back to `FetchContent`
- When a system nanoarrow is found, create a plain `nanoarrow` alias target so the existing `if(NOT TARGET nanoarrow)` guard skips the download
- Handles the CMake alias-of-alias restriction by resolving `nanoarrow::nanoarrow_shared` or `nanoarrow::nanoarrow_static` as the alias target

**Motivation:** When nanoarrow is installed as a system package, there is no need to download it via FetchContent. This is useful for distro packaging and build systems like Yggdrasil/BinaryBuilder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)