### PR TITLE
Fix cross-compilation for Windows with MinGW/GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,11 +292,13 @@ target_compile_definitions(
          S2_VERSION_PATCH=${S2_VERSION_PATCH}
   PRIVATE ${GEOARROW_COMPILE_DEFINITIONS})
 
-if(MSVC)
+if(WIN32)
   # used in s2geometry's CMakeLists.txt but not defined in target
   target_compile_definitions(s2geography PUBLIC _USE_MATH_DEFINES)
   target_compile_definitions(s2geography PUBLIC NOMINMAX)
-  target_compile_options(s2geography PUBLIC /J)
+  if(MSVC)
+    target_compile_options(s2geography PUBLIC /J)
+  endif()
 endif()
 
 target_link_libraries(


### PR DESCRIPTION
## Summary

- Change `if(MSVC)` to `if(WIN32)` for `_USE_MATH_DEFINES` and `NOMINMAX` compile definitions so they apply when cross-compiling for Windows with MinGW/GCC (not just MSVC)
- Keep the `/J` compiler flag guarded by `if(MSVC)` since it is MSVC-specific

## Context

Discovered when cross-compiling s2geography for Windows with MinGW/GCC in [Yggdrasil/BinaryBuilder](https://github.com/JuliaPackaging/Yggdrasil). Without `_USE_MATH_DEFINES`, `M_PI` and other math constants from `<cmath>` are undefined on MinGW, causing compilation failures. `NOMINMAX` is similarly needed on all Windows toolchains to avoid `min`/`max` macro conflicts from `<windows.h>`.