### PR TITLE
chore(ci): Update conda version in CI

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -80,7 +80,6 @@ jobs:
         shell: bash -l {0}
         run: |
           cmake --build build --config Release
-
       - name: Run tests
         shell: bash -l {0}
         run: |

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - cxx-compiler
-  - s2geometry
+  - s2geometry >=0.11
   - libabseil
   - cmake


### PR DESCRIPTION
The conda in CI for the run-tests workflow is resolving the oldest possible s2geography, which we no longer support. (I suppose we could support it if we needed to but I'm not sure we do!). This PR pins the version to be at least a version we do.

Closes #72.