### PR TITLE
chore: Separate geography interface header from concerete implementations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ add_library(
   src/s2geography/distance.cc
   src/s2geography/geoarrow-geography.cc
   src/s2geography/geoarrow.cc
+  src/s2geography/geography_interface.cc
   src/s2geography/geography.cc
   src/s2geography/linear-referencing.cc
   src/s2geography/op/cell.cc

--- a/src/s2geography.h
+++ b/src/s2geography.h
@@ -11,6 +11,7 @@
 #include "s2geography/distance.h"
 #include "s2geography/geoarrow.h"
 #include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 #include "s2geography/index.h"
 #include "s2geography/linear-referencing.h"
 #include "s2geography/predicates.h"

--- a/src/s2geography/accessors-geog.cc
+++ b/src/s2geography/accessors-geog.cc
@@ -5,7 +5,7 @@
 
 #include "s2geography/accessors.h"
 #include "s2geography/build.h"
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 #include "s2geography/sedona_udf/sedona_udf_internal.h"
 
 namespace s2geography {

--- a/src/s2geography/accessors.cc
+++ b/src/s2geography/accessors.cc
@@ -4,7 +4,7 @@
 #include <s2/s2earth.h>
 
 #include "s2geography/build.h"
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 #include "s2geography/sedona_udf/sedona_udf_internal.h"
 
 namespace s2geography {

--- a/src/s2geography/accessors.h
+++ b/src/s2geography/accessors.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 #include "s2geography/sedona_udf/sedona_extension.h"
 
 namespace s2geography {

--- a/src/s2geography/aggregator.h
+++ b/src/s2geography/aggregator.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 
 namespace s2geography {
 

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -11,7 +11,7 @@
 #include <sstream>
 
 #include "s2geography/accessors.h"
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 #include "s2geography/macros.h"
 #include "s2geography/sedona_udf/sedona_udf_internal.h"
 

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -1,6 +1,7 @@
 
 #include "s2geography/geoarrow-geography.h"
 
+#include <s2/s2loop_measures.h>
 #include <s2/s2point.h>
 #include <s2/s2projections.h>
 #include <s2/s2shapeutil_get_reference_point.h>
@@ -9,7 +10,7 @@
 #include <cstring>
 #include <limits>
 
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 
 namespace s2geography {
 

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "geoarrow/geoarrow.hpp"
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 #include "s2geography/wkt-reader.h"
 
 using namespace s2geography;

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "geoarrow/geoarrow.hpp"
-#include "s2geography/geography_interface.h"
+#include "s2geography/geography.h"
 #include "s2geography/wkt-reader.h"
 
 using namespace s2geography;

--- a/src/s2geography/geoarrow.h
+++ b/src/s2geography/geoarrow.h
@@ -7,7 +7,7 @@
 #include "s2/s1angle.h"
 #include "s2/s2projections.h"
 #include "s2geography/arrow_abi.h"
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 #include "s2geography/projections.h"
 
 namespace s2geography {

--- a/src/s2geography/geography.cc
+++ b/src/s2geography/geography.cc
@@ -17,64 +17,10 @@
 
 #include <sstream>
 
+#include "s2geography/geography_interface.h"
 #include "s2geography/macros.h"
 
 using namespace s2geography;
-
-// This class is a shim to allow a class to return a std::unique_ptr<S2Shape>(),
-// which is required by MutableS2ShapeIndex::Add(), without copying the
-// underlying data. S2Shape instances do not typically own their data (e.g.,
-// S2Polygon::Shape), so this does not change the general relationship (that
-// anything returned by Geography::Shape() is only valid within the scope of
-// the Geography). Note that this class is also available (but not exposed) in
-// s2/s2shapeutil_coding.cc.
-class S2ShapeWrapper : public S2Shape {
- public:
-  S2ShapeWrapper(const S2Shape* shape) : shape_(shape) {}
-  int num_edges() const { return shape_->num_edges(); }
-  Edge edge(int edge_id) const { return shape_->edge(edge_id); }
-  int dimension() const { return shape_->dimension(); }
-  ReferencePoint GetReferencePoint() const {
-    return shape_->GetReferencePoint();
-  }
-  int num_chains() const { return shape_->num_chains(); }
-  Chain chain(int chain_id) const { return shape_->chain(chain_id); }
-  Edge chain_edge(int chain_id, int offset) const {
-    return shape_->chain_edge(chain_id, offset);
-  }
-  ChainPosition chain_position(int edge_id) const {
-    return shape_->chain_position(edge_id);
-  }
-
- private:
-  const S2Shape* shape_;
-};
-
-// Just like the S2ShapeWrapper, the S2RegionWrapper helps reconcile the
-// differences in lifecycle expectation between S2 and Geography. We often
-// need access to a S2Region to generalize algorithms; however, there are some
-// operations that need ownership of the region (e.g., the S2RegionUnion). In
-// Geography the assumption is that anything returned by a Geography is only
-// valid for the lifetime of the underlying Geography. A different design of
-// the algorithms implemented here might well make this unnecessary.
-class S2RegionWrapper : public S2Region {
- public:
-  S2RegionWrapper(S2Region* region) : region_(region) {}
-  S2Region* Clone() const { return region_->Clone(); }
-  S2Cap GetCapBound() const { return region_->GetCapBound(); }
-  S2LatLngRect GetRectBound() const { return region_->GetRectBound(); }
-  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const {
-    return region_->GetCellUnionBound(cell_ids);
-  }
-  bool Contains(const S2Cell& cell) const { return region_->Contains(cell); }
-  bool MayIntersect(const S2Cell& cell) const {
-    return region_->MayIntersect(cell);
-  }
-  bool Contains(const S2Point& p) const { return region_->Contains(p); }
-
- private:
-  S2Region* region_;
-};
 
 void Geography::GetCellUnionBound(std::vector<S2CellId>* cell_ids) const {
   MutableS2ShapeIndex index;
@@ -575,81 +521,5 @@ std::unique_ptr<Geography> Geography::DecodeTagged(Decoder* decoder) {
     default: {
       throw Exception("DecodeTagged(): kind not implemented");
     }
-  }
-}
-
-void EncodeTag::Encode(Encoder* encoder) const {
-  encoder->Ensure(4 * sizeof(uint8_t));
-  encoder->put8(static_cast<uint8_t>(kind));
-  encoder->put8(flags);
-  encoder->put8(covering_size);
-  encoder->put8(reserved);
-}
-
-void EncodeTag::Decode(Decoder* decoder) {
-  if (decoder->avail() < 4 * sizeof(uint8_t)) {
-    throw Exception(
-        "EncodeTag::Decode() fewer than 4 bytes available in decoder");
-  }
-
-  uint8_t geography_type = decoder->get8();
-
-  if (geography_type == static_cast<uint8_t>(GeographyKind::POINT)) {
-    kind = GeographyKind::POINT;
-  } else if (geography_type == static_cast<uint8_t>(GeographyKind::POLYLINE)) {
-    kind = GeographyKind::POLYLINE;
-  } else if (geography_type == static_cast<uint8_t>(GeographyKind::POLYGON)) {
-    kind = GeographyKind::POLYGON;
-  } else if (geography_type ==
-             static_cast<uint8_t>(GeographyKind::GEOGRAPHY_COLLECTION)) {
-    kind = GeographyKind::GEOGRAPHY_COLLECTION;
-  } else if (geography_type ==
-             static_cast<uint8_t>(GeographyKind::SHAPE_INDEX)) {
-    kind = GeographyKind::SHAPE_INDEX;
-  } else if (geography_type ==
-             static_cast<uint8_t>(GeographyKind::CELL_CENTER)) {
-    kind = GeographyKind::CELL_CENTER;
-
-  } else {
-    throw Exception("EncodeTag::Decode(): Unknown geography kind identifier " +
-                    std::to_string(geography_type));
-  }
-
-  flags = decoder->get8();
-  covering_size = decoder->get8();
-  reserved = decoder->get8();
-  Validate();
-}
-
-void EncodeTag::DecodeCovering(Decoder* decoder,
-                               std::vector<S2CellId>* cell_ids) const {
-  if (decoder->avail() < (covering_size * sizeof(uint64_t))) {
-    throw Exception("Insufficient size in decoder for " +
-                    std::to_string(covering_size) + " cell ids");
-  }
-
-  cell_ids->resize(covering_size);
-  for (uint8_t i = 0; i < covering_size; i++) {
-    cell_ids->at(i) = S2CellId(decoder->get64());
-  }
-}
-
-void s2geography::EncodeTag::SkipCovering(Decoder* decoder) const {
-  if (decoder->avail() < (covering_size * sizeof(uint64_t))) {
-    throw Exception("Insufficient size in decoder for " +
-                    std::to_string(covering_size) + " cell ids");
-  }
-
-  decoder->skip(covering_size * sizeof(uint64_t));
-}
-
-void EncodeTag::Validate() {
-  if (reserved != 0) {
-    throw Exception("EncodeTag: reserved byte must be zero");
-  }
-
-  uint8_t flags_validate = flags & ~kFlagEmpty;
-  if (flags_validate != 0) {
-    throw Exception("EncodeTag: Unknown flag(s)");
   }
 }

--- a/src/s2geography/geography.cc
+++ b/src/s2geography/geography.cc
@@ -15,8 +15,6 @@
 #include <s2/s2shape_index_region.h>
 #include <s2/s2shapeutil_coding.h>
 
-#include <sstream>
-
 #include "s2geography/geography_interface.h"
 #include "s2geography/macros.h"
 

--- a/src/s2geography/geography.h
+++ b/src/s2geography/geography.h
@@ -16,97 +16,104 @@
 
 namespace s2geography {
 
-// An Geography representing zero or more points using a std::vector<S2Point>
-// as the underlying representation.
+/// \brief S2Point Geography implementation
+///
+/// An Geography representing zero or more points using a std::vector<S2Point>
+/// as the underlying representation.
 class PointGeography : public Geography {
  public:
   PointGeography() : Geography(GeographyKind::POINT) {}
-  PointGeography(S2Point point) : Geography(GeographyKind::POINT) {
+  explicit PointGeography(S2Point point) : Geography(GeographyKind::POINT) {
     points_.push_back(point);
   }
-  PointGeography(std::vector<S2Point> points)
+  explicit PointGeography(std::vector<S2Point> points)
       : Geography(GeographyKind::POINT), points_(std::move(points)) {}
 
-  int dimension() const { return 0; }
-  int num_shapes() const {
+  const std::vector<S2Point>& Points() const { return points_; }
+
+  void Decode(Decoder* decoder, const EncodeTag& tag);
+
+  int dimension() const override { return 0; }
+  int num_shapes() const override {
     if (points_.empty()) {
       return 0;
     } else {
       return 1;
     }
   }
-  std::unique_ptr<S2Shape> Shape(int id) const;
-  std::unique_ptr<S2Region> Region() const;
-  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
-
-  const std::vector<S2Point>& Points() const { return points_; }
-
-  void EncodeTagged(Encoder* encoder, const EncodeOptions& options) const;
-  void Encode(Encoder* encoder, const EncodeOptions& options) const;
-  void Decode(Decoder* decoder, const EncodeTag& tag);
+  std::unique_ptr<S2Shape> Shape(int id) const override;
+  std::unique_ptr<S2Region> Region() const override;
+  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const override;
+  void EncodeTagged(Encoder* encoder,
+                    const EncodeOptions& options) const override;
+  void Encode(Encoder* encoder, const EncodeOptions& options) const override;
 
  private:
   std::vector<S2Point> points_;
 };
 
-// An Geography representing zero or more polylines using the S2Polyline class
-// as the underlying representation.
+/// \brief S2Polyline Geography implementation
+///
+/// An Geography representing zero or more polylines using the S2Polyline class
+/// as the underlying representation.
 class PolylineGeography : public Geography {
  public:
   PolylineGeography() : Geography(GeographyKind::POLYLINE) {}
-  PolylineGeography(std::unique_ptr<S2Polyline> polyline)
+  explicit PolylineGeography(std::unique_ptr<S2Polyline> polyline)
       : Geography(GeographyKind::POLYLINE) {
     polylines_.push_back(std::move(polyline));
   }
-  PolylineGeography(std::vector<std::unique_ptr<S2Polyline>> polylines)
+  explicit PolylineGeography(std::vector<std::unique_ptr<S2Polyline>> polylines)
       : Geography(GeographyKind::POLYLINE), polylines_(std::move(polylines)) {}
 
-  int dimension() const { return 1; }
-  int num_shapes() const;
-  std::unique_ptr<S2Shape> Shape(int id) const;
-  std::unique_ptr<S2Region> Region() const;
-  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
+  void Decode(Decoder* decoder, const EncodeTag& tag);
 
   const std::vector<std::unique_ptr<S2Polyline>>& Polylines() const {
     return polylines_;
   }
 
-  void Encode(Encoder* encoder, const EncodeOptions& options) const;
-
-  void Decode(Decoder* decoder, const EncodeTag& tag);
+  int dimension() const override { return 1; }
+  int num_shapes() const override;
+  std::unique_ptr<S2Shape> Shape(int id) const override;
+  std::unique_ptr<S2Region> Region() const override;
+  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const override;
+  void Encode(Encoder* encoder, const EncodeOptions& options) const override;
 
  private:
   std::vector<std::unique_ptr<S2Polyline>> polylines_;
 };
 
-// An Geography representing zero or more polygons using the S2Polygon class
-// as the underlying representation. Note that a single S2Polygon (from the S2
-// perspective) can represent zero or more polygons (from the simple features
-// perspective).
+/// \brief S2Polygon Geography implementation
+///
+/// An Geography representing zero or more polygons using the S2Polygon class
+/// as the underlying representation. Note that a single S2Polygon (from the S2
+/// perspective) can represent zero or more polygons (from the simple features
+/// perspective).
 class PolygonGeography : public Geography {
  public:
   PolygonGeography();
-  PolygonGeography(std::unique_ptr<S2Polygon> polygon)
+  explicit PolygonGeography(std::unique_ptr<S2Polygon> polygon)
       : Geography(GeographyKind::POLYGON), polygon_(std::move(polygon)) {}
 
-  int dimension() const { return 2; }
-  int num_shapes() const;
-  std::unique_ptr<S2Shape> Shape(int id) const;
-  std::unique_ptr<S2Region> Region() const;
-  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
+  void Decode(Decoder* decoder, const EncodeTag& tag);
 
   const std::unique_ptr<S2Polygon>& Polygon() const { return polygon_; }
 
-  void Encode(Encoder* encoder, const EncodeOptions& options) const;
-
-  void Decode(Decoder* decoder, const EncodeTag& tag);
+  int dimension() const override { return 2; }
+  int num_shapes() const override;
+  std::unique_ptr<S2Shape> Shape(int id) const override;
+  std::unique_ptr<S2Region> Region() const override;
+  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const override;
+  void Encode(Encoder* encoder, const EncodeOptions& options) const override;
 
  private:
   std::unique_ptr<S2Polygon> polygon_;
 };
 
-// An Geography wrapping zero or more Geography objects. These objects
-// can be used to represent a simple features GEOMETRYCOLLECTION.
+/// \brief Collection of arbitrary Geographies
+///
+/// An Geography wrapping zero or more Geography objects. These objects
+/// can be used to represent a simple features GEOMETRYCOLLECTION.
 class GeographyCollection : public Geography {
  public:
   GeographyCollection()
@@ -119,17 +126,16 @@ class GeographyCollection : public Geography {
     CountShapes();
   }
 
-  int num_shapes() const;
-  std::unique_ptr<S2Shape> Shape(int id) const;
-  std::unique_ptr<S2Region> Region() const;
+  void Decode(Decoder* decoder, const EncodeTag& tag);
 
   const std::vector<std::unique_ptr<Geography>>& Features() const {
     return features_;
   }
 
-  void Encode(Encoder* encoder, const EncodeOptions& options) const;
-
-  void Decode(Decoder* decoder, const EncodeTag& tag);
+  int num_shapes() const override;
+  std::unique_ptr<S2Shape> Shape(int id) const override;
+  std::unique_ptr<S2Region> Region() const override;
+  void Encode(Encoder* encoder, const EncodeOptions& options) const override;
 
  private:
   std::vector<std::unique_ptr<Geography>> features_;
@@ -144,13 +150,15 @@ class GeographyCollection : public Geography {
   }
 };
 
-// A Geography with a MutableS2ShapeIndex as the underlying data.
-// These are used as inputs for operations that are implemented in S2
-// using the S2ShapeIndex (e.g., boolean operations). If an Geography
-// instance will be used repeatedly, it will be faster to construct
-// one ShapeIndexGeography and use it repeatedly. This class does not
-// own any Geography objects that are added do it and thus is only
-// valid for the scope of those objects.
+/// \brief MutableS2ShapeIndex Geoography
+///
+/// A Geography with a MutableS2ShapeIndex as the underlying data.
+/// These are used as inputs for operations that are implemented in S2
+/// using the S2ShapeIndex (e.g., boolean operations). If an Geography
+/// instance will be used repeatedly, it will be faster to construct
+/// one ShapeIndexGeography and use it repeatedly. This class does not
+/// own any Geography objects that are added do it and thus is only
+/// valid for the scope of those objects.
 class ShapeIndexGeography : public Geography {
  public:
   ShapeIndexGeography();
@@ -158,39 +166,41 @@ class ShapeIndexGeography : public Geography {
 
   explicit ShapeIndexGeography(const Geography& geog);
 
-  // Add a Geography to the index, returning the last shape_id
-  // that was added to the index or -1 if no shapes were added
-  // to the index.
+  /// \brief Add a Geography to the index
+  ///
+  /// Returns the last shape_id that was added to the index or -1 if no shapes
+  /// were added to the index.
   int Add(const Geography& geog);
-
-  int num_shapes() const;
-  std::unique_ptr<S2Shape> Shape(int id) const;
-  std::unique_ptr<S2Region> Region() const;
 
   const S2ShapeIndex& ShapeIndex() const { return *shape_index_; }
 
-  void Encode(Encoder* encoder, const EncodeOptions& options) const;
+  int num_shapes() const override;
+  std::unique_ptr<S2Shape> Shape(int id) const override;
+  std::unique_ptr<S2Region> Region() const override;
+
+  void Encode(Encoder* encoder, const EncodeOptions& options) const override;
 
  private:
   std::unique_ptr<MutableS2ShapeIndex> shape_index_;
 };
 
-// A Geography with a EncodedS2ShapeIndex as the underlying data.
-// This is to facilitate decoding, whereas a MutableS2ShapeIndex is
-// used to construct the S2ShapeIndex required for many S2 operations.
+/// \brief EncodedS2ShapeIndex Geoography
+///
+/// A Geography with a EncodedS2ShapeIndex as the underlying data.
+/// This is to facilitate decoding, whereas a MutableS2ShapeIndex is
+/// used to construct the S2ShapeIndex required for many S2 operations.
 class EncodedShapeIndexGeography : public Geography {
  public:
   EncodedShapeIndexGeography();
 
-  int num_shapes() const;
-  std::unique_ptr<S2Shape> Shape(int id) const;
-  std::unique_ptr<S2Region> Region() const;
+  void Decode(Decoder* decoder, const EncodeTag& tag);
 
   const S2ShapeIndex& ShapeIndex() const { return *shape_index_; }
 
-  void Encode(Encoder* encoder, const EncodeOptions& options) const;
-
-  void Decode(Decoder* decoder, const EncodeTag& tag);
+  int num_shapes() const override;
+  std::unique_ptr<S2Shape> Shape(int id) const override;
+  std::unique_ptr<S2Region> Region() const override;
+  void Encode(Encoder* encoder, const EncodeOptions& options) const override;
 
  private:
   std::unique_ptr<S2ShapeIndex> shape_index_;

--- a/src/s2geography/geography.h
+++ b/src/s2geography/geography.h
@@ -9,109 +9,12 @@
 #include <s2/s2region.h>
 #include <s2/s2shape.h>
 #include <s2/s2shape_index.h>
-#include <stdint.h>
 
-#include <stdexcept>
-#include <string>
 #include <vector>
 
+#include "s2geography/geography_interface.h"
+
 namespace s2geography {
-
-class Exception : public std::runtime_error {
- public:
-  Exception(std::string what) : std::runtime_error(what.c_str()) {}
-};
-
-// enum to tag concrete Geography implementations. Note that
-// CELL_CENTER does not currently represent a concrete subclass
-// but is used to mark a compact encoding method for small numbers of points.
-enum class GeographyKind {
-  UNINITIALIZED = 0,
-  POINT = 1,
-  POLYLINE = 2,
-  POLYGON = 3,
-  GEOGRAPHY_COLLECTION = 4,
-  SHAPE_INDEX = 5,
-  ENCODED_SHAPE_INDEX = 6,
-  CELL_CENTER = 7,
-};
-
-class EncodeOptions;
-struct EncodeTag;
-
-// An Geography is an abstraction of S2 types that is designed to closely
-// match the scope of a GEOS Geometry. Its methods are limited to those needed
-// to implement C API functions. From an S2 perspective, an Geography is an
-// S2Region that can be represented by zero or more S2Shape objects. Current
-// implementations of Geography own their data (i.e., the coordinate vectors
-// and underlying S2 objects), however, the interface is designed to allow
-// future abstractions where this is not the case.
-class Geography {
- public:
-  Geography(GeographyKind kind) : kind_(kind) {}
-  virtual ~Geography() {}
-
-  GeographyKind kind() const { return kind_; }
-
-  // Returns 0, 1, or 2 if all Shape()s that are returned will have
-  // the same dimension (i.e., they are all points, all lines, or
-  // all polygons).
-  virtual int dimension() const {
-    if (num_shapes() == 0) {
-      return -1;
-    }
-
-    int dim = Shape(0)->dimension();
-    for (int i = 1; i < num_shapes(); i++) {
-      if (dim != Shape(i)->dimension()) {
-        return -1;
-      }
-    }
-
-    return dim;
-  }
-
-  // The number of S2Shape objects needed to represent this Geography
-  virtual int num_shapes() const = 0;
-
-  // Returns the given S2Shape (where 0 <= id < num_shapes()). The
-  // caller retains ownership of the S2Shape but the data pointed to
-  // by the object requires that the underlying Geography outlives
-  // the returned object.
-  virtual std::unique_ptr<S2Shape> Shape(int id) const = 0;
-
-  // Returns an S2Region that represents the object. The caller retains
-  // ownership of the S2Region but the data pointed to by the object
-  // requires that the underlying Geography outlives the returned
-  // object.
-  virtual std::unique_ptr<S2Region> Region() const = 0;
-
-  // Adds an unnormalized set of S2CellIDs to `cell_ids`. This is intended
-  // to be faster than using Region().GetCovering() directly and to
-  // return a small number of cells that can be used to compute a possible
-  // intersection quickly.
-  virtual void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
-
-  // Serialize this geography to an encoder. This does not include any
-  // encapsulating information (e.g., which geography type or flags).
-  virtual void Encode(Encoder* encoder, const EncodeOptions& options) const = 0;
-
-  // Serialize this geography to an encoder such that it can roundtrip
-  // with DecodeTagged(). EXPERIMENTAL.
-  virtual void EncodeTagged(Encoder* encoder,
-                            const EncodeOptions& options) const;
-
-  // Create a geography from output written with EncodeTagged. EXPERIMENTAL.
-  static std::unique_ptr<Geography> DecodeTagged(Decoder* decoder);
-
- protected:
-  // Helper for subclasses to write a covering. Subclasses must call this
-  // or encode their own covering when implementing Encode().
-  void EncodeCoveringDefault(Encoder* encoder);
-
- private:
-  GeographyKind kind_;
-};
 
 // An Geography representing zero or more points using a std::vector<S2Point>
 // as the underlying representation.
@@ -292,76 +195,6 @@ class EncodedShapeIndexGeography : public Geography {
  private:
   std::unique_ptr<S2ShapeIndex> shape_index_;
   std::unique_ptr<S2ShapeIndex::ShapeFactory> shape_factory_;
-};
-
-// Options for serializing geographies using Geography::EncodeTagged()
-class EncodeOptions {
- public:
-  // Create options with default values, which optimize for the
-  // scenario where a geography is about to be fully deserialized
-  // in another process. Set the appropriate options for smaller
-  // encoded size and/or better query performance when running queries
-  // directly on encoded data.
-  EncodeOptions() = default;
-
-  // Control whether to optimize for speed (by writing vertices as
-  // doubles) or space (by writing cell identifiers for vertices that
-  // are snapped to a cell center). For vertices that are snapped to a
-  // cell center at a lower zoom level, the encoder can encode each
-  // vertex with 4 or fewer bytes.
-  void set_coding_hint(s2coding::CodingHint hint) { hint_ = hint; }
-  s2coding::CodingHint coding_hint() const { return hint_; }
-
-  // Control whether to spend extra effort converting shapes that
-  // aren't able to be lazily decoded (e.g., S2Polyline::Shape and
-  // S2Polygon::Shape to S2LaxPolylineShape and S2LaxPolygonShape,
-  // respectively).
-  void set_enable_lazy_decode(bool enable_lazy_decode) {
-    enable_lazy_decode_ = enable_lazy_decode;
-  }
-  bool enable_lazy_decode() const { return enable_lazy_decode_; }
-
-  // Control whether to prefix the serialized geography with a covering
-  // to more rapidy check for possible intersection. The covering that is
-  // written is currently the normalized result of GetCellUnionBound().
-  void set_include_covering(bool include_covering) {
-    include_covering_ = include_covering;
-  }
-  bool include_covering() const { return include_covering_; }
-
- private:
-  s2coding::CodingHint hint_{s2coding::CodingHint::FAST};
-  bool enable_lazy_decode_{false};
-  bool include_covering_{false};
-};
-
-// A 4 byte prefix for encoded geographies. 4 bytes is essential so that
-// German-style strings store these bytes in their prefix (i.e., don't have
-// to load any auxiliary buffers to inspect this information).
-struct EncodeTag {
-  // Geography subclass whose Decode() method will be called.
-  // Encoded as a uint8_t.
-  GeographyKind kind{GeographyKind::UNINITIALIZED};
-
-  // Flags. Currently supported are kFlagEmpty (set if and only if there
-  // are zero shapes in the geography).
-  uint8_t flags{};
-
-  // Number of cells identifiers that follow this tag. Note that zero cells
-  // (i.e., an empty covering) indicates that no covering was written and does
-  // NOT imply an empty geography.
-  uint8_t covering_size{};
-
-  // Reserved byte (must be 0)
-  uint8_t reserved{};
-
-  void Encode(Encoder* encoder) const;
-  void Decode(Decoder* decoder);
-  void DecodeCovering(Decoder* decoder, std::vector<S2CellId>* cell_ids) const;
-  void SkipCovering(Decoder* decoder) const;
-  void Validate();
-
-  static constexpr uint8_t kFlagEmpty = 1;
 };
 
 }  // namespace s2geography

--- a/src/s2geography/geography_interface.cc
+++ b/src/s2geography/geography_interface.cc
@@ -1,0 +1,99 @@
+
+#include "s2geography/geography_interface.h"
+
+#include <s2/s2cell_id.h>
+
+namespace s2geography {
+
+int s2geography::Geography::dimension() const {
+  if (num_shapes() == 0) {
+    return -1;
+  }
+
+  int dim = Shape(0)->dimension();
+  for (int i = 1; i < num_shapes(); i++) {
+    if (dim != Shape(i)->dimension()) {
+      return -1;
+    }
+  }
+
+  return dim;
+}
+
+void EncodeTag::Encode(Encoder* encoder) const {
+  encoder->Ensure(4 * sizeof(uint8_t));
+  encoder->put8(static_cast<uint8_t>(kind));
+  encoder->put8(flags);
+  encoder->put8(covering_size);
+  encoder->put8(reserved);
+}
+
+void EncodeTag::Decode(Decoder* decoder) {
+  if (decoder->avail() < 4 * sizeof(uint8_t)) {
+    throw Exception(
+        "EncodeTag::Decode() fewer than 4 bytes available in decoder");
+  }
+
+  uint8_t geography_type = decoder->get8();
+
+  if (geography_type == static_cast<uint8_t>(GeographyKind::POINT)) {
+    kind = GeographyKind::POINT;
+  } else if (geography_type == static_cast<uint8_t>(GeographyKind::POLYLINE)) {
+    kind = GeographyKind::POLYLINE;
+  } else if (geography_type == static_cast<uint8_t>(GeographyKind::POLYGON)) {
+    kind = GeographyKind::POLYGON;
+  } else if (geography_type ==
+             static_cast<uint8_t>(GeographyKind::GEOGRAPHY_COLLECTION)) {
+    kind = GeographyKind::GEOGRAPHY_COLLECTION;
+  } else if (geography_type ==
+             static_cast<uint8_t>(GeographyKind::SHAPE_INDEX)) {
+    kind = GeographyKind::SHAPE_INDEX;
+  } else if (geography_type ==
+             static_cast<uint8_t>(GeographyKind::CELL_CENTER)) {
+    kind = GeographyKind::CELL_CENTER;
+
+  } else {
+    throw Exception("EncodeTag::Decode(): Unknown geography kind identifier " +
+                    std::to_string(geography_type));
+  }
+
+  flags = decoder->get8();
+  covering_size = decoder->get8();
+  reserved = decoder->get8();
+  Validate();
+}
+
+void EncodeTag::DecodeCovering(Decoder* decoder,
+                               std::vector<S2CellId>* cell_ids) const {
+  if (decoder->avail() < (covering_size * sizeof(uint64_t))) {
+    throw Exception("Insufficient size in decoder for " +
+                    std::to_string(covering_size) + " cell ids");
+  }
+
+  cell_ids->resize(covering_size);
+  for (uint8_t i = 0; i < covering_size; i++) {
+    cell_ids->at(i) = S2CellId(decoder->get64());
+  }
+}
+
+void s2geography::EncodeTag::SkipCovering(Decoder* decoder) const {
+  if (decoder->avail() < (covering_size * sizeof(uint64_t))) {
+    throw Exception("Insufficient size in decoder for " +
+                    std::to_string(covering_size) + " cell ids");
+  }
+
+  decoder->skip(covering_size * sizeof(uint64_t));
+}
+
+void EncodeTag::Validate() {
+  if (reserved != 0) {
+    throw Exception("EncodeTag: reserved byte must be zero");
+  }
+
+  uint8_t flags_validate = flags & ~kFlagEmpty;
+  if (flags_validate != 0) {
+    throw Exception("EncodeTag: Unknown flag(s)");
+  }
+}
+
+}  // namespace s2geography

--- a/src/s2geography/geography_interface.h
+++ b/src/s2geography/geography_interface.h
@@ -1,0 +1,263 @@
+
+#pragma once
+
+#include <s2/s2cap.h>
+#include <s2/s2latlng_rect.h>
+#include <s2/s2region.h>
+#include <s2/s2shape.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+namespace s2geography {
+
+/// \brief Base exception class thrown by S2Geography functions
+class Exception : public std::runtime_error {
+ public:
+  Exception(std::string what) : std::runtime_error(what.c_str()) {}
+};
+
+// enum to tag concrete Geography implementations. Note that
+// CELL_CENTER does not currently represent a concrete subclass
+// but is used to mark a compact encoding method for small numbers of points.
+enum class GeographyKind {
+  UNINITIALIZED = 0,
+  POINT = 1,
+  POLYLINE = 2,
+  POLYGON = 3,
+  GEOGRAPHY_COLLECTION = 4,
+  SHAPE_INDEX = 5,
+  ENCODED_SHAPE_INDEX = 6,
+  CELL_CENTER = 7,
+};
+
+class EncodeOptions;
+struct EncodeTag;
+
+/// \brief Abstract Geography base class
+///
+/// An Geography is an abstraction of S2 types that is designed to closely
+/// match the scope of a GEOS Geometry. Its methods are limited to those needed
+/// to implement C API functions. From an S2 perspective, an Geography is an
+/// S2Region that can be represented by zero or more S2Shape objects. Current
+/// implementations of Geography own their data (i.e., the coordinate vectors
+/// and underlying S2 objects), however, the interface is designed to allow
+/// future abstractions where this is not the case.
+class Geography {
+ public:
+  explicit Geography(GeographyKind kind) : kind_(kind) {}
+  virtual ~Geography() {}
+
+  /// \brief Identify the concerete geometry implementation
+  GeographyKind kind() const { return kind_; }
+
+  /// \brief Identify the geometry dimension
+  ///
+  /// Returns 0, 1, or 2 if all Shape()s that are returned will have
+  /// the same dimension (i.e., they are all points, all lines, or
+  /// all polygons). Returns -1 if this geography contains mixed
+  /// dimensions.
+  virtual int dimension() const;
+
+  /// \brief The number of S2Shape objects needed to represent this Geography
+  virtual int num_shapes() const = 0;
+
+  /// \brief Get an owning S2Shape
+  ///
+  /// Returns the given S2Shape (where 0 <= id < num_shapes()). The
+  /// caller retains ownership of the S2Shape but the data pointed to
+  /// by the object requires that the underlying Geography outlives
+  /// the returned object.
+  virtual std::unique_ptr<S2Shape> Shape(int id) const = 0;
+
+  /// \brief Get an owning S2Region
+  ///
+  /// Returns an S2Region that represents the object. The caller retains
+  /// ownership of the S2Region but the data pointed to by the object
+  /// requires that the underlying Geography outlives the returned
+  /// object.
+  virtual std::unique_ptr<S2Region> Region() const = 0;
+
+  /// \brief Add an unnormalized set of S2CellIds that cover this geography
+  ///
+  /// Adds an unnormalized set of S2CellIDs to `cell_ids`. This is intended
+  /// to be faster than using Region().GetCovering() directly and to
+  /// return a small number of cells that can be used to compute a possible
+  /// intersection quickly.
+  virtual void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
+
+  /// \brief Serialize this geography
+  ///
+  /// Serialize this geography to an encoder. This does not include any
+  /// encapsulating information (e.g., which geography type or flags).
+  virtual void Encode(Encoder* encoder, const EncodeOptions& options) const = 0;
+
+  /// \brief Serialized this geography with identifying information
+  ///
+  /// Serialize this geography to an encoder such that it can roundtrip
+  /// with DecodeTagged(). EXPERIMENTAL.
+  virtual void EncodeTagged(Encoder* encoder,
+                            const EncodeOptions& options) const;
+
+  /// \brief Create a geography from output written with EncodeTagged.
+  /// EXPERIMENTAL.
+  static std::unique_ptr<Geography> DecodeTagged(Decoder* decoder);
+
+ protected:
+  // Helper for subclasses to write a covering. Subclasses must call this
+  // or encode their own covering when implementing Encode().
+  void EncodeCoveringDefault(Encoder* encoder);
+
+ private:
+  GeographyKind kind_;
+};
+
+/// \brief Options for serializing geographies using Geography::EncodeTagged()
+class EncodeOptions {
+ public:
+  /// \brief Default options
+  ///
+  /// Create options with default values, which optimize for the
+  /// scenario where a geography is about to be fully deserialized
+  /// in another process. Set the appropriate options for smaller
+  /// encoded size and/or better query performance when running queries
+  /// directly on encoded data.
+  EncodeOptions() = default;
+
+  /// \brief Coding hint
+  ///
+  /// Control whether to optimize for speed (by writing vertices as
+  /// doubles) or space (by writing cell identifiers for vertices that
+  /// are snapped to a cell center). For vertices that are snapped to a
+  /// cell center at a lower zoom level, the encoder can encode each
+  /// vertex with 4 or fewer bytes.
+  void set_coding_hint(s2coding::CodingHint hint) { hint_ = hint; }
+  s2coding::CodingHint coding_hint() const { return hint_; }
+
+  /// \brief Lazy decode
+  ///
+  /// Control whether to spend extra effort converting shapes that
+  /// aren't able to be lazily decoded (e.g., S2Polyline::Shape and
+  /// S2Polygon::Shape to S2LaxPolylineShape and S2LaxPolygonShape,
+  /// respectively).
+  void set_enable_lazy_decode(bool enable_lazy_decode) {
+    enable_lazy_decode_ = enable_lazy_decode;
+  }
+  bool enable_lazy_decode() const { return enable_lazy_decode_; }
+
+  /// \brief Embedded covering
+  ///
+  /// Control whether to prefix the serialized geography with a covering
+  /// to more rapidy check for possible intersection. The covering that is
+  /// written is currently the normalized result of GetCellUnionBound().
+  void set_include_covering(bool include_covering) {
+    include_covering_ = include_covering;
+  }
+  bool include_covering() const { return include_covering_; }
+
+ private:
+  s2coding::CodingHint hint_{s2coding::CodingHint::FAST};
+  bool enable_lazy_decode_{false};
+  bool include_covering_{false};
+};
+
+/// \brief Encoded data prefix
+///
+/// A 4 byte prefix for encoded geographies. 4 bytes is essential so that
+/// German-style strings store these bytes in their prefix (i.e., don't have
+/// to load any auxiliary buffers to inspect this information).
+struct EncodeTag {
+  /// \brief Geography subclass whose Decode() method will be called. Encoded as
+  /// a uint8_t.
+  GeographyKind kind{GeographyKind::UNINITIALIZED};
+
+  /// \brief Flags
+  ///
+  /// Currently supported are kFlagEmpty (set if and only if there are zero
+  /// shapes in the geography).
+  uint8_t flags{};
+
+  /// \brief Embedded covering size
+  ///
+  /// Number of cells identifiers that follow this tag. Note that zero cells
+  /// (i.e., an empty covering) indicates that no covering was written and does
+  /// NOT imply an empty geography.
+  uint8_t covering_size{};
+
+  /// \brief Reserved byte
+  ///
+  /// Reserved byte (must be 0)
+  uint8_t reserved{};
+
+  void Encode(Encoder* encoder) const;
+  void Decode(Decoder* decoder);
+  void DecodeCovering(Decoder* decoder, std::vector<S2CellId>* cell_ids) const;
+  void SkipCovering(Decoder* decoder) const;
+  void Validate();
+
+  static constexpr uint8_t kFlagEmpty = 1;
+};
+
+/// \brief Non-owning wrapper around an S2Shape
+///
+/// This class is a shim to allow a class to return a
+/// std::unique_ptr<S2Shape>(), which is required by MutableS2ShapeIndex::Add(),
+/// without copying the underlying data. S2Shape instances do not typically own
+/// their data (e.g., S2Polygon::Shape), so this does not change the general
+/// relationship (that anything returned by Geography::Shape() is only valid
+/// within the scope of the Geography). Note that this class is also available
+/// (but not exposed) in s2/s2shapeutil_coding.cc.
+class S2ShapeWrapper : public S2Shape {
+ public:
+  explicit S2ShapeWrapper(const S2Shape* shape) : shape_(shape) {}
+
+  int num_edges() const { return shape_->num_edges(); }
+  Edge edge(int edge_id) const { return shape_->edge(edge_id); }
+  int dimension() const { return shape_->dimension(); }
+  ReferencePoint GetReferencePoint() const {
+    return shape_->GetReferencePoint();
+  }
+  int num_chains() const { return shape_->num_chains(); }
+  Chain chain(int chain_id) const { return shape_->chain(chain_id); }
+  Edge chain_edge(int chain_id, int offset) const {
+    return shape_->chain_edge(chain_id, offset);
+  }
+  ChainPosition chain_position(int edge_id) const {
+    return shape_->chain_position(edge_id);
+  }
+
+ private:
+  const S2Shape* shape_;
+};
+
+/// \brief Non-owning wrapper around an S2Region
+///
+/// Just like the S2ShapeWrapper, the S2RegionWrapper helps reconcile the
+/// differences in lifecycle expectation between S2 and Geography. We often
+/// need access to a S2Region to generalize algorithms; however, there are some
+/// operations that need ownership of the region (e.g., the S2RegionUnion). In
+/// Geography the assumption is that anything returned by a Geography is only
+/// valid for the lifetime of the underlying Geography. A different design of
+/// the algorithms implemented here might well make this unnecessary.
+class S2RegionWrapper : public S2Region {
+ public:
+  explicit S2RegionWrapper(S2Region* region) : region_(region) {}
+
+  S2Region* Clone() const { return region_->Clone(); }
+  S2Cap GetCapBound() const { return region_->GetCapBound(); }
+  S2LatLngRect GetRectBound() const { return region_->GetRectBound(); }
+  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const {
+    return region_->GetCellUnionBound(cell_ids);
+  }
+  bool Contains(const S2Cell& cell) const { return region_->Contains(cell); }
+  bool MayIntersect(const S2Cell& cell) const {
+    return region_->MayIntersect(cell);
+  }
+  bool Contains(const S2Point& p) const { return region_->Contains(p); }
+
+ private:
+  S2Region* region_;
+};
+
+}  // namespace s2geography

--- a/src/s2geography/index.h
+++ b/src/s2geography/index.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include <s2/mutable_s2shape_index.h>
+
 #include <unordered_set>
 
 #include "s2geography/geography_interface.h"

--- a/src/s2geography/index.h
+++ b/src/s2geography/index.h
@@ -3,7 +3,7 @@
 
 #include <unordered_set>
 
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 
 // S2ShapeIndex::CellRelation was renamed to S2CellRelation
 // in S2 version 0.11

--- a/src/s2geography/linear-referencing.cc
+++ b/src/s2geography/linear-referencing.cc
@@ -84,7 +84,7 @@ struct S2LineInterpolatePointExec {
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    stashed_ = s2_interpolate_normalized(value0, value1);
+    stashed_ = PointGeography(s2_interpolate_normalized(value0, value1));
     return stashed_;
   }
 

--- a/src/s2geography/linear-referencing.h
+++ b/src/s2geography/linear-referencing.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 #include "s2geography/sedona_udf/sedona_extension.h"
 
 namespace s2geography {

--- a/src/s2geography/projections.cc
+++ b/src/s2geography/projections.cc
@@ -6,7 +6,7 @@
 #include <s2/s2pointutil.h>
 #include <s2/s2projections.h>
 
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 
 namespace s2geography {
 

--- a/src/s2geography/wkb.cc
+++ b/src/s2geography/wkb.cc
@@ -3,10 +3,9 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <sstream>
 
 #include "s2geography/geoarrow.h"
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 
 namespace s2geography {
 

--- a/src/s2geography/wkb.h
+++ b/src/s2geography/wkb.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "s2geography/geoarrow.h"
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 
 namespace s2geography {
 

--- a/src/s2geography/wkt-reader.cc
+++ b/src/s2geography/wkt-reader.cc
@@ -3,7 +3,6 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <sstream>
 
 #include "s2geography/geoarrow.h"
 #include "s2geography/geography_interface.h"

--- a/src/s2geography/wkt-reader.cc
+++ b/src/s2geography/wkt-reader.cc
@@ -6,7 +6,7 @@
 #include <sstream>
 
 #include "s2geography/geoarrow.h"
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 
 namespace s2geography {
 

--- a/src/s2geography/wkt-reader.h
+++ b/src/s2geography/wkt-reader.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "s2geography/geoarrow.h"
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 
 namespace s2geography {
 

--- a/src/s2geography/wkt-writer.h
+++ b/src/s2geography/wkt-writer.h
@@ -2,10 +2,9 @@
 #pragma once
 
 #include <memory>
-#include <sstream>
 
 #include "s2geography/geoarrow.h"
-#include "s2geography/geography.h"
+#include "s2geography/geography_interface.h"
 
 namespace s2geography {
 


### PR DESCRIPTION
This PR separates the `Geography` definition and some common utilities from the file that contains all of the current subclasses. I did this because I'm about to add a dedicated GeoArrowGeography that is a wrapper around the view shapes I just added.

While I was here I also made the comments proper docstrings! I also made constructors explicit and added `override` where it made sense to do so.