### PR TITLE
feat: Improve performance and test coverage of non-intersects predicates

### DIFF
--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -78,6 +78,16 @@ void VisitLngLat(const struct GeoArrowGeometryNode* node, int64_t offset,
   }
 }
 
+bool AllLngLatNaN(struct GeoArrowGeometryView geom) {
+  bool out = true;
+  VisitNodes(geom, [&](const struct GeoArrowGeometryNode* node) {
+    VisitLngLat(node, 0, node->size, [&](double lng, double lat) {
+      out = out && std::isnan(lng) && std::isnan(lat);
+    });
+  });
+  return out;
+}
+
 const char* GeometryTypeString(uint8_t geometry_type) {
   switch (geometry_type) {
     case GEOARROW_GEOMETRY_TYPE_POINT:
@@ -106,7 +116,9 @@ void GeoArrowPointShape::Init(struct GeoArrowGeometryView geom) {
   switch (geom.root->geometry_type) {
     case GEOARROW_GEOMETRY_TYPE_POINT:
       // Treat an empty point as MULTIPOINT EMPTY
-      if (geom.root->size == 0) {
+      // geoarrow-c currently reads POINT EMPTY as nan nan instead of a
+      // proper EMPTY
+      if (geom.root->size == 0 || AllLngLatNaN(geom)) {
         geom_ = {nullptr, 0};
       } else {
         geom_ = geom;

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -178,13 +178,43 @@ struct S2Contains {
   using arg1_t = GeoArrowGeographyInputView;
   using out_t = BoolOutputBuilder;
 
-  void Init(const std::unordered_map<std::string, std::string>& options) {}
+  void Init(const std::unordered_map<std::string, std::string>& options) {
+    // Use Simple Features compatibility options
+    options_.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
+  }
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
+    // If either argument is EMPTY, the result is FALSE
+    if (value0.is_empty() || value1.is_empty()) {
+      return false;
+    }
+
+    auto maybe_point0 = value0.Point();
+    auto maybe_point1 = value1.Point();
+    if (maybe_point0) {
+      // A point cannot contain anything
+      return false;
+    } else if (maybe_point1) {
+      auto region0 = value0.Region();
+      return region0->MayIntersect(S2Cell(*maybe_point1)) &&
+             region0->Contains(*maybe_point1);
+    }
+
+    S2CellUnion::GetIntersection(value0.Covering(), value1.Covering(),
+                                 &intersection_);
+    if (intersection_.empty()) {
+      return false;
+    }
+
+    return ExecUsingShapeIndex(value0, value1);
+  }
+
+  bool ExecUsingShapeIndex(arg0_t::c_type value0, arg1_t::c_type value1) {
     return s2_contains(value0.ShapeIndex(), value1.ShapeIndex(), options_);
   }
 
   S2BooleanOperation::Options options_;
+  std::vector<S2CellId> intersection_;
 };
 
 struct S2Equals {
@@ -192,13 +222,84 @@ struct S2Equals {
   using arg1_t = GeoArrowGeographyInputView;
   using out_t = BoolOutputBuilder;
 
-  void Init(const std::unordered_map<std::string, std::string>& options) {}
+  void Init(const std::unordered_map<std::string, std::string>& options) {
+    options_.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
+  }
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
+    if (GeographyIdentical(value0, value1)) {
+      return true;
+    }
+
+    S2CellUnion::GetIntersection(value0.Covering(), value1.Covering(),
+                                 &intersection_);
+    if (intersection_.empty()) {
+      return false;
+    }
+
     return s2_equals(value0.ShapeIndex(), value1.ShapeIndex(), options_);
   }
 
+  bool GeographyIdentical(GeoArrowGeography& value0,
+                          GeoArrowGeography& value1) {
+    if (value0.num_shapes() != value1.num_shapes() == 1) {
+      return false;
+    }
+
+    for (int i = 0; i < value0.num_shapes(); ++i) {
+      if (!ShapeIdentical(value0.Shape(i), value1.Shape(i))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  bool ShapeIdentical(const S2Shape* lhs, const S2Shape* rhs) {
+    if (lhs->dimension() != rhs->dimension()) {
+      return false;
+    }
+
+    if (lhs->num_chains() != rhs->num_chains()) {
+      return false;
+    }
+
+    for (int i = 0; i < lhs->num_chains(); i++) {
+      S2Shape::Chain chain_lhs = lhs->chain(i);
+      S2Shape::Chain chain_rhs = rhs->chain(i);
+
+      if (chain_lhs.length != chain_rhs.length) {
+        return false;
+      }
+
+      if (chain_lhs.length == 0) {
+        continue;
+      }
+
+      S2Shape::Edge lhs_e = lhs->chain_edge(i, 0);
+      S2Shape::Edge rhs_e = rhs->chain_edge(i, 0);
+      S2Point lhs_v0 = lhs_e.v0;
+      S2Point rhs_v0 = rhs_e.v0;
+      if (lhs_v0 != rhs_v0) {
+        return false;
+      }
+
+      for (int j = 1; j < chain_lhs.length; j++) {
+        lhs_e = lhs->chain_edge(i, j);
+        rhs_e = rhs->chain_edge(i, j);
+        S2Point lhs_v1 = lhs_e.v1;
+        S2Point rhs_v1 = rhs_e.v1;
+        if (lhs_v1 != rhs_v1) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
   S2BooleanOperation::Options options_;
+  std::vector<S2CellId> intersection_;
 };
 
 void IntersectsKernel(struct SedonaCScalarKernel* out) {

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -224,6 +224,11 @@ struct S2Equals {
   }
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
+    // Empties equal each other regardless of exactly how they are empty
+    if (value0.is_empty() && value1.is_empty()) {
+      return true;
+    }
+
     if (GeographyIdentical(value0, value1)) {
       return true;
     }

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -178,10 +178,7 @@ struct S2Contains {
   using arg1_t = GeoArrowGeographyInputView;
   using out_t = BoolOutputBuilder;
 
-  void Init(const std::unordered_map<std::string, std::string>& options) {
-    // Use Simple Features compatibility options
-    options_.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
-  }
+  void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
     // If either argument is EMPTY, the result is FALSE

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -244,7 +244,7 @@ struct S2Equals {
 
   bool GeographyIdentical(GeoArrowGeography& value0,
                           GeoArrowGeography& value1) {
-    if (value0.num_shapes() != value1.num_shapes() == 1) {
+    if (value0.num_shapes() != value1.num_shapes()) {
       return false;
     }
 
@@ -278,20 +278,24 @@ struct S2Equals {
         continue;
       }
 
-      S2Shape::Edge lhs_e = lhs->chain_edge(i, 0);
-      S2Shape::Edge rhs_e = rhs->chain_edge(i, 0);
-      S2Point lhs_v0 = lhs_e.v0;
-      S2Point rhs_v0 = rhs_e.v0;
-      if (lhs_v0 != rhs_v0) {
-        return false;
-      }
-
-      for (int j = 1; j < chain_lhs.length; j++) {
+      S2Shape::Edge lhs_e, rhs_e;
+      S2Point lhs_v, rhs_v;
+      for (int j = 0; j < chain_lhs.length; j++) {
         lhs_e = lhs->chain_edge(i, j);
         rhs_e = rhs->chain_edge(i, j);
-        S2Point lhs_v1 = lhs_e.v1;
-        S2Point rhs_v1 = rhs_e.v1;
-        if (lhs_v1 != rhs_v1) {
+
+        // Only for the first edge: check the start point
+        if (j == 0) {
+          lhs_v = lhs_e.v0;
+          rhs_v = rhs_e.v0;
+          if (lhs_v != rhs_v) {
+            return false;
+          }
+        }
+
+        lhs_v = lhs_e.v1;
+        rhs_v = rhs_e.v1;
+        if (lhs_v != rhs_v) {
           return false;
         }
       }

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -266,6 +266,10 @@ struct S2Equals {
       return false;
     }
 
+    if (lhs->num_edges() != rhs->num_edges()) {
+      return false;
+    }
+
     for (int i = 0; i < lhs->num_chains(); i++) {
       S2Shape::Chain chain_lhs = lhs->chain(i);
       S2Shape::Chain chain_rhs = rhs->chain(i);

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -86,6 +86,25 @@ TEST(Predicates, SedonaUdfContainsScalarArray) {
                                           {true, false, std::nullopt}));
 }
 
+TEST(Predicates, EmptyDebug) {
+  struct SedonaCScalarKernel kernel;
+  struct SedonaCScalarKernelImpl impl;
+  s2geography::sedona_udf::EqualsKernel(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, NANOARROW_TYPE_BOOL));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
+      &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+      {{"POINT EMPTY"}, {"POINT EMPTY"}}, {}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(
+      TestResultArrow(out_array.get(), NANOARROW_TYPE_BOOL, {true}));
+}
+
 struct ScalarScalarParam {
   std::string name;
   std::optional<std::string> lhs;
@@ -251,10 +270,10 @@ INSTANTIATE_TEST_SUITE_P(
                           "POINT EMPTY", false},
         ScalarScalarParam{"empty_equals", "POINT EMPTY", "equals",
                           "POINT (0 0)", false},
-        ScalarScalarParam{"empty_point_equals_empty_point", "POINT EMPTY", "equals",
-                          "POINT EMPTY", true},
-        ScalarScalarParam{"empty_point_equals_empty_linestring", "POINT EMPTY", "equals",
-                          "LINESTRING EMPTY", true},
+        ScalarScalarParam{"empty_point_equals_empty_point", "POINT EMPTY",
+                          "equals", "POINT EMPTY", true},
+        ScalarScalarParam{"empty_point_equals_empty_linestring", "POINT EMPTY",
+                          "equals", "LINESTRING EMPTY", true},
 
         // Fast path for identical values
         ScalarScalarParam{"polygon_equals_identical_polygon",

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -86,25 +86,6 @@ TEST(Predicates, SedonaUdfContainsScalarArray) {
                                           {true, false, std::nullopt}));
 }
 
-TEST(Predicates, EmptyDebug) {
-  struct SedonaCScalarKernel kernel;
-  struct SedonaCScalarKernelImpl impl;
-  s2geography::sedona_udf::EqualsKernel(&kernel);
-
-  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
-      &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, NANOARROW_TYPE_BOOL));
-
-  nanoarrow::UniqueArray out_array;
-  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
-      &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
-      {{"POINT EMPTY"}, {"POINT EMPTY"}}, {}, out_array.get()));
-  impl.release(&impl);
-  kernel.release(&kernel);
-
-  ASSERT_NO_FATAL_FAILURE(
-      TestResultArrow(out_array.get(), NANOARROW_TYPE_BOOL, {true}));
-}
-
 struct ScalarScalarParam {
   std::string name;
   std::optional<std::string> lhs;
@@ -226,7 +207,7 @@ INSTANTIATE_TEST_SUITE_P(
                           "POLYGON ((0 0, 2 0, 0 2, 0 0))", "contains",
                           "POINT (0.25 0.25)", true},
         // Point does not contain anything
-        ScalarScalarParam{"point_contains_polygon", "POINT (0.25 0.25)",
+        ScalarScalarParam{"point_not_contains_polygon", "POINT (0.25 0.25)",
                           "contains", "POLYGON ((0 0, 2 0, 0 2, 0 0))", false},
         // Point definitely not in polygon (outside the covering)
         ScalarScalarParam{"polygon_not_contains_distant_point",

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -246,6 +246,16 @@ INSTANTIATE_TEST_SUITE_P(
         ScalarScalarParam{"null_equals_null", std::nullopt, "equals",
                           std::nullopt, std::nullopt},
 
+        // Empties
+        ScalarScalarParam{"equals_empty", "POINT (0 0)", "equals",
+                          "POINT EMPTY", false},
+        ScalarScalarParam{"empty_equals", "POINT EMPTY", "equals",
+                          "POINT (0 0)", false},
+        ScalarScalarParam{"empty_point_equals_empty_point", "POINT EMPTY", "equals",
+                          "POINT EMPTY", true},
+        ScalarScalarParam{"empty_point_equals_empty_linestring", "POINT EMPTY", "equals",
+                          "LINESTRING EMPTY", true},
+
         // Fast path for identical values
         ScalarScalarParam{"polygon_equals_identical_polygon",
                           "POLYGON ((0 0, 1 0, 0 1, 0 0))", "equals",

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -237,13 +237,43 @@ INSTANTIATE_TEST_SUITE_P(
                           "POLYGON ((0.1 0.1, 0.5 0.1, 0.1 0.5, 0.1 0.1))",
                           "contains", "POLYGON ((0 0, 2 0, 0 2, 0 0))", false},
 
-        // Others we haven't implemented yet
+        // Equals
+        // Nulls
+        ScalarScalarParam{"null_equals", std::nullopt, "equals", "POINT EMPTY",
+                          std::nullopt},
+        ScalarScalarParam{"equals_null", "POINT EMPTY", "equals", std::nullopt,
+                          std::nullopt},
+        ScalarScalarParam{"null_equals_null", std::nullopt, "equals",
+                          std::nullopt, std::nullopt},
+
+        // Fast path for identical values
+        ScalarScalarParam{"polygon_equals_identical_polygon",
+                          "POLYGON ((0 0, 1 0, 0 1, 0 0))", "equals",
+                          "POLYGON ((0 0, 1 0, 0 1, 0 0))", true},
+
+        // Rotated vertices
         ScalarScalarParam{"polygon_equals_polygon",
                           "POLYGON ((0 0, 1 0, 0 1, 0 0))", "equals",
                           "POLYGON ((1 0, 0 1, 0 0, 1 0))", true},
-        ScalarScalarParam{"polygon_not_equals_polygon",
+
+        // Potentially intersecting but not equal
+        ScalarScalarParam{"polygon_not_equals_close_polygon",
                           "POLYGON ((0 0, 1 0, 0 1, 0 0))", "equals",
-                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", false}
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", false},
+        // Not at all intersecting and not equal
+        ScalarScalarParam{"polygon_not_equals_distant_polygon",
+                          "POLYGON ((0 0, 1 0, 0 1, 0 0))", "equals",
+                          "POLYGON ((30 30, 32 30, 30 32, 30 30))", false},
+
+        // Different number of chains
+        ScalarScalarParam{"polygon_not_equals_chains_ne",
+                          "MULTIPOLYGON (((0 0, 1 0, 0 1, 0 0)), ((10 10, 11 "
+                          "10, 10 11, 10 10)))",
+                          "equals", "POLYGON ((0 0, 2 0, 0 2, 0 0))", false},
+        // Different number of edges
+        ScalarScalarParam{"polygon_not_equals_edges_ne",
+                          "POLYGON ((0 0, 1 0, 0 1, 0 0))", "equals",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 1, 0 0))", false}
 
         ),
     [](const ::testing::TestParamInfo<ScalarScalarParam>& info) {

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -151,6 +151,12 @@ INSTANTIATE_TEST_SUITE_P(
                           std::nullopt, std::nullopt},
 
         // Intersects cases that take one of the faster paths
+        // Empties
+        ScalarScalarParam{"intersects_empty", "POINT (0 0)", "intersects",
+                          "POINT EMPTY", false},
+        ScalarScalarParam{"empty_intersects", "POINT EMPTY", "intersects",
+                          "POINT (0 0)", false},
+
         // Point x polygon
         ScalarScalarParam{"polygon_intersects_point",
                           "POLYGON ((0 0, 2 0, 0 2, 0 0))", "intersects",
@@ -180,13 +186,58 @@ INSTANTIATE_TEST_SUITE_P(
                           "POLYGON ((0 0, 2 0, 0 2, 0 0))", "intersects",
                           "POLYGON ((0 0, 1 0, 0 1, 0 0))", true},
 
-        // Other predicates (currently there are no special cases here)
+        // Contains
+        // Nulls
+        ScalarScalarParam{"null_contains", std::nullopt, "contains",
+                          "POINT EMPTY", std::nullopt},
+        ScalarScalarParam{"contains_null", "POINT EMPTY", "contains",
+                          std::nullopt, std::nullopt},
+        ScalarScalarParam{"null_contains_null", std::nullopt, "contains",
+                          std::nullopt, std::nullopt},
+
+        // Contains cases that take one of the faster paths
+        // Empties
+        ScalarScalarParam{"contains_empty", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+                          "contains", "POINT EMPTY", false},
+        ScalarScalarParam{"empty_contains", "POINT EMPTY", "contains",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", false},
+
+        // Polygon contains interior point
         ScalarScalarParam{"polygon_contains_point",
                           "POLYGON ((0 0, 2 0, 0 2, 0 0))", "contains",
                           "POINT (0.25 0.25)", true},
-        ScalarScalarParam{"polygon_not_contains_point",
+        // Point does not contain anything
+        ScalarScalarParam{"point_contains_polygon", "POINT (0.25 0.25)",
+                          "contains", "POLYGON ((0 0, 2 0, 0 2, 0 0))", false},
+        // Point definitely not in polygon (outside the covering)
+        ScalarScalarParam{"polygon_not_contains_distant_point",
                           "POLYGON ((0 0, 2 0, 0 2, 0 0))", "contains",
-                          "POINT (-1 -1)", false},
+                          "POINT (-30 -30)", false},
+        // Point definitely not in polygon (probably inside the covering)
+        ScalarScalarParam{"polygon_not_contains_close_point",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", "contains",
+                          "POINT (1.01 1.01)", false},
+        // Polygon does not contain boundary point
+        ScalarScalarParam{"polygon_not_contains_boundary_point",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", "contains",
+                          "POINT (0 0)", false},
+
+        // Polygon contains interior sub-polygon
+        ScalarScalarParam{
+            "polygon_contains_polygon", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+            "contains", "POLYGON ((0.1 0.1, 0.5 0.1, 0.1 0.5, 0.1 0.1))", true},
+
+        // Polygon does not contain interior sub-polygon with shared boundary
+        ScalarScalarParam{"polygon_does_not_contain_polygon_boundary",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", "contains",
+                          "POLYGON ((0 0, 0.5 0, 0 0.5, 0 0))", false},
+
+        // Interior polygon does not contain Polygon
+        ScalarScalarParam{"polygon_does_not_contain_polygon",
+                          "POLYGON ((0.1 0.1, 0.5 0.1, 0.1 0.5, 0.1 0.1))",
+                          "contains", "POLYGON ((0 0, 2 0, 0 2, 0 0))", false},
+
+        // Others we haven't implemented yet
         ScalarScalarParam{"polygon_equals_polygon",
                           "POLYGON ((0 0, 1 0, 0 1, 0 0))", "equals",
                           "POLYGON ((1 0, 0 1, 0 0, 1 0))", true},


### PR DESCRIPTION
This PR updates the ST_Contains and ST_Equals to use a few easy-to-optimize cases like ST_Intersects in #86. It also adds corresponding test cases in the parameterized test case list. Essentially, it uses the S2Region containment check for point-in-polygon and a cell union bound check for potential intersection to reduce the number of index constructions or index checks we need to do.

I'll follow up with implementations for some other predicates that are easy to compose based on what we already have.