### PR TITLE
refactor: Migrate kernels to use GeoArrowGeography

### DIFF
--- a/src/s2geography/accessors-geog.cc
+++ b/src/s2geography/accessors-geog.cc
@@ -217,22 +217,6 @@ struct S2CentroidExec {
   PointGeography stashed_;
 };
 
-struct S2ClosestPointExec {
-  using arg0_t = GeographyIndexInputView;
-  using arg1_t = GeographyIndexInputView;
-  using out_t = WkbGeographyOutputBuilder;
-
-  void Init(const std::unordered_map<std::string, std::string>& options) {}
-
-  out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    S2Point out = s2_closest_point(value0, value1);
-    stashed_ = PointGeography(out);
-    return stashed_;
-  }
-
-  PointGeography stashed_;
-};
-
 struct S2ConvexHullExec {
   using arg0_t = GeographyInputView;
   using out_t = WkbGeographyOutputBuilder;
@@ -275,9 +259,6 @@ void PointOnSurfaceKernel(struct SedonaCScalarKernel* out) {
   InitUnaryKernel<S2PointOnSurfaceExec>(out, "st_pointonsurface");
 }
 
-void ClosestPointKernel(struct SedonaCScalarKernel* out) {
-  InitBinaryKernel<S2ClosestPointExec>(out, "st_closestpoint");
-}
 }  // namespace sedona_udf
 
 }  // namespace s2geography

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -436,8 +436,8 @@ namespace sedona_udf {
 
 template <S2BooleanOperation::OpType op_type>
 struct BooleanOperationExec {
-  using arg0_t = GeographyIndexInputView;
-  using arg1_t = GeographyIndexInputView;
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = GeoArrowGeographyInputView;
   using out_t = WkbGeographyOutputBuilder;
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -13,8 +13,12 @@ namespace s2geography {
 
 double s2_distance(const ShapeIndexGeography& geog1,
                    const ShapeIndexGeography& geog2) {
-  S2ClosestEdgeQuery query(&geog1.ShapeIndex());
-  S2ClosestEdgeQuery::ShapeIndexTarget target(&geog2.ShapeIndex());
+  return s2_distance(geog1.ShapeIndex(), geog2.ShapeIndex());
+}
+
+double s2_distance(const S2ShapeIndex& geog1, const S2ShapeIndex& geog2) {
+  S2ClosestEdgeQuery query(&geog1);
+  S2ClosestEdgeQuery::ShapeIndexTarget target(&geog2);
 
   const auto& result = query.FindClosestEdge(&target);
 
@@ -24,8 +28,12 @@ double s2_distance(const ShapeIndexGeography& geog1,
 
 double s2_max_distance(const ShapeIndexGeography& geog1,
                        const ShapeIndexGeography& geog2) {
-  S2FurthestEdgeQuery query(&geog1.ShapeIndex());
-  S2FurthestEdgeQuery::ShapeIndexTarget target(&geog2.ShapeIndex());
+  return s2_max_distance(geog1.ShapeIndex(), geog2.ShapeIndex());
+}
+
+double s2_max_distance(const S2ShapeIndex& geog1, const S2ShapeIndex& geog2) {
+  S2FurthestEdgeQuery query(&geog1);
+  S2FurthestEdgeQuery::ShapeIndexTarget target(&geog2);
 
   const auto& result = query.FindFurthestEdge(&target);
 
@@ -38,11 +46,21 @@ S2Point s2_closest_point(const ShapeIndexGeography& geog1,
   return s2_minimum_clearance_line_between(geog1, geog2).first;
 }
 
+S2Point s2_closest_point(const S2ShapeIndex& geog1, const S2ShapeIndex& geog2) {
+  return s2_minimum_clearance_line_between(geog1, geog2).first;
+}
+
 std::pair<S2Point, S2Point> s2_minimum_clearance_line_between(
     const ShapeIndexGeography& geog1, const ShapeIndexGeography& geog2) {
-  S2ClosestEdgeQuery query1(&geog1.ShapeIndex());
+  return s2_minimum_clearance_line_between(geog1.ShapeIndex(),
+                                           geog2.ShapeIndex());
+}
+
+std::pair<S2Point, S2Point> s2_minimum_clearance_line_between(
+    const S2ShapeIndex& geog1, const S2ShapeIndex& geog2) {
+  S2ClosestEdgeQuery query1(&geog1);
   query1.mutable_options()->set_include_interiors(false);
-  S2ClosestEdgeQuery::ShapeIndexTarget target(&geog2.ShapeIndex());
+  S2ClosestEdgeQuery::ShapeIndexTarget target(&geog2);
 
   const auto& result1 = query1.FindClosestEdge(&target);
 
@@ -54,7 +72,7 @@ std::pair<S2Point, S2Point> s2_minimum_clearance_line_between(
   S2Shape::Edge edge1 = query1.GetEdge(result1);
 
   // Now find the edge from index2 (edge2) that is closest to edge1.
-  S2ClosestEdgeQuery query2(&geog2.ShapeIndex());
+  S2ClosestEdgeQuery query2(&geog2);
   query2.mutable_options()->set_include_interiors(false);
   S2ClosestEdgeQuery::EdgeTarget target2(edge1.v0, edge1.v1);
   auto result2 = query2.FindClosestEdge(&target2);
@@ -72,40 +90,58 @@ std::pair<S2Point, S2Point> s2_minimum_clearance_line_between(
 
 namespace sedona_udf {
 
-struct S2DistanceExec {
-  using arg0_t = GeographyIndexInputView;
-  using arg1_t = GeographyIndexInputView;
-  using out_t = DoubleOutputBuilder;
-
-  void Init(const std::unordered_map<std::string, std::string>& options) {}
-
-  out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    return s2_distance(value0, value1) * S2Earth::RadiusMeters();
-  }
-};
-
-struct S2MaxDistanceExec {
-  using arg0_t = GeographyIndexInputView;
-  using arg1_t = GeographyIndexInputView;
-  using out_t = DoubleOutputBuilder;
-
-  void Init(const std::unordered_map<std::string, std::string>& options) {}
-
-  out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    return s2_max_distance(value0, value1) * S2Earth::RadiusMeters();
-  }
-};
-
-struct S2ShortestLineExec {
-  using arg0_t = GeographyIndexInputView;
-  using arg1_t = GeographyIndexInputView;
+struct S2ClosestPointExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = GeoArrowGeographyInputView;
   using out_t = WkbGeographyOutputBuilder;
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    std::pair<S2Point, S2Point> out =
-        s2_minimum_clearance_line_between(value0, value1);
+    S2Point out = s2_closest_point(value0.ShapeIndex(), value1.ShapeIndex());
+    stashed_ = PointGeography(out);
+    return stashed_;
+  }
+
+  PointGeography stashed_;
+};
+
+struct S2DistanceExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = GeoArrowGeographyInputView;
+  using out_t = DoubleOutputBuilder;
+
+  void Init(const std::unordered_map<std::string, std::string>& options) {}
+
+  out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
+    return s2_distance(value0.ShapeIndex(), value1.ShapeIndex()) *
+           S2Earth::RadiusMeters();
+  }
+};
+
+struct S2MaxDistanceExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = GeoArrowGeographyInputView;
+  using out_t = DoubleOutputBuilder;
+
+  void Init(const std::unordered_map<std::string, std::string>& options) {}
+
+  out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
+    return s2_max_distance(value0.ShapeIndex(), value1.ShapeIndex()) *
+           S2Earth::RadiusMeters();
+  }
+};
+
+struct S2ShortestLineExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = GeoArrowGeographyInputView;
+  using out_t = WkbGeographyOutputBuilder;
+
+  void Init(const std::unordered_map<std::string, std::string>& options) {}
+
+  out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
+    std::pair<S2Point, S2Point> out = s2_minimum_clearance_line_between(
+        value0.ShapeIndex(), value1.ShapeIndex());
     stashed_ = PolylineGeography(std::make_unique<S2Polyline>(
         std::vector<S2Point>{out.first, out.second}, S2Debug::DISABLE));
     return stashed_;
@@ -113,6 +149,10 @@ struct S2ShortestLineExec {
 
   PolylineGeography stashed_;
 };
+
+void ClosestPointKernel(struct SedonaCScalarKernel* out) {
+  InitBinaryKernel<S2ClosestPointExec>(out, "st_closestpoint");
+}
 
 void DistanceKernel(struct SedonaCScalarKernel* out) {
   InitBinaryKernel<S2DistanceExec>(out, "st_distance");

--- a/src/s2geography/distance.h
+++ b/src/s2geography/distance.h
@@ -8,12 +8,20 @@ namespace s2geography {
 
 double s2_distance(const ShapeIndexGeography& geog1,
                    const ShapeIndexGeography& geog2);
+double s2_distance(const S2ShapeIndex& geog1, const S2ShapeIndex& geog2);
+
 double s2_max_distance(const ShapeIndexGeography& geog1,
                        const ShapeIndexGeography& geog2);
+double s2_max_distance(const S2ShapeIndex& geog1, const S2ShapeIndex& geog2);
+
 S2Point s2_closest_point(const ShapeIndexGeography& geog1,
                          const ShapeIndexGeography& geog2);
+S2Point s2_closest_point(const S2ShapeIndex& geog1, const S2ShapeIndex& geog2);
+
 std::pair<S2Point, S2Point> s2_minimum_clearance_line_between(
     const ShapeIndexGeography& geog1, const ShapeIndexGeography& geog2);
+std::pair<S2Point, S2Point> s2_minimum_clearance_line_between(
+    const S2ShapeIndex& geog1, const S2ShapeIndex& geog2);
 
 namespace sedona_udf {
 
@@ -21,6 +29,7 @@ void DistanceKernel(struct SedonaCScalarKernel* out);
 void MaxDistanceKernel(struct SedonaCScalarKernel* out);
 void ShortestLineKernel(struct SedonaCScalarKernel* out);
 void ClosestPointKernel(struct SedonaCScalarKernel* out);
+
 }  // namespace sedona_udf
 
 }  // namespace s2geography

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -99,28 +99,30 @@ struct S2Intersects {
 };
 
 struct S2Contains {
-  using arg0_t = GeographyIndexInputView;
-  using arg1_t = GeographyIndexInputView;
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = GeoArrowGeographyInputView;
   using out_t = BoolOutputBuilder;
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    return s2_contains(value0, value1, options_);
+    return S2BooleanOperation::Contains(value0.ShapeIndex(),
+                                        value1.ShapeIndex(), options_);
   }
 
   S2BooleanOperation::Options options_;
 };
 
 struct S2Equals {
-  using arg0_t = GeographyIndexInputView;
-  using arg1_t = GeographyIndexInputView;
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = GeoArrowGeographyInputView;
   using out_t = BoolOutputBuilder;
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    return s2_equals(value0, value1, options_);
+    return S2BooleanOperation::Equals(value0.ShapeIndex(), value1.ShapeIndex(),
+                                      options_);
   }
 
   S2BooleanOperation::Options options_;

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -84,14 +84,15 @@ bool s2_intersects_box(const ShapeIndexGeography& geog1,
 namespace sedona_udf {
 
 struct S2Intersects {
-  using arg0_t = GeographyIndexInputView;
-  using arg1_t = GeographyIndexInputView;
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = GeoArrowGeographyInputView;
   using out_t = BoolOutputBuilder;
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    return s2_intersects(value0, value1, options_);
+    return S2BooleanOperation::Intersects(value0.ShapeIndex(),
+                                          value1.ShapeIndex(), options_);
   }
 
   S2BooleanOperation::Options options_;

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -5,7 +5,6 @@
 #include <s2/s2edge_tessellator.h>
 #include <s2/s2lax_loop_shape.h>
 
-#include "s2geography/accessors.h"
 #include "s2geography/sedona_udf/sedona_udf_internal.h"
 
 namespace s2geography {
@@ -13,26 +12,45 @@ namespace s2geography {
 bool s2_intersects(const ShapeIndexGeography& geog1,
                    const ShapeIndexGeography& geog2,
                    const S2BooleanOperation::Options& options) {
-  return S2BooleanOperation::Intersects(geog1.ShapeIndex(), geog2.ShapeIndex(),
-                                        options);
+  return s2_intersects(geog1.ShapeIndex(), geog2.ShapeIndex(), options);
+}
+
+bool s2_intersects(const S2ShapeIndex& geog1, const S2ShapeIndex& geog2,
+                   const S2BooleanOperation::Options& options) {
+  return S2BooleanOperation::Intersects(geog1, geog2, options);
 }
 
 bool s2_equals(const ShapeIndexGeography& geog1,
                const ShapeIndexGeography& geog2,
                const S2BooleanOperation::Options& options) {
-  return S2BooleanOperation::Equals(geog1.ShapeIndex(), geog2.ShapeIndex(),
-                                    options);
+  return s2_equals(geog1.ShapeIndex(), geog2.ShapeIndex(), options);
+}
+
+bool s2_equals(const S2ShapeIndex& geog1, const S2ShapeIndex& geog2,
+               const S2BooleanOperation::Options& options) {
+  return S2BooleanOperation::Equals(geog1, geog2, options);
 }
 
 bool s2_contains(const ShapeIndexGeography& geog1,
                  const ShapeIndexGeography& geog2,
                  const S2BooleanOperation::Options& options) {
-  if (s2_is_empty(geog2)) {
+  return s2_contains(geog1.ShapeIndex(), geog2.ShapeIndex(), options);
+}
+
+bool s2_contains(const S2ShapeIndex& geog1, const S2ShapeIndex& geog2,
+                 const S2BooleanOperation::Options& options) {
+  if (geog2.num_shape_ids() == 0) {
     return false;
-  } else {
-    return S2BooleanOperation::Contains(geog1.ShapeIndex(), geog2.ShapeIndex(),
-                                        options);
   }
+
+  for (int i = 0; i < geog2.num_shape_ids(); i++) {
+    const S2Shape* shape = geog2.shape(i);
+    if (shape != nullptr && !shape->is_empty()) {
+      return S2BooleanOperation::Contains(geog1, geog2, options);
+    }
+  }
+
+  return false;
 }
 
 // Note that 'touches' can be implemented using:
@@ -51,6 +69,12 @@ bool s2_contains(const ShapeIndexGeography& geog1,
 
 bool s2_intersects_box(const ShapeIndexGeography& geog1,
                        const S2LatLngRect& rect,
+                       const S2BooleanOperation::Options& options,
+                       double tolerance) {
+  return s2_intersects_box(geog1.ShapeIndex(), rect, options, tolerance);
+}
+
+bool s2_intersects_box(const S2ShapeIndex& geog1, const S2LatLngRect& rect,
                        const S2BooleanOperation::Options& options,
                        double tolerance) {
   // 99% of this is making a S2Loop out of a S2LatLngRect
@@ -78,7 +102,7 @@ bool s2_intersects_box(const ShapeIndexGeography& geog1,
   MutableS2ShapeIndex index;
   index.Add(std::move(loop));
 
-  return S2BooleanOperation::Intersects(geog1.ShapeIndex(), index, options);
+  return S2BooleanOperation::Intersects(geog1, index, options);
 }
 
 namespace sedona_udf {
@@ -91,8 +115,7 @@ struct S2Intersects {
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    return S2BooleanOperation::Intersects(value0.ShapeIndex(),
-                                          value1.ShapeIndex(), options_);
+    return s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
   }
 
   S2BooleanOperation::Options options_;
@@ -106,8 +129,7 @@ struct S2Contains {
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    return S2BooleanOperation::Contains(value0.ShapeIndex(),
-                                        value1.ShapeIndex(), options_);
+    return s2_contains(value0.ShapeIndex(), value1.ShapeIndex(), options_);
   }
 
   S2BooleanOperation::Options options_;
@@ -121,8 +143,7 @@ struct S2Equals {
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    return S2BooleanOperation::Equals(value0.ShapeIndex(), value1.ShapeIndex(),
-                                      options_);
+    return s2_equals(value0.ShapeIndex(), value1.ShapeIndex(), options_);
   }
 
   S2BooleanOperation::Options options_;

--- a/src/s2geography/predicates.h
+++ b/src/s2geography/predicates.h
@@ -12,12 +12,21 @@ bool s2_intersects(const ShapeIndexGeography& geog1,
                    const ShapeIndexGeography& geog2,
                    const S2BooleanOperation::Options& options);
 
+bool s2_intersects(const S2ShapeIndex& geog1, const S2ShapeIndex& geog2,
+                   const S2BooleanOperation::Options& options);
+
 bool s2_equals(const ShapeIndexGeography& geog1,
                const ShapeIndexGeography& geog2,
                const S2BooleanOperation::Options& options);
 
+bool s2_equals(const S2ShapeIndex& geog1, const S2ShapeIndex& geog2,
+               const S2BooleanOperation::Options& options);
+
 bool s2_contains(const ShapeIndexGeography& geog1,
                  const ShapeIndexGeography& geog2,
+                 const S2BooleanOperation::Options& options);
+
+bool s2_contains(const S2ShapeIndex& geog1, const S2ShapeIndex& geog2,
                  const S2BooleanOperation::Options& options);
 
 bool s2_touches(const ShapeIndexGeography& geog1,
@@ -26,6 +35,10 @@ bool s2_touches(const ShapeIndexGeography& geog1,
 
 bool s2_intersects_box(const ShapeIndexGeography& geog1,
                        const S2LatLngRect& rect,
+                       const S2BooleanOperation::Options& options,
+                       double tolerance);
+
+bool s2_intersects_box(const S2ShapeIndex& geog1, const S2LatLngRect& rect,
                        const S2BooleanOperation::Options& options,
                        double tolerance);
 

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -440,7 +440,7 @@ class GeoArrowGeographyInputView {
       GEOARROW_THROW_NOT_OK(
           nullptr, GeoArrowWKBReaderRead(&reader_, src, &geom, nullptr));
 
-      stashed_.InitOriented(geom);
+      stashed_.Init(geom);
       stashed_index_ = i;
     }
   }

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -440,7 +440,7 @@ class GeoArrowGeographyInputView {
       GEOARROW_THROW_NOT_OK(
           nullptr, GeoArrowWKBReaderRead(&reader_, src, &geom, nullptr));
 
-      stashed_.Init(geom);
+      stashed_.InitOriented(geom);
       stashed_index_ = i;
     }
   }

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -446,55 +446,6 @@ class GeoArrowGeographyInputView {
   }
 };
 
-/// \brief View of geometry index input
-///
-/// This is used for operations like the S2BooleanOperation that require
-/// a ShapeIndexGeometry as input. Like the GeographyInputView, we stash
-/// the decoded value to avoid decoding and indexing a scalar input more
-/// than once.
-class GeographyIndexInputView {
- public:
-  using c_type = const ShapeIndexGeography&;
-
-  static bool Matches(const struct ArrowSchema* type) {
-    return GeographyInputView::Matches(type);
-  }
-
-  GeographyIndexInputView(const struct ArrowSchema* type)
-      : inner_(type), stashed_index_(-1) {}
-  GeographyIndexInputView(const GeographyIndexInputView&) = delete;
-  GeographyIndexInputView& operator=(const GeographyIndexInputView&) = delete;
-
-  std::string GetCrs() { return inner_.GetCrs(); }
-
-  void SetArray(const struct ArrowArray* array, int64_t num_rows) {
-    stashed_index_ = -1;
-    inner_.SetArray(array, num_rows);
-    current_array_length_ = array->length;
-  }
-
-  bool IsNull(int64_t i) { return inner_.IsNull(i); }
-
-  const ShapeIndexGeography& Get(int64_t i) {
-    StashIfNeeded(i % current_array_length_);
-    return stashed_;
-  }
-
- private:
-  GeographyInputView inner_;
-  int64_t current_array_length_;
-  int64_t stashed_index_;
-  ShapeIndexGeography stashed_;
-
-  void StashIfNeeded(int64_t i) {
-    if (i != stashed_index_) {
-      const auto& geog = inner_.Get(i);
-      stashed_ = ShapeIndexGeography(geog);
-      stashed_index_ = i;
-    }
-  }
-};
-
 /// @}
 
 /// \defgroup sedona-kernel-adapters Sedona C Scalar Kernel Adapters

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -409,6 +409,7 @@ class GeoArrowGeographyInputView {
   std::string GetCrs() { return type_.crs(); }
 
   void SetArray(const struct ArrowArray* array, int64_t num_rows) {
+    inner_.SetArray(array, num_rows);
     current_array_length_ = array->length;
     stashed_index_ = -1;
   }

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -5,6 +5,7 @@
 #include "geoarrow/geoarrow.hpp"
 #include "nanoarrow/nanoarrow.hpp"
 #include "s2geography.h"
+#include "s2geography/geoarrow-geography.h"
 #include "s2geography/sedona_udf/sedona_extension.h"
 
 namespace s2geography {
@@ -71,6 +72,8 @@ class ArrowOutputBuilder {
   using c_type = c_type_t;
 
   ArrowOutputBuilder() = default;
+  ArrowOutputBuilder(const ArrowOutputBuilder&) = delete;
+  ArrowOutputBuilder& operator=(const ArrowOutputBuilder&) = delete;
 
   void InitOutputType(struct ArrowSchema* out) {
     NANOARROW_THROW_NOT_OK(ArrowSchemaInitFromType(out, arrow_type_val));
@@ -132,6 +135,9 @@ class WkbGeographyOutputBuilder {
   WkbGeographyOutputBuilder() {
     writer_.Init(geoarrow::Writer::OutputType::kWKB, geoarrow::ExportOptions());
   }
+  WkbGeographyOutputBuilder(const WkbGeographyOutputBuilder&) = delete;
+  WkbGeographyOutputBuilder& operator=(const WkbGeographyOutputBuilder&) =
+      delete;
 
   void InitOutputType(struct ArrowSchema* out) {
     ::geoarrow::Wkb()
@@ -225,6 +231,19 @@ class ArrowInputView {
         default:
           return false;
       }
+    } else if constexpr (std::is_same_v<c_type_t, std::string_view>) {
+      switch (schema_view.type) {
+        case NANOARROW_TYPE_STRING:
+        case NANOARROW_TYPE_STRING_VIEW:
+        case NANOARROW_TYPE_LARGE_STRING:
+        case NANOARROW_TYPE_BINARY:
+        case NANOARROW_TYPE_BINARY_VIEW:
+        case NANOARROW_TYPE_LARGE_BINARY:
+          return true;
+
+        default:
+          return false;
+      }
     } else {
       static_assert(always_false<c_type>::value, "value type not supported");
     }
@@ -236,6 +255,8 @@ class ArrowInputView {
     NANOARROW_THROW_NOT_OK(
         ArrowArrayViewInitFromSchema(view_.get(), type, nullptr));
   }
+  ArrowInputView(const ArrowInputView&) = delete;
+  ArrowInputView& operator=(const ArrowInputView&) = delete;
 
   void SetArray(const struct ArrowArray* array, int64_t num_rows) {
     NANOARROW_THROW_NOT_OK(ArrowArrayViewSetArray(view_.get(), array, nullptr));
@@ -256,6 +277,11 @@ class ArrowInputView {
       return ArrowArrayViewGetIntUnsafe(view_.get(), i % view_->length);
     } else if constexpr (std::is_same_v<c_type, double>) {
       return ArrowArrayViewGetDoubleUnsafe(view_.get(), i % view_->length);
+    } else if constexpr (std::is_same_v<c_type_t, std::string_view>) {
+      struct ArrowBufferView val =
+          ArrowArrayViewGetBytesUnsafe(view_.get(), i % view_->length);
+      return std::string_view(val.data.as_char,
+                              static_cast<size_t>(val.size_bytes));
     } else {
       static_assert(always_false<c_type>::value, "value type not supported");
     }
@@ -301,6 +327,8 @@ class GeographyInputView {
     type_ = ::geoarrow::GeometryDataType::Make(type);
     reader_.Init(type);
   }
+  GeographyInputView(const GeographyInputView&) = delete;
+  GeographyInputView& operator=(const GeographyInputView&) = delete;
 
   std::string GetCrs() { return type_.crs(); }
 
@@ -335,6 +363,88 @@ class GeographyInputView {
   }
 };
 
+/// \brief View of GeoArrow input
+///
+/// This currently handles geoarrow.wkb arrays, although in theory can
+/// represent any GeoArrow type when supported by geoarrow-c.
+class GeoArrowGeographyInputView {
+ public:
+  using c_type = const GeoArrowGeography&;
+
+  static bool Matches(const struct ArrowSchema* type) {
+    struct GeoArrowSchemaView schema_view;
+    int err_code = GeoArrowSchemaViewInit(&schema_view, type, nullptr);
+    if (err_code != GEOARROW_OK) {
+      return false;
+    }
+
+    // Only handles WKB for now
+    switch (schema_view.type) {
+      case GEOARROW_TYPE_WKB:
+      case GEOARROW_TYPE_WKB_VIEW:
+      case GEOARROW_TYPE_LARGE_WKB:
+        break;
+      default:
+        return false;
+    }
+
+    struct GeoArrowMetadataView metadata_view;
+    err_code = GeoArrowMetadataViewInit(
+        &metadata_view, schema_view.extension_metadata, nullptr);
+    return err_code == GEOARROW_OK &&
+           metadata_view.edge_type == GEOARROW_EDGE_TYPE_SPHERICAL;
+  }
+
+  GeoArrowGeographyInputView(const struct ArrowSchema* type)
+      : inner_(type), current_array_length_(1), stashed_index_(-1) {
+    type_ = ::geoarrow::GeometryDataType::Make(type);
+    GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKBReaderInit(&reader_));
+  }
+  GeoArrowGeographyInputView(const GeoArrowGeographyInputView&) = delete;
+  GeoArrowGeographyInputView& operator=(const GeoArrowGeographyInputView&) =
+      delete;
+
+  ~GeoArrowGeographyInputView() { GeoArrowWKBReaderReset(&reader_); }
+
+  std::string GetCrs() { return type_.crs(); }
+
+  void SetArray(const struct ArrowArray* array, int64_t num_rows) {
+    current_array_length_ = array->length;
+    stashed_index_ = -1;
+  }
+
+  bool IsNull(int64_t i) { return inner_.IsNull(i); }
+
+  const GeoArrowGeography& Get(int64_t i) {
+    StashIfNeeded(i % current_array_length_);
+    return stashed_;
+  }
+
+ private:
+  ::geoarrow::GeometryDataType type_;
+  struct GeoArrowWKBReader reader_;
+  ArrowInputView<std::string_view> inner_;
+  int64_t current_array_length_;
+  int64_t stashed_index_;
+  GeoArrowGeography stashed_;
+
+  void StashIfNeeded(int64_t i) {
+    if (i != stashed_index_) {
+      std::string_view inner = inner_.Get(i);
+      struct GeoArrowBufferView src = {
+          reinterpret_cast<const uint8_t*>(inner.data()),
+          static_cast<int64_t>(inner.size())};
+
+      struct GeoArrowGeometryView geom{};
+      GEOARROW_THROW_NOT_OK(
+          nullptr, GeoArrowWKBReaderRead(&reader_, src, &geom, nullptr));
+
+      stashed_.Init(geom);
+      stashed_index_ = i;
+    }
+  }
+};
+
 /// \brief View of geometry index input
 ///
 /// This is used for operations like the S2BooleanOperation that require
@@ -351,6 +461,8 @@ class GeographyIndexInputView {
 
   GeographyIndexInputView(const struct ArrowSchema* type)
       : inner_(type), stashed_index_(-1) {}
+  GeographyIndexInputView(const GeographyIndexInputView&) = delete;
+  GeographyIndexInputView& operator=(const GeographyIndexInputView&) = delete;
 
   std::string GetCrs() { return inner_.GetCrs(); }
 


### PR DESCRIPTION
This PR replaces one of the helper classes that had been used to support operations that require a `ShapeIndex` (e.g., boolean operation, distance calculations) to instead use the `GeoArrowGeography` added in #82. This reduces the support of kernels to `geoarrow.wkb` for now, although the GeoArrowGeography (and the `struct GeoArrowGeometryView` on which it is based) can represent any GeoArrow geometry encoding without copies (except geoarrow.wkt and geoarrow.box) and could be extended to work with other types.

This doesn't address a major performance issue identified in #84 (which is that building a spatial index is very expensive even for very small geometries). I'll address this next (by implementing special `S2SpatialIndex` implementations for very small geometries).