### PR TITLE
feat: Check covering intersection before running S2BooleanOperation

### DIFF
--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -443,7 +443,8 @@ struct BooleanOperationExec {
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    stashed_ = s2_boolean_operation(value0, value1, op_type, options_);
+    stashed_ = s2_boolean_operation(value0.ShapeIndex(), value1.ShapeIndex(),
+                                    op_type, options_);
     return *stashed_;
   }
 

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -411,6 +411,7 @@ GeoArrowGeography::GeoArrowGeography(GeoArrowGeography&& other)
       index_() {
   // index_ needs to be rebuilt
   index_.Clear();
+  indexed_ = false;
 }
 
 GeoArrowGeography& GeoArrowGeography::operator=(GeoArrowGeography&& other) {
@@ -422,6 +423,7 @@ GeoArrowGeography& GeoArrowGeography::operator=(GeoArrowGeography&& other) {
     polygons_ = std::move(other.polygons_);
     // index_ needs to be rebuilt
     index_.Clear();
+    indexed_ = false;
   }
   return *this;
 }
@@ -531,7 +533,9 @@ std::optional<S2Point> GeoArrowGeography::Point() const {
   switch (geom_.root->geometry_type) {
     case GEOARROW_GEOMETRY_TYPE_POINT:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
-      return points_.edge(0).v0;
+      if (points_.num_edges() == 1) {
+        return points_.edge(0).v0;
+      }
     default:
       return std::nullopt;
   }

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -407,6 +407,7 @@ GeoArrowGeography::GeoArrowGeography(GeoArrowGeography&& other)
       points_(std::move(other.points_)),
       lines_(std::move(other.lines_)),
       polygons_(std::move(other.polygons_)),
+      covering_(std::move(other.covering_)),
       index_() {
   // index_ needs to be rebuilt
   index_.Clear();
@@ -419,6 +420,7 @@ GeoArrowGeography& GeoArrowGeography::operator=(GeoArrowGeography&& other) {
     points_ = std::move(other.points_);
     lines_ = std::move(other.lines_);
     polygons_ = std::move(other.polygons_);
+    covering_ = std::move(other.covering_);
     // index_ needs to be rebuilt
     index_.Clear();
     indexed_ = false;
@@ -475,7 +477,7 @@ void GeoArrowGeography::GetCellUnionBound(std::vector<S2CellId>* cell_ids) {
   switch (geom_.root->geometry_type) {
     case GEOARROW_GEOMETRY_TYPE_POINT:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
-      if (points_.num_vertices() <= 100) {
+      if (points_.num_vertices() <= 32) {
         for (int i = 0; i < points_.num_edges(); ++i) {
           cell_ids->push_back(S2CellId(points_.vertex(i)));
         }

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -479,10 +479,9 @@ void GeoArrowGeography::GetCellUnionBound(std::vector<S2CellId>* cell_ids) {
         for (int i = 0; i < points_.num_edges(); ++i) {
           cell_ids->push_back(S2CellId(points_.vertex(i)));
         }
+        return;
       }
-
-      return;
-
+      break;
     default:
       break;
   }

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -480,6 +480,9 @@ void GeoArrowGeography::GetCellUnionBound(std::vector<S2CellId>* cell_ids) {
           cell_ids->push_back(S2CellId(points_.vertex(i)));
         }
       }
+
+      return;
+
     default:
       break;
   }

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -468,6 +468,27 @@ void GeoArrowGeography::InitOriented(struct GeoArrowGeometryView geom) {
   AddShapesToIndex();
 }
 
+void GeoArrowGeography::GetCellUnionBound(
+    std::vector<S2CellId>* cell_ids) const {
+  if (geom_.size_nodes == 0) {
+    return;
+  }
+
+  switch (geom_.root->geometry_type) {
+    case GEOARROW_GEOMETRY_TYPE_POINT:
+    case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
+      if (points_.num_vertices() <= 100) {
+        for (int i = 0; i < points_.num_edges(); ++i) {
+          cell_ids->push_back(S2CellId(points_.vertex(i)));
+        }
+      }
+    default:
+      break;
+  }
+
+  return Geography::GetCellUnionBound(cell_ids);
+}
+
 const S2ShapeIndex& GeoArrowGeography::ShapeIndex() const { return index_; }
 
 int GeoArrowGeography::dimension() const {

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <limits>
 
+#include "s2/s2point_region.h"
 #include "s2geography/geography_interface.h"
 
 namespace s2geography {
@@ -594,6 +595,11 @@ std::unique_ptr<S2Shape> GeoArrowGeography::Shape(int id) const {
 }
 
 std::unique_ptr<S2Region> GeoArrowGeography::Region() const {
+  auto maybe_point = Point();
+  if (maybe_point) {
+    return std::make_unique<S2PointRegion>(*maybe_point);
+  }
+
   return std::make_unique<S2ShapeIndexRegion<MutableS2ShapeIndex>>(&index_);
 }
 

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -527,6 +527,10 @@ bool GeoArrowGeography::is_empty() const {
 }
 
 std::optional<S2Point> GeoArrowGeography::Point() const {
+  if (geom_.size_nodes == 0) {
+    return std::nullopt;
+  }
+
   switch (geom_.root->geometry_type) {
     case GEOARROW_GEOMETRY_TYPE_POINT:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -437,6 +437,7 @@ void GeoArrowGeography::InitOriented(struct GeoArrowGeometryView geom) {
   lines_.Clear();
   polygons_.Clear();
   index_.Clear();
+  covering_.clear();
   geom_ = geom;
 
   if (geom.size_nodes == 0) {
@@ -487,6 +488,14 @@ void GeoArrowGeography::GetCellUnionBound(
   }
 
   return Geography::GetCellUnionBound(cell_ids);
+}
+
+const std::vector<S2CellId>& GeoArrowGeography::GetStashedCovering() {
+  if (covering_.empty()) {
+    GetCellUnionBound(&covering_);
+  }
+
+  return covering_;
 }
 
 const S2ShapeIndex& GeoArrowGeography::ShapeIndex() const { return index_; }

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -408,9 +408,8 @@ GeoArrowGeography::GeoArrowGeography(GeoArrowGeography&& other)
       lines_(std::move(other.lines_)),
       polygons_(std::move(other.polygons_)),
       index_() {
-  // Rebuild index_ so that any internal wrappers point to this object's
-  // members rather than to the moved-from object.
-  AddShapesToIndex();
+  // index_ needs to be rebuilt
+  index_.Clear();
 }
 
 GeoArrowGeography& GeoArrowGeography::operator=(GeoArrowGeography&& other) {
@@ -420,9 +419,8 @@ GeoArrowGeography& GeoArrowGeography::operator=(GeoArrowGeography&& other) {
     points_ = std::move(other.points_);
     lines_ = std::move(other.lines_);
     polygons_ = std::move(other.polygons_);
+    // index_ needs to be rebuilt
     index_.Clear();
-    // Rebuild index_ with wrappers bound to this object's members.
-    AddShapesToIndex();
   }
   return *this;
 }
@@ -438,6 +436,7 @@ void GeoArrowGeography::InitOriented(struct GeoArrowGeometryView geom) {
   polygons_.Clear();
   index_.Clear();
   covering_.clear();
+  indexed_ = false;
   geom_ = geom;
 
   if (geom.size_nodes == 0) {
@@ -465,8 +464,6 @@ void GeoArrowGeography::InitOriented(struct GeoArrowGeometryView geom) {
           "Can't create GeoArrowGeography from geometry type " +
           std::string(GeometryTypeString(geom.root->geometry_type)));
   }
-
-  AddShapesToIndex();
 }
 
 void GeoArrowGeography::GetCellUnionBound(
@@ -490,7 +487,7 @@ void GeoArrowGeography::GetCellUnionBound(
   return Geography::GetCellUnionBound(cell_ids);
 }
 
-const std::vector<S2CellId>& GeoArrowGeography::GetStashedCovering() {
+const std::vector<S2CellId>& GeoArrowGeography::StashedCovering() {
   if (covering_.empty()) {
     GetCellUnionBound(&covering_);
   }
@@ -498,7 +495,46 @@ const std::vector<S2CellId>& GeoArrowGeography::GetStashedCovering() {
   return covering_;
 }
 
-const S2ShapeIndex& GeoArrowGeography::ShapeIndex() const { return index_; }
+const S2ShapeIndex& GeoArrowGeography::ShapeIndex() {
+  AddShapesToIndexIfNeeded();
+  return index_;
+}
+
+bool GeoArrowGeography::is_empty() const {
+  if (geom_.size_nodes == 0) {
+    return true;
+  }
+
+  switch (geom_.root->geometry_type) {
+    case GEOARROW_GEOMETRY_TYPE_POINT:
+    case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
+      return points_.is_empty();
+    case GEOARROW_GEOMETRY_TYPE_LINESTRING:
+    case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
+      return lines_.is_empty();
+    case GEOARROW_GEOMETRY_TYPE_POLYGON:
+    case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
+      return polygons_.is_empty();
+    default:
+      for (int i = 0; i < num_shapes(); ++i) {
+        if (!Shape(i)->is_empty()) {
+          return false;
+        }
+      }
+
+      return true;
+  }
+}
+
+std::optional<S2Point> GeoArrowGeography::Point() const {
+  switch (geom_.root->geometry_type) {
+    case GEOARROW_GEOMETRY_TYPE_POINT:
+    case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
+      return points_.edge(0).v0;
+    default:
+      return std::nullopt;
+  }
+}
 
 int GeoArrowGeography::dimension() const {
   if (geom_.size_nodes == 0) {
@@ -566,8 +602,8 @@ void GeoArrowGeography::Encode(Encoder* /*encoder*/,
   throw Exception("Encode() not implemented for GeoArrowGeography");
 }
 
-void GeoArrowGeography::AddShapesToIndex() {
-  if (geom_.size_nodes == 0) {
+void GeoArrowGeography::AddShapesToIndexIfNeeded() {
+  if (indexed_ || geom_.size_nodes == 0) {
     return;
   }
 
@@ -592,6 +628,8 @@ void GeoArrowGeography::AddShapesToIndex() {
           "Can't create index from geometry type " +
           std::string(GeometryTypeString(geom_.root->geometry_type)));
   }
+
+  indexed_ = true;
 }
 
 }  // namespace s2geography

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -403,8 +403,7 @@ S2Shape::TypeTag GeoArrowLaxPolygonShape::type_tag() const { return kTypeTag; }
 /// GeoArrowGeography
 
 GeoArrowGeography::GeoArrowGeography(GeoArrowGeography&& other)
-    : Geography(std::move(other)),
-      geom_(other.geom_),
+    : geom_(other.geom_),
       points_(std::move(other.points_)),
       lines_(std::move(other.lines_)),
       polygons_(std::move(other.polygons_)),
@@ -416,7 +415,6 @@ GeoArrowGeography::GeoArrowGeography(GeoArrowGeography&& other)
 
 GeoArrowGeography& GeoArrowGeography::operator=(GeoArrowGeography&& other) {
   if (this != &other) {
-    Geography::operator=(std::move(other));
     geom_ = other.geom_;
     points_ = std::move(other.points_);
     lines_ = std::move(other.lines_);
@@ -469,9 +467,8 @@ void GeoArrowGeography::InitOriented(struct GeoArrowGeometryView geom) {
   }
 }
 
-void GeoArrowGeography::GetCellUnionBound(
-    std::vector<S2CellId>* cell_ids) const {
-  if (geom_.size_nodes == 0) {
+void GeoArrowGeography::GetCellUnionBound(std::vector<S2CellId>* cell_ids) {
+  if (geom_.size_nodes == 0 || is_empty()) {
     return;
   }
 
@@ -487,7 +484,7 @@ void GeoArrowGeography::GetCellUnionBound(
       break;
   }
 
-  return Geography::GetCellUnionBound(cell_ids);
+  Region()->GetCellUnionBound(cell_ids);
 }
 
 const std::vector<S2CellId>& GeoArrowGeography::StashedCovering() {
@@ -499,7 +496,7 @@ const std::vector<S2CellId>& GeoArrowGeography::StashedCovering() {
 }
 
 const S2ShapeIndex& GeoArrowGeography::ShapeIndex() {
-  AddShapesToIndexIfNeeded();
+  InitIndex();
   return index_;
 }
 
@@ -557,7 +554,7 @@ int GeoArrowGeography::dimension() const {
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
       return 2;
     default:
-      return Geography::dimension();
+      return -1;
   }
 }
 
@@ -579,40 +576,36 @@ int GeoArrowGeography::num_shapes() const {
   }
 }
 
-std::unique_ptr<S2Shape> GeoArrowGeography::Shape(int id) const {
+const S2Shape* GeoArrowGeography::Shape(int id) const {
   switch (geom_.root->geometry_type) {
     case GEOARROW_GEOMETRY_TYPE_POINT:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
-      return std::make_unique<S2ShapeWrapper>(&points_);
+      return &points_;
 
     case GEOARROW_GEOMETRY_TYPE_LINESTRING:
     case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
-      return std::make_unique<S2ShapeWrapper>(&lines_);
+      return &lines_;
 
     case GEOARROW_GEOMETRY_TYPE_POLYGON:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
-      return std::make_unique<S2ShapeWrapper>(&polygons_);
+      return &polygons_;
 
     default:
       throw Exception("unsupported geometry type");
   }
 }
 
-std::unique_ptr<S2Region> GeoArrowGeography::Region() const {
+std::unique_ptr<S2Region> GeoArrowGeography::Region() {
   auto maybe_point = Point();
   if (maybe_point) {
     return std::make_unique<S2PointRegion>(*maybe_point);
   }
 
+  InitIndex();
   return std::make_unique<S2ShapeIndexRegion<MutableS2ShapeIndex>>(&index_);
 }
 
-void GeoArrowGeography::Encode(Encoder* /*encoder*/,
-                               const EncodeOptions& /*options*/) const {
-  throw Exception("Encode() not implemented for GeoArrowGeography");
-}
-
-void GeoArrowGeography::AddShapesToIndexIfNeeded() {
+void GeoArrowGeography::InitIndex() {
   if (indexed_ || geom_.size_nodes == 0) {
     return;
   }

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -487,7 +487,7 @@ void GeoArrowGeography::GetCellUnionBound(std::vector<S2CellId>* cell_ids) {
   Region()->GetCellUnionBound(cell_ids);
 }
 
-const std::vector<S2CellId>& GeoArrowGeography::StashedCovering() {
+const std::vector<S2CellId>& GeoArrowGeography::Covering() {
   if (covering_.empty()) {
     GetCellUnionBound(&covering_);
   }

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -203,6 +203,8 @@ class GeoArrowGeography : public Geography {
 
   const S2ShapeIndex& ShapeIndex() const;
 
+  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const override;
+
   int dimension() const override;
   int num_shapes() const override;
   std::unique_ptr<S2Shape> Shape(int id) const override;

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -187,27 +187,81 @@ class GeoArrowLaxPolygonShape : public S2Shape {
   std::vector<S2Point> point_scratch_;
 };
 
+/// \brief Reusable Geography-like wrapper around a GeoArrowGeometryNode
+///
+/// This class is conceptually a union of zero or more of the
+/// GeoArrowPointShape, GeoArrowLaxPolylineShape, and/or the
+/// GeoArrowLaxPolygonShape. It is not currently a subclass of Geography because
+/// it intentionally defers creating its index and provides a few other features
+/// specifically targeted at rapid iteration over many GeoArrowGeometryViews
+/// (this makes it difficult to comply with the const requirements of the
+/// Geography which aren't necessary here).
 class GeoArrowGeography {
  public:
+  /// \brief Create an empty geography
   GeoArrowGeography() = default;
 
   GeoArrowGeography(const GeoArrowGeography&) = delete;
   GeoArrowGeography& operator=(const GeoArrowGeography&) = delete;
   GeoArrowGeography(GeoArrowGeography&& other);
-
   GeoArrowGeography& operator=(GeoArrowGeography&& other);
 
+  /// \brief (Re)Initialize this Geography from a GeoArrowGeometryView
+  ///
+  /// If this view contains polygons, the internals will ensure that shells are
+  /// treated as shells and holes are treated as holes regardless of winding
+  /// direction.
   void Init(struct GeoArrowGeometryView geom);
+
+  /// \brief (Re)Initialize this Geography from a GeoArrowGeometryView
+  ///
+  /// If this view contains polygons, the internals will assume that the winding
+  /// order is the sole determinant of containment.
   void InitOriented(struct GeoArrowGeometryView geom);
 
-  const std::vector<S2CellId>& StashedCovering();
+  /// \brief A collection of cells that completely cover this geography
+  ///
+  /// This may be used with S2CellUnion utilities to check potential
+  /// containment. This is lazily computed and may incur building an index. For
+  /// Small point or multipoint geographies this will not incur the cost of
+  /// building an index.
+  const std::vector<S2CellId>& Covering();
+
+  /// \brief Return a S2ShapeIndex representation of this geography
+  ///
+  /// This index is lazy: it will not be created until potentially this call,
+  /// and will not be built until it is queried (see MutableS2ShapeIndex). Note
+  /// that building an index of a small geography is comparatively very costly
+  /// to brute force iteration if that is an option for a given algorithm.
   const S2ShapeIndex& ShapeIndex();
+
+  /// \brief Return a Region representation of this geography
+  ///
+  /// This region is lazy: it will not be created until potentially this call.
+  /// For (single) point geographies the implementation avoids creating or
+  /// building an index.
   std::unique_ptr<S2Region> Region();
 
+  /// \brief If this geography represents a single point, compute and return it
+  ///
+  /// This allows callers to use potentially much faster implmentations of
+  /// various algorithms that take an S2Point.
   std::optional<S2Point> Point() const;
+
+  /// \brief Returns true if this geography has no edges
   bool is_empty() const;
+
+  /// \brief Returns the dimension (0 for point, 1 for linestring, 2 for polygon), or
+  /// -1 for geometry collections
   int dimension() const;
+
+  /// \brief The number of shapes
+  ///
+  /// This is usually one (exactly one of the point, line, or polygon shape
+  /// classes) but may be higher for geometrycollections.
   int num_shapes() const;
+
+  /// \brief Retreive a shape
   const S2Shape* Shape(int id) const;
 
  private:

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -244,15 +244,15 @@ class GeoArrowGeography {
 
   /// \brief If this geography represents a single point, compute and return it
   ///
-  /// This allows callers to use potentially much faster implmentations of
+  /// This allows callers to use potentially much faster implementations of
   /// various algorithms that take an S2Point.
   std::optional<S2Point> Point() const;
 
   /// \brief Returns true if this geography has no edges
   bool is_empty() const;
 
-  /// \brief Returns the dimension (0 for point, 1 for linestring, 2 for polygon), or
-  /// -1 for geometry collections
+  /// \brief Returns the dimension (0 for point, 1 for linestring, 2 for
+  /// polygon), or -1 for geometry collections
   int dimension() const;
 
   /// \brief The number of shapes
@@ -261,7 +261,7 @@ class GeoArrowGeography {
   /// classes) but may be higher for geometrycollections.
   int num_shapes() const;
 
-  /// \brief Retreive a shape
+  /// \brief Retrieve a shape
   const S2Shape* Shape(int id) const;
 
  private:

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -201,12 +201,12 @@ class GeoArrowGeography : public Geography {
   void Init(struct GeoArrowGeometryView geom);
   void InitOriented(struct GeoArrowGeometryView geom);
 
-  const std::vector<S2CellId>& GetStashedCovering();
-
-  const S2ShapeIndex& ShapeIndex() const;
+  const std::vector<S2CellId>& StashedCovering();
+  const S2ShapeIndex& ShapeIndex();
+  std::optional<S2Point> Point() const;
+  bool is_empty() const;
 
   void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const override;
-
   int dimension() const override;
   int num_shapes() const override;
   std::unique_ptr<S2Shape> Shape(int id) const override;
@@ -220,8 +220,9 @@ class GeoArrowGeography : public Geography {
   GeoArrowLaxPolygonShape polygons_;
   MutableS2ShapeIndex index_;
   std::vector<S2CellId> covering_;
+  bool indexed_{};
 
-  void AddShapesToIndex();
+  void AddShapesToIndexIfNeeded();
 };
 
 /// @}

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -201,6 +201,8 @@ class GeoArrowGeography : public Geography {
   void Init(struct GeoArrowGeometryView geom);
   void InitOriented(struct GeoArrowGeometryView geom);
 
+  const std::vector<S2CellId>& GetStashedCovering();
+
   const S2ShapeIndex& ShapeIndex() const;
 
   void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const override;
@@ -217,6 +219,7 @@ class GeoArrowGeography : public Geography {
   GeoArrowLaxPolylineShape lines_;
   GeoArrowLaxPolygonShape polygons_;
   MutableS2ShapeIndex index_;
+  std::vector<S2CellId> covering_;
 
   void AddShapesToIndex();
 };

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include "geoarrow/geoarrow.hpp"
-#include "s2geography/geography_interface.h"
 
 namespace s2geography {
 
@@ -188,9 +187,9 @@ class GeoArrowLaxPolygonShape : public S2Shape {
   std::vector<S2Point> point_scratch_;
 };
 
-class GeoArrowGeography : public Geography {
+class GeoArrowGeography {
  public:
-  GeoArrowGeography() : Geography(GeographyKind::GEOARROW) {}
+  GeoArrowGeography() = default;
 
   GeoArrowGeography(const GeoArrowGeography&) = delete;
   GeoArrowGeography& operator=(const GeoArrowGeography&) = delete;
@@ -203,15 +202,13 @@ class GeoArrowGeography : public Geography {
 
   const std::vector<S2CellId>& StashedCovering();
   const S2ShapeIndex& ShapeIndex();
+  std::unique_ptr<S2Region> Region();
+
   std::optional<S2Point> Point() const;
   bool is_empty() const;
-
-  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const override;
-  int dimension() const override;
-  int num_shapes() const override;
-  std::unique_ptr<S2Shape> Shape(int id) const override;
-  std::unique_ptr<S2Region> Region() const override;
-  void Encode(Encoder* encoder, const EncodeOptions& options) const override;
+  int dimension() const;
+  int num_shapes() const;
+  const S2Shape* Shape(int id) const;
 
  private:
   struct GeoArrowGeometryView geom_{};
@@ -222,7 +219,8 @@ class GeoArrowGeography : public Geography {
   std::vector<S2CellId> covering_;
   bool indexed_{};
 
-  void AddShapesToIndexIfNeeded();
+  void InitIndex();
+  void GetCellUnionBound(std::vector<S2CellId>* cell_ids);
 };
 
 /// @}

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -736,7 +736,6 @@ TEST_F(GeoArrowGeographyTest, Point) {
   auto geog = MakeGeography("POINT (1 2)");
   EXPECT_EQ(geog.dimension(), 0);
   EXPECT_EQ(geog.num_shapes(), 1);
-  EXPECT_EQ(geog.kind(), GeographyKind::GEOARROW);
 
   auto shape = geog.Shape(0);
   ASSERT_NE(shape, nullptr);
@@ -820,13 +819,6 @@ TEST_F(GeoArrowGeographyTest, RegionNotNull) {
   auto geog = MakeGeography("POLYGON ((0 0, 1 0, 0 1, 0 0))");
   auto region = geog.Region();
   EXPECT_NE(region, nullptr);
-}
-
-TEST_F(GeoArrowGeographyTest, EncodeThrows) {
-  auto geog = MakeGeography("POINT (0 0)");
-  Encoder encoder;
-  EncodeOptions options;
-  EXPECT_THROW(geog.Encode(&encoder, options), Exception);
 }
 
 TEST_F(GeoArrowGeographyTest, ShapeIndexIntersection) {

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -859,7 +859,7 @@ TEST_F(GeoArrowGeographyTest, Region) {
 
   // Point regions are specialized to make them less expensive to create
   auto geog_point = MakeGeography("POINT (0 0)");
-  auto point_region = geog.Region();
+  auto point_region = geog_point.Region();
   EXPECT_TRUE(point_region->Contains(S2LatLng::FromDegrees(0, 0).ToPoint()));
 }
 

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -705,8 +705,10 @@ class GeoArrowGeographyTest : public ::testing::Test {
 
 TEST_F(GeoArrowGeographyTest, DefaultConstructor) {
   GeoArrowGeography geog;
+  EXPECT_TRUE(geog.is_empty());
   EXPECT_EQ(geog.num_shapes(), 0);
   EXPECT_EQ(geog.dimension(), -1);
+  ASSERT_EQ(geog.Covering().size(), 0);
 
   auto point = MakeGeography("POINT (0 0)");
   EXPECT_FALSE(
@@ -720,8 +722,10 @@ TEST_F(GeoArrowGeographyTest, DefaultConstructor) {
 TEST_F(GeoArrowGeographyTest, InitGeometryZeroNodes) {
   GeoArrowGeography geog;
   geog.Init({nullptr, 0});
+  EXPECT_TRUE(geog.is_empty());
   EXPECT_EQ(geog.num_shapes(), 0);
   EXPECT_EQ(geog.dimension(), -1);
+  ASSERT_EQ(geog.Covering().size(), 0);
 
   auto point = MakeGeography("POINT (0 0)");
   EXPECT_FALSE(
@@ -736,6 +740,9 @@ TEST_F(GeoArrowGeographyTest, Point) {
   auto geog = MakeGeography("POINT (1 2)");
   EXPECT_EQ(geog.dimension(), 0);
   EXPECT_EQ(geog.num_shapes(), 1);
+  // Check twice because the value is cached
+  ASSERT_EQ(geog.Covering().size(), 1);
+  ASSERT_EQ(geog.Covering().size(), 1);
 
   auto shape = geog.Shape(0);
   ASSERT_NE(shape, nullptr);
@@ -749,6 +756,9 @@ TEST_F(GeoArrowGeographyTest, MultiPoint) {
   auto geog = MakeGeography("MULTIPOINT ((0 0), (1 1), (2 2))");
   EXPECT_EQ(geog.dimension(), 0);
   EXPECT_EQ(geog.num_shapes(), 1);
+  // Check twice because the value is cached
+  ASSERT_EQ(geog.Covering().size(), 3);
+  ASSERT_EQ(geog.Covering().size(), 3);
 
   auto shape = geog.Shape(0);
   ASSERT_NE(shape, nullptr);
@@ -759,6 +769,7 @@ TEST_F(GeoArrowGeographyTest, EmptyPoint) {
   auto geog = MakeGeography("POINT EMPTY");
   EXPECT_EQ(geog.dimension(), 0);
   EXPECT_EQ(geog.num_shapes(), 1);
+  ASSERT_EQ(geog.Covering().size(), 0);
 
   auto shape = geog.Shape(0);
   ASSERT_NE(shape, nullptr);
@@ -769,6 +780,7 @@ TEST_F(GeoArrowGeographyTest, Linestring) {
   auto geog = MakeGeography("LINESTRING (0 0, 1 1, 2 2)");
   EXPECT_EQ(geog.dimension(), 1);
   EXPECT_EQ(geog.num_shapes(), 1);
+  ASSERT_GT(geog.Covering().size(), 0);
 
   auto shape = geog.Shape(0);
   ASSERT_NE(shape, nullptr);
@@ -780,6 +792,7 @@ TEST_F(GeoArrowGeographyTest, MultiLinestring) {
   auto geog = MakeGeography("MULTILINESTRING ((0 0, 1 1), (2 2, 3 3, 4 4))");
   EXPECT_EQ(geog.dimension(), 1);
   EXPECT_EQ(geog.num_shapes(), 1);
+  ASSERT_GT(geog.Covering().size(), 0);
 
   auto shape = geog.Shape(0);
   ASSERT_NE(shape, nullptr);
@@ -790,6 +803,7 @@ TEST_F(GeoArrowGeographyTest, Polygon) {
   auto geog = MakeGeography("POLYGON ((0 0, 1 0, 0 1, 0 0))");
   EXPECT_EQ(geog.dimension(), 2);
   EXPECT_EQ(geog.num_shapes(), 1);
+  ASSERT_GT(geog.Covering().size(), 0);
 
   auto shape = geog.Shape(0);
   ASSERT_NE(shape, nullptr);
@@ -803,6 +817,7 @@ TEST_F(GeoArrowGeographyTest, MultiPolygon) {
       "((10 10, 11 10, 10 11, 10 10)))");
   EXPECT_EQ(geog.dimension(), 2);
   EXPECT_EQ(geog.num_shapes(), 1);
+  ASSERT_GT(geog.Covering().size(), 0);
 
   auto shape = geog.Shape(0);
   ASSERT_NE(shape, nullptr);
@@ -812,6 +827,7 @@ TEST_F(GeoArrowGeographyTest, MultiPolygon) {
 TEST_F(GeoArrowGeographyTest, GeometryCollectionThrows) {
   auto gc_geom = TestGeometry::FromWKT("GEOMETRYCOLLECTION (POINT (0 0))");
   GeoArrowGeography geog;
+  // Not yet supported
   EXPECT_THROW(geog.Init(gc_geom.geom()), Exception);
 }
 
@@ -840,6 +856,11 @@ TEST_F(GeoArrowGeographyTest, Region) {
   auto geog = MakeGeography("POLYGON ((-1 -1, 2 -1, 2 2, -1 2, -1 -1))");
   auto region = geog.Region();
   EXPECT_TRUE(region->Contains(S2LatLng::FromDegrees(0, 0).ToPoint()));
+
+  // Point regions are specialized to make them less expensive to create
+  auto geog_point = MakeGeography("POINT (0 0)");
+  auto point_region = geog.Region();
+  EXPECT_TRUE(point_region->Contains(S2LatLng::FromDegrees(0, 0).ToPoint()));
 }
 
 TEST_F(GeoArrowGeographyTest, RegionReversedWinding) {

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -145,19 +145,23 @@ struct S2Intersects {
     if (maybe_point0 && maybe_point1) {
       return maybe_point0->Normalize() == maybe_point1->Normalize();
     } else if (maybe_point0) {
+      // ShapeIndex() must be called first to populate the index; Region()
+      // wraps &index_ which would otherwise be empty.
+      const auto& index1 = value1.ShapeIndex();
       auto region1 = value1.Region();
-      if (region1->MayIntersect(S2Cell(*maybe_point0))) {
-        return region1->Contains(*maybe_point0) ||
-               s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(),
-                             options_);
+      if (!region1->MayIntersect(S2Cell(*maybe_point0))) {
+        return false;
       }
+      return region1->Contains(*maybe_point0) ||
+             s2_intersects(value0.ShapeIndex(), index1, options_);
     } else if (maybe_point1) {
+      const auto& index0 = value0.ShapeIndex();
       auto region0 = value0.Region();
-      if (region0->MayIntersect(S2Cell(*maybe_point1))) {
-        return region0->Contains(*maybe_point1) ||
-               s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(),
-                             options_);
+      if (!region0->MayIntersect(S2Cell(*maybe_point1))) {
+        return false;
       }
+      return region0->Contains(*maybe_point1) ||
+             s2_intersects(index0, value1.ShapeIndex(), options_);
     }
 
     S2CellUnion::GetIntersection(value0.StashedCovering(),

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -142,17 +142,22 @@ struct S2Intersects {
 
     auto maybe_point0 = value0.Point();
     auto maybe_point1 = value1.Point();
-
-    auto region1 = value1.Region();
-    if (maybe_point0 && region1->MayIntersect(S2Cell(*maybe_point0))) {
-      return region1->Contains(*maybe_point0) ||
-             s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
-    }
-
-    auto region0 = value0.Region();
-    if (maybe_point1 && region0->MayIntersect(S2Cell(*maybe_point1))) {
-      return region0->Contains(*maybe_point1) ||
-             s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
+    if (maybe_point0 && maybe_point1) {
+      return maybe_point0->Normalize() == maybe_point1->Normalize();
+    } else if (maybe_point0) {
+      auto region1 = value1.Region();
+      if (region1->MayIntersect(S2Cell(*maybe_point0))) {
+        return region1->Contains(*maybe_point0) ||
+               s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(),
+                             options_);
+      }
+    } else if (maybe_point1) {
+      auto region0 = value0.Region();
+      if (region0->MayIntersect(S2Cell(*maybe_point1))) {
+        return region0->Contains(*maybe_point1) ||
+               s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(),
+                             options_);
+      }
     }
 
     S2CellUnion::GetIntersection(value0.StashedCovering(),

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -155,7 +155,7 @@ struct S2Intersects {
     // has already been built. In the event that an index does have to be built
     // to build the covering, it is effectively reused in the actual
     // s2_intersection() check. This is 2x faster than an intersection check for
-    // selective point-in-polygon queries but may need to be reevaluted.
+    // selective point-in-polygon queries but may need to be reevaluated.
     S2CellUnion::GetIntersection(value0.Covering(), value1.Covering(),
                                  &intersection_);
     if (intersection_.empty()) {

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -112,7 +112,10 @@ struct S2Intersects {
   using arg1_t = GeoArrowGeographyInputView;
   using out_t = BoolOutputBuilder;
 
-  void Init(const std::unordered_map<std::string, std::string>& options) {}
+  void Init(const std::unordered_map<std::string, std::string>& options) {
+    // Use Simple Features compatibility options
+    options_.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
+  }
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
     // If either argument is EMPTY, the result is FALSE
@@ -133,31 +136,36 @@ struct S2Intersects {
         return false;
       }
       return region1->Contains(*maybe_point0) ||
-             s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
+             ExecUsingShapeIndex(value0, value1);
     } else if (maybe_point1) {
       auto region0 = value0.Region();
       if (!region0->MayIntersect(S2Cell(*maybe_point1))) {
         return false;
       }
       return region0->Contains(*maybe_point1) ||
-             s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
+             ExecUsingShapeIndex(value0, value1);
     }
 
-    // We could consider special casing more things here. S2Geometry special cases
-    // loops with less than 32 vertices to avoid building an index which is likely
-    // worth doing here based on some heuristics for other geometry types too.
+    // We could consider special casing more things here. S2Geometry special
+    // cases loops with less than 32 vertices to avoid building an index which
+    // is likely worth doing here based on some heuristics for other geometry
+    // types too.
 
     // Next we try a covering intersection check. This is very cheap if an index
     // has already been built. In the event that an index does have to be built
-    // to build the covering, it is effectively reused in the actual s2_intersection()
-    // check. This is 2x faster than an intersection check for selective
-    // point-in-polygon queries but may need to be reevaluted.
+    // to build the covering, it is effectively reused in the actual
+    // s2_intersection() check. This is 2x faster than an intersection check for
+    // selective point-in-polygon queries but may need to be reevaluted.
     S2CellUnion::GetIntersection(value0.Covering(), value1.Covering(),
                                  &intersection_);
     if (intersection_.empty()) {
       return false;
     }
 
+    return ExecUsingShapeIndex(value0, value1);
+  }
+
+  bool ExecUsingShapeIndex(arg0_t::c_type value0, arg1_t::c_type value1) {
     return s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
   }
 

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -141,14 +141,16 @@ struct S2Intersects {
     }
 
     auto maybe_point0 = value0.Point();
-    if (maybe_point0) {
-      return value1.Region()->Contains(*maybe_point0) ||
+    auto region1 = value1.Region();
+    if (maybe_point0 && region1->MayIntersect(S2Cell(*maybe_point0))) {
+      return region1->Contains(*maybe_point0) ||
              s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
     }
 
     auto maybe_point1 = value1.Point();
-    if (maybe_point1) {
-      return value1.Region()->Contains(*maybe_point0) ||
+    auto region0 = value0.Region();
+    if (maybe_point1 && region0->MayIntersect(S2Cell(*maybe_point1))) {
+      return region0->Contains(*maybe_point1) ||
              s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
     }
 

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -141,17 +141,24 @@ struct S2Intersects {
     }
 
     auto maybe_point0 = value0.Point();
+    auto maybe_point1 = value1.Point();
+
     auto region1 = value1.Region();
     if (maybe_point0 && region1->MayIntersect(S2Cell(*maybe_point0))) {
       return region1->Contains(*maybe_point0) ||
              s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
     }
 
-    auto maybe_point1 = value1.Point();
     auto region0 = value0.Region();
     if (maybe_point1 && region0->MayIntersect(S2Cell(*maybe_point1))) {
       return region0->Contains(*maybe_point1) ||
              s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
+    }
+
+    S2CellUnion::GetIntersection(value0.StashedCovering(),
+                                 value1.StashedCovering(), &intersection_);
+    if (intersection_.empty()) {
+      return false;
     }
 
     return s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -145,23 +145,19 @@ struct S2Intersects {
     if (maybe_point0 && maybe_point1) {
       return maybe_point0->Normalize() == maybe_point1->Normalize();
     } else if (maybe_point0) {
-      // ShapeIndex() must be called first to populate the index; Region()
-      // wraps &index_ which would otherwise be empty.
-      const auto& index1 = value1.ShapeIndex();
       auto region1 = value1.Region();
       if (!region1->MayIntersect(S2Cell(*maybe_point0))) {
         return false;
       }
       return region1->Contains(*maybe_point0) ||
-             s2_intersects(value0.ShapeIndex(), index1, options_);
+             s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
     } else if (maybe_point1) {
-      const auto& index0 = value0.ShapeIndex();
       auto region0 = value0.Region();
       if (!region0->MayIntersect(S2Cell(*maybe_point1))) {
         return false;
       }
       return region0->Contains(*maybe_point1) ||
-             s2_intersects(index0, value1.ShapeIndex(), options_);
+             s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
     }
 
     S2CellUnion::GetIntersection(value0.StashedCovering(),

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -107,27 +107,6 @@ bool s2_intersects_box(const S2ShapeIndex& geog1, const S2LatLngRect& rect,
 
 namespace sedona_udf {
 
-namespace {
-bool ContainsPoint(GeoArrowGeography& lhs, GeoArrowGeography& rhs) {
-  if (rhs.num_shapes() != 1) {
-    return false;
-  }
-
-  auto rhs_shape = rhs.Shape(0);
-  if (rhs_shape->num_edges() != 1) {
-    return false;
-  }
-
-  auto rhs_edge = rhs_shape->edge(0);
-  if (!rhs_edge.IsDegenerate()) {
-    return false;
-  }
-
-  auto lhs_region = lhs.Region();
-  return lhs_region->Contains(rhs_edge.v0);
-}
-}  // namespace
-
 struct S2Intersects {
   using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = GeoArrowGeographyInputView;
@@ -136,10 +115,14 @@ struct S2Intersects {
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
+    // If either argument is EMPTY, the result is FALSE
     if (value0.is_empty() || value1.is_empty()) {
       return false;
     }
 
+    // The containment test for a S2Point is ~20x faster than building an index
+    // containing exactly one point for every element so we try very hard to
+    // avoid it.
     auto maybe_point0 = value0.Point();
     auto maybe_point1 = value1.Point();
     if (maybe_point0 && maybe_point1) {
@@ -160,6 +143,15 @@ struct S2Intersects {
              s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
     }
 
+    // We could consider special casing more things here. S2Geometry special cases
+    // loops with less than 32 vertices to avoid building an index which is likely
+    // worth doing here based on some heuristics for other geometry types too.
+
+    // Next we try a covering intersection check. This is very cheap if an index
+    // has already been built. In the event that an index does have to be built
+    // to build the covering, it is effectively reused in the actual s2_intersection()
+    // check. This is 2x faster than an intersection check for selective
+    // point-in-polygon queries but may need to be reevaluted.
     S2CellUnion::GetIntersection(value0.Covering(), value1.Covering(),
                                  &intersection_);
     if (intersection_.empty()) {

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -115,10 +115,17 @@ struct S2Intersects {
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
+    S2CellUnion::GetIntersection(value0.GetStashedCovering(),
+                                 value1.GetStashedCovering(), &intersection_);
+    if (intersection_.empty()) {
+      return false;
+    }
+
     return s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
   }
 
   S2BooleanOperation::Options options_;
+  std::vector<S2CellId> intersection_;
 };
 
 struct S2Contains {

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -107,6 +107,27 @@ bool s2_intersects_box(const S2ShapeIndex& geog1, const S2LatLngRect& rect,
 
 namespace sedona_udf {
 
+namespace {
+bool ContainsPoint(GeoArrowGeography& lhs, GeoArrowGeography& rhs) {
+  if (rhs.num_shapes() != 1) {
+    return false;
+  }
+
+  auto rhs_shape = rhs.Shape(0);
+  if (rhs_shape->num_edges() != 1) {
+    return false;
+  }
+
+  auto rhs_edge = rhs_shape->edge(0);
+  if (!rhs_edge.IsDegenerate()) {
+    return false;
+  }
+
+  auto lhs_region = lhs.Region();
+  return lhs_region->Contains(rhs_edge.v0);
+}
+}  // namespace
+
 struct S2Intersects {
   using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = GeoArrowGeographyInputView;
@@ -115,10 +136,20 @@ struct S2Intersects {
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    S2CellUnion::GetIntersection(value0.GetStashedCovering(),
-                                 value1.GetStashedCovering(), &intersection_);
-    if (intersection_.empty()) {
+    if (value0.is_empty() || value1.is_empty()) {
       return false;
+    }
+
+    auto maybe_point0 = value0.Point();
+    if (maybe_point0) {
+      return value1.Region()->Contains(*maybe_point0) ||
+             s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
+    }
+
+    auto maybe_point1 = value1.Point();
+    if (maybe_point1) {
+      return value1.Region()->Contains(*maybe_point0) ||
+             s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
     }
 
     return s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -160,8 +160,8 @@ struct S2Intersects {
              s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
     }
 
-    S2CellUnion::GetIntersection(value0.Covering(),
-                                 value1.Covering(), &intersection_);
+    S2CellUnion::GetIntersection(value0.Covering(), value1.Covering(),
+                                 &intersection_);
     if (intersection_.empty()) {
       return false;
     }

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -160,8 +160,8 @@ struct S2Intersects {
              s2_intersects(value0.ShapeIndex(), value1.ShapeIndex(), options_);
     }
 
-    S2CellUnion::GetIntersection(value0.StashedCovering(),
-                                 value1.StashedCovering(), &intersection_);
+    S2CellUnion::GetIntersection(value0.Covering(),
+                                 value1.Covering(), &intersection_);
     if (intersection_.empty()) {
       return false;
     }

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -86,19 +86,42 @@ TEST(Predicates, SedonaUdfContainsScalarArray) {
                                           {true, false, std::nullopt}));
 }
 
-TEST(Predicates, SedonaUdfScalarScalar) {
-  std::optional<std::string> lhs = "POLYGON ((0 0, 2 0, 0 2, 0 0))";
-  std::string op = "intersects";
-  std::optional<std::string> rhs = "POINT (0.25 0.25)";
-  std::optional<bool> result = true;
+struct ScalarScalarParam {
+  std::string name;
+  std::optional<std::string> lhs;
+  std::string op;
+  std::optional<std::string> rhs;
+  std::optional<bool> expected;
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const ScalarScalarParam& p) {
+    os << (p.lhs ? *p.lhs : "null") << " " << p.op << " "
+       << (p.rhs ? *p.rhs : "null") << " -> ";
+    if (p.expected) {
+      os << (*p.expected ? "true" : "false");
+    } else {
+      os << "null";
+    }
+    return os;
+  }
+};
+
+class PredicatesScalarScalarTest
+    : public ::testing::TestWithParam<ScalarScalarParam> {};
+
+TEST_P(PredicatesScalarScalarTest, SedonaUdf) {
+  const auto& p = GetParam();
 
   struct SedonaCScalarKernel kernel;
   struct SedonaCScalarKernelImpl impl;
-  if (op == "intersects") {
+  if (p.op == "intersects") {
     s2geography::sedona_udf::IntersectsKernel(&kernel);
-
+  } else if (p.op == "contains") {
+    s2geography::sedona_udf::ContainsKernel(&kernel);
+  } else if (p.op == "equals") {
+    s2geography::sedona_udf::EqualsKernel(&kernel);
   } else {
-    ASSERT_TRUE(false) << "Unknown predicate";
+    FAIL() << "Unknown predicate: " << p.op;
   }
 
   ASSERT_NO_FATAL_FAILURE(TestInitKernel(
@@ -106,11 +129,71 @@ TEST(Predicates, SedonaUdfScalarScalar) {
 
   nanoarrow::UniqueArray out_array;
   ASSERT_NO_FATAL_FAILURE(
-      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, {{lhs}, {rhs}},
-                        {}, out_array.get()));
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                        {{p.lhs}, {p.rhs}}, {}, out_array.get()));
   impl.release(&impl);
   kernel.release(&kernel);
 
   ASSERT_NO_FATAL_FAILURE(
-      TestResultArrow(out_array.get(), NANOARROW_TYPE_BOOL, {result}));
+      TestResultArrow(out_array.get(), NANOARROW_TYPE_BOOL, {p.expected}));
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    Predicates, PredicatesScalarScalarTest,
+    ::testing::Values(
+        // Intersects
+        // Nulls
+        ScalarScalarParam{"null_intersects", std::nullopt, "intersects",
+                          "POINT EMPTY", std::nullopt},
+        ScalarScalarParam{"intersects_null", "POINT EMPTY", "intersects",
+                          std::nullopt, std::nullopt},
+        ScalarScalarParam{"null_intersects_null", std::nullopt, "intersects",
+                          std::nullopt, std::nullopt},
+
+        // Intersects cases that take one of the faster paths
+        // Point x polygon
+        ScalarScalarParam{"polygon_intersects_point",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", "intersects",
+                          "POINT (0.25 0.25)", true},
+        // Polygon x point
+        ScalarScalarParam{"point_intersects_polygon", "POINT (0.25 0.25)",
+                          "intersects", "POLYGON ((0 0, 2 0, 0 2, 0 0))", true},
+        // Point definitely not in polygon (outside the covering)
+        ScalarScalarParam{"polygon_not_intersects_distant_point",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", "intersects",
+                          "POINT (-30 -30)", false},
+        // Point definitely not in polygon (probably inside the covering)
+        ScalarScalarParam{"polygon_not_intersects_close_point",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", "intersects",
+                          "POINT (1.01 1.01)", false},
+
+        // Polygon x boundary point
+        ScalarScalarParam{"boundary_point_intersects_polygon", "POINT (0 0)",
+                          "intersects", "POLYGON ((0 0, 2 0, 0 2, 0 0))", true},
+        // Boundary point x polygon
+        ScalarScalarParam{"polygon_intersects_boundary_point", "POINT (0 0)",
+                          "intersects", "POLYGON ((0 0, 2 0, 0 2, 0 0))", true},
+
+        // Polygon in polygon
+        ScalarScalarParam{"polygon_intersects_polygon",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", "intersects",
+                          "POLYGON ((0 0, 1 0, 0 1, 0 0))", true},
+
+        // Other predicates (currently there are no special cases here)
+        ScalarScalarParam{"polygon_contains_point",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", "contains",
+                          "POINT (0.25 0.25)", true},
+        ScalarScalarParam{"polygon_not_contains_point",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", "contains",
+                          "POINT (-1 -1)", false},
+        ScalarScalarParam{"polygon_equals_polygon",
+                          "POLYGON ((0 0, 1 0, 0 1, 0 0))", "equals",
+                          "POLYGON ((1 0, 0 1, 0 0, 1 0))", true},
+        ScalarScalarParam{"polygon_not_equals_polygon",
+                          "POLYGON ((0 0, 1 0, 0 1, 0 0))", "equals",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", false}
+
+        ),
+    [](const ::testing::TestParamInfo<ScalarScalarParam>& info) {
+      return info.param.name;
+    });

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -5,7 +5,7 @@
 #include "nanoarrow/nanoarrow.hpp"
 #include "s2geography/sedona_udf/sedona_udf_test_internal.h"
 
-TEST(Predicates, SedonaUdfIntersects) {
+TEST(Predicates, SedonaUdfIntersectsScalarArray) {
   struct SedonaCScalarKernel kernel;
   s2geography::sedona_udf::IntersectsKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
@@ -25,7 +25,27 @@ TEST(Predicates, SedonaUdfIntersects) {
                                           {true, false, std::nullopt}));
 }
 
-TEST(Predicates, SedonaUdfEquals) {
+TEST(Predicates, SedonaUdfIntersectsArrayScalar) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::IntersectsKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, NANOARROW_TYPE_BOOL));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                        {{"POINT (0.25 0.25)", "POINT (-1 -1)", std::nullopt},
+                         {"POLYGON ((0 0, 1 0, 0 1, 0 0))"}},
+                        {}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(TestResultArrow(out_array.get(), NANOARROW_TYPE_BOOL,
+                                          {true, false, std::nullopt}));
+}
+
+TEST(Predicates, SedonaUdfEqualsScalarArray) {
   struct SedonaCScalarKernel kernel;
   s2geography::sedona_udf::EqualsKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
@@ -46,7 +66,7 @@ TEST(Predicates, SedonaUdfEquals) {
                                           {true, false, std::nullopt}));
 }
 
-TEST(Predicates, SedonaUdfContains) {
+TEST(Predicates, SedonaUdfContainsScalarArray) {
   struct SedonaCScalarKernel kernel;
   s2geography::sedona_udf::ContainsKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
@@ -64,4 +84,33 @@ TEST(Predicates, SedonaUdfContains) {
 
   ASSERT_NO_FATAL_FAILURE(TestResultArrow(out_array.get(), NANOARROW_TYPE_BOOL,
                                           {true, false, std::nullopt}));
+}
+
+TEST(Predicates, SedonaUdfScalarScalar) {
+  std::optional<std::string> lhs = "POLYGON ((0 0, 2 0, 0 2, 0 0))";
+  std::string op = "intersects";
+  std::optional<std::string> rhs = "POINT (0.25 0.25)";
+  std::optional<bool> result = true;
+
+  struct SedonaCScalarKernel kernel;
+  struct SedonaCScalarKernelImpl impl;
+  if (op == "intersects") {
+    s2geography::sedona_udf::IntersectsKernel(&kernel);
+
+  } else {
+    ASSERT_TRUE(false) << "Unknown predicate";
+  }
+
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, NANOARROW_TYPE_BOOL));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, {{lhs}, {rhs}},
+                        {}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(
+      TestResultArrow(out_array.get(), NANOARROW_TYPE_BOOL, {result}));
 }

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -171,8 +171,9 @@ INSTANTIATE_TEST_SUITE_P(
         ScalarScalarParam{"boundary_point_intersects_polygon", "POINT (0 0)",
                           "intersects", "POLYGON ((0 0, 2 0, 0 2, 0 0))", true},
         // Boundary point x polygon
-        ScalarScalarParam{"polygon_intersects_boundary_point", "POINT (0 0)",
-                          "intersects", "POLYGON ((0 0, 2 0, 0 2, 0 0))", true},
+        ScalarScalarParam{"polygon_intersects_boundary_point",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", "intersects",
+                          "POINT (0 0)", true},
 
         // Polygon in polygon
         ScalarScalarParam{"polygon_intersects_polygon",

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -369,7 +369,7 @@ class GeographyInputView {
 /// represent any GeoArrow type when supported by geoarrow-c.
 class GeoArrowGeographyInputView {
  public:
-  using c_type = const GeoArrowGeography&;
+  using c_type = GeoArrowGeography&;
 
   static bool Matches(const struct ArrowSchema* type) {
     struct GeoArrowSchemaView schema_view;
@@ -416,7 +416,7 @@ class GeoArrowGeographyInputView {
 
   bool IsNull(int64_t i) { return inner_.IsNull(i); }
 
-  const GeoArrowGeography& Get(int64_t i) {
+  GeoArrowGeography& Get(int64_t i) {
     StashIfNeeded(i % current_array_length_);
     return stashed_;
   }


### PR DESCRIPTION
This PR implements a series of potential intersection checks to avoid initializing an index on each element of the input (the root cause for the performance issue described in #84). The pre-checks are:

- If one of the inputs is a point, extract it and try `other.Region()->MayIntersect(S2Cell(point))` to filter out matches
- Try `other->Region()->Contains(point)` (faster than a straight intersection)
- Create a covering of both sides and check for potential intersection
- Fall back to S2BooleanOperation.

This brings the st_intersects(point_column, polygon_scalar) benchmark from 200ms to 13ms! (e.g., a polygon filter on point input). This even works for big polygons as long as the big polygon is a Scalar (i.e., the caching of the covering and the index can be effectively leveraged).

For non-point inputs, we still have a performance issue because we need to build an index on both inputs no matter what (even to discard a false positive with a covering because we need the index to build the covering). I left a TODO in the implementation for this (there is code in S2 to brute force the calculation using lower level primitives).