### PR TITLE
perf: Improve performance of unary functions

### DIFF
--- a/src/s2geography/accessors-geog.cc
+++ b/src/s2geography/accessors-geog.cc
@@ -245,12 +245,11 @@ struct S2CentroidExec {
       return stashed_;
     }
 
-    // TODO: this needs to be a geometrycollection empty
-    stashed_ = PointGeography();
-    return stashed_;
+    return empty_;
   }
 
   PointGeography stashed_;
+  GeographyCollection empty_;
   std::vector<S2Point> scratch_;
 };
 

--- a/src/s2geography/accessors-geog.cc
+++ b/src/s2geography/accessors-geog.cc
@@ -203,32 +203,116 @@ std::unique_ptr<PolygonGeography> S2ConvexHullAggregator::Finalize() {
 namespace sedona_udf {
 
 struct S2CentroidExec {
-  using arg0_t = GeographyInputView;
+  using arg0_t = GeoArrowGeographyInputView;
   using out_t = WkbGeographyOutputBuilder;
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value) {
-    S2Point out = s2_centroid(value);
-    stashed_ = PointGeography(out);
+    S2Point pt;
+
+    // Compute in decreasing dimensionality and return early, because
+    // centroids of lower dimension do not count towards the final value
+    // if the geography has mixed dimension.
+    if (!value.polygons()->is_empty()) {
+      value.polygons()->geom().VisitLoops(&scratch_, [&](GeoArrowLoop loop) {
+        pt += loop.GetCentroid();
+        return true;
+      });
+
+      stashed_ = PointGeography(pt.Normalize());
+      return stashed_;
+    }
+
+    if (!value.lines()->is_empty()) {
+      value.lines()->geom().VisitEdges([&](const S2Shape::Edge& e) {
+        pt += S2::TrueCentroid(e.v0, e.v1);
+        return true;
+      });
+
+      stashed_ = PointGeography(pt.Normalize());
+      return stashed_;
+    }
+
+    if (!value.points()->is_empty()) {
+      value.points()->geom().VisitVertices([&](const S2Point& v) {
+        pt += v;
+        return true;
+      });
+
+      stashed_ = PointGeography(pt.Normalize());
+      return stashed_;
+    }
+
+    // TODO: this needs to be a geometrycollection empty
+    stashed_ = PointGeography();
     return stashed_;
   }
 
   PointGeography stashed_;
+  std::vector<S2Point> scratch_;
 };
 
 struct S2ConvexHullExec {
-  using arg0_t = GeographyInputView;
+  using arg0_t = GeoArrowGeographyInputView;
   using out_t = WkbGeographyOutputBuilder;
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value) {
-    stashed_ = s2_convex_hull(value);
+    if (value.is_empty()) {
+      stashed_ = std::make_unique<GeographyCollection>();
+      return *stashed_;
+    }
+
+    auto maybe_point = value.Point();
+    if (maybe_point) {
+      stashed_ = std::make_unique<PointGeography>(*maybe_point);
+      return *stashed_;
+    }
+
+    // This query could be more efficient if we vendored the S2ConvexHullQuery
+    // because there are a lot of unnecessary copies involved here.
+    S2ConvexHullQuery query;
+
+    // Points and lines are added purely on the basis of their vertices
+    // (in the internals of the S2ConvexHullQuery as well).
+    value.points()->geom().VisitVertices([&](const S2Point& v) {
+      query.AddPoint(v);
+      return true;
+    });
+
+    value.lines()->geom().VisitVertices([&](const S2Point& v) {
+      query.AddPoint(v);
+      return true;
+    });
+
+    value.polygons()->geom().VisitLoops(&scratch_, [&](GeoArrowLoop loop) {
+      // Holes don't contribute to convex hulls
+      if (loop.is_hole()) {
+        return true;
+      }
+
+      loop.VisitVertices([&](const S2Point& v) {
+        query.AddPoint(v);
+        return true;
+      });
+
+      return true;
+    });
+
+    auto hull_loop = query.GetConvexHull();
+    // TODO: check if it is a very small loop with only 3 points, because
+    // if the input is colinear the output should be a line.
+
+    auto polygon = std::make_unique<S2Polygon>();
+    polygon->Init(std::move(hull_loop));
+    stashed_ = std::make_unique<PolygonGeography>(std::move(polygon));
     return *stashed_;
   }
 
   std::unique_ptr<Geography> stashed_;
+  std::vector<S2Point> scratch_;
 };
 
 struct S2PointOnSurfaceExec {

--- a/src/s2geography/accessors-geog.cc
+++ b/src/s2geography/accessors-geog.cc
@@ -2,6 +2,7 @@
 #include "s2geography/accessors-geog.h"
 
 #include <s2/s2centroids.h>
+#include <s2/s2edge_distances.h>
 
 #include "s2geography/accessors.h"
 #include "s2geography/build.h"
@@ -302,8 +303,51 @@ struct S2ConvexHullExec {
     });
 
     auto hull_loop = query.GetConvexHull();
-    // TODO: check if it is a very small loop with only 3 points, because
-    // if the input is colinear the output should be a line.
+
+    // If we have a very skinny loop this means the output should be a line.
+    // TODO: make less verbose.
+    if (hull_loop->num_vertices() == 3) {
+      S1ChordAngle perp_limit(S2::kProjectPerpendicularError);
+      const S2Point& v0 = hull_loop->vertex(0);
+      const S2Point& v1 = hull_loop->vertex(1);
+      const S2Point& v2 = hull_loop->vertex(2);
+
+      // Check each vertex against its opposite edge. If any vertex lies
+      // on the opposite edge, the three points are collinear and the
+      // convex hull is really a line segment (the longest edge).
+      S2Point edge_vertices[3][2] = {
+          {v1, v2},  // edge opposite v0
+          {v0, v2},  // edge opposite v1
+          {v0, v1},  // edge opposite v2
+      };
+
+      for (int i = 0; i < 3; i++) {
+        const S2Point& x = hull_loop->vertex(i);
+        const S2Point& a = edge_vertices[i][0];
+        const S2Point& b = edge_vertices[i][1];
+        if (S2::IsDistanceLess(x, a, b, perp_limit)) {
+          // Find the longest edge to use as the polyline
+          S1ChordAngle d01(v0, v1);
+          S1ChordAngle d02(v0, v2);
+          S1ChordAngle d12(v1, v2);
+          S2Point pa, pb;
+          if (d01 >= d02 && d01 >= d12) {
+            pa = v0;
+            pb = v1;
+          } else if (d02 >= d01 && d02 >= d12) {
+            pa = v0;
+            pb = v2;
+          } else {
+            pa = v1;
+            pb = v2;
+          }
+          auto polyline =
+              std::make_unique<S2Polyline>(std::vector<S2Point>{pa, pb});
+          stashed_ = std::make_unique<PolylineGeography>(std::move(polyline));
+          return *stashed_;
+        }
+      }
+    }
 
     auto polygon = std::make_unique<S2Polygon>();
     polygon->Init(std::move(hull_loop));

--- a/src/s2geography/accessors-geog_test.cc
+++ b/src/s2geography/accessors-geog_test.cc
@@ -90,13 +90,13 @@ TEST(AccessorsGeog, SedonaUdfConvexHull) {
                         "POLYGON ((0 0, 1 0, 0 1, 0 0))", std::nullopt}));
 }
 
-
-struct AreaScalarParam {
+struct UnaryDoubleScalarParam {
   std::string name;
   std::optional<std::string> input;
   std::optional<double> expected;
 
-  friend std::ostream& operator<<(std::ostream& os, const AreaScalarParam& p) {
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const UnaryDoubleScalarParam& p) {
     os << (p.input ? *p.input : "null") << " -> ";
     if (p.expected) {
       os << *p.expected;
@@ -107,13 +107,10 @@ struct AreaScalarParam {
   }
 };
 
-class AreaScalarTest : public ::testing::TestWithParam<AreaScalarParam> {};
-
-TEST_P(AreaScalarTest, SedonaUdf) {
-  const auto& p = GetParam();
-
+void TestUnaryScalarDouble(void (*init_kernel)(struct SedonaCScalarKernel*),
+                           const UnaryDoubleScalarParam& p) {
   struct SedonaCScalarKernel kernel;
-  s2geography::sedona_udf::AreaKernel(&kernel);
+  init_kernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
   ASSERT_NO_FATAL_FAILURE(
       TestInitKernel(&kernel, &impl, {ARROW_TYPE_WKB}, NANOARROW_TYPE_DOUBLE));
@@ -128,45 +125,149 @@ TEST_P(AreaScalarTest, SedonaUdf) {
       TestResultArrow(out_array.get(), NANOARROW_TYPE_DOUBLE, {p.expected}));
 }
 
+class AreaScalarTest : public ::testing::TestWithParam<UnaryDoubleScalarParam> {
+};
+
+TEST_P(AreaScalarTest, SedonaUdf) {
+  ASSERT_NO_FATAL_FAILURE(
+      TestUnaryScalarDouble(s2geography::sedona_udf::AreaKernel, GetParam()));
+}
+
 INSTANTIATE_TEST_SUITE_P(
     Accessors, AreaScalarTest,
     ::testing::Values(
         // Nulls
-        AreaScalarParam{"null_area", std::nullopt, std::nullopt},
+        UnaryDoubleScalarParam{"null_area", std::nullopt, std::nullopt},
 
         // Empties
-        AreaScalarParam{"point_empty", "POINT EMPTY", 0.0},
-        AreaScalarParam{"linestring_empty", "LINESTRING EMPTY", 0.0},
-        AreaScalarParam{"polygon_empty", "POLYGON EMPTY", 0.0},
+        UnaryDoubleScalarParam{"point_empty", "POINT EMPTY", 0.0},
+        UnaryDoubleScalarParam{"linestring_empty", "LINESTRING EMPTY", 0.0},
+        UnaryDoubleScalarParam{"polygon_empty", "POLYGON EMPTY", 0.0},
 
         // Points (zero area)
-        AreaScalarParam{"point", "POINT (0 0)", 0.0},
-        AreaScalarParam{"multipoint", "MULTIPOINT ((0 0), (1 1))", 0.0},
+        UnaryDoubleScalarParam{"point", "POINT (0 0)", 0.0},
+        UnaryDoubleScalarParam{"multipoint", "MULTIPOINT ((0 0), (1 1))", 0.0},
 
         // Linestrings (zero area)
-        AreaScalarParam{"linestring", "LINESTRING (0 0, 0 1)", 0.0},
-        AreaScalarParam{"multilinestring",
-                        "MULTILINESTRING ((0 0, 0 1), (1 0, 1 1))", 0.0},
+        UnaryDoubleScalarParam{"linestring", "LINESTRING (0 0, 0 1)", 0.0},
+        UnaryDoubleScalarParam{"multilinestring",
+                               "MULTILINESTRING ((0 0, 0 1), (1 0, 1 1))", 0.0},
 
         // Polygons
-        AreaScalarParam{"triangle", "POLYGON ((0 0, 0 1, 1 0, 0 0))",
-                        6182489130.9071951},
-        AreaScalarParam{"square", "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
-                        12364036567.076418},
+        UnaryDoubleScalarParam{"triangle", "POLYGON ((0 0, 0 1, 1 0, 0 0))",
+                               6182489130.9071951},
+        UnaryDoubleScalarParam{"square", "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+                               12364036567.076418},
 
         // Multipolygon
-        AreaScalarParam{
+        UnaryDoubleScalarParam{
             "multipolygon",
-            "MULTIPOLYGON (((0 0, 0 1, 1 0, 0 0)), ((10 10, 10 11, 11 10, 10 10)))",
+            "MULTIPOLYGON (((0 0, 0 1, 1 0, 0 0)), ((10 10, 10 11, "
+            "11 10, 10 10)))",
             12271037686.230379},
 
         // Polygon with hole
-        AreaScalarParam{
+        UnaryDoubleScalarParam{
             "polygon_with_hole",
-            "POLYGON ((0 0, 0 2, 2 0, 0 0), (0.1 0.1, 0.1 0.5, 0.5 0.1, 0.1 0.1))",
+            "POLYGON ((0 0, 0 2, 2 0, 0 0), (0.1 0.1, 0.1 0.5, 0.5 "
+            "0.1, 0.1 0.1))",
             23744568445.094166}
 
         ),
-    [](const ::testing::TestParamInfo<AreaScalarParam>& info) {
+    [](const ::testing::TestParamInfo<UnaryDoubleScalarParam>& info) {
+      return info.param.name;
+    });
+
+class LengthScalarTest
+    : public ::testing::TestWithParam<UnaryDoubleScalarParam> {};
+
+TEST_P(LengthScalarTest, SedonaUdf) {
+  ASSERT_NO_FATAL_FAILURE(
+      TestUnaryScalarDouble(s2geography::sedona_udf::LengthKernel, GetParam()));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Accessors, LengthScalarTest,
+    ::testing::Values(
+        // Nulls
+        UnaryDoubleScalarParam{"null_length", std::nullopt, std::nullopt},
+
+        // Empties
+        UnaryDoubleScalarParam{"point_empty", "POINT EMPTY", 0.0},
+        UnaryDoubleScalarParam{"linestring_empty", "LINESTRING EMPTY", 0.0},
+        UnaryDoubleScalarParam{"polygon_empty", "POLYGON EMPTY", 0.0},
+
+        // Points (zero length)
+        UnaryDoubleScalarParam{"point", "POINT (0 0)", 0.0},
+        UnaryDoubleScalarParam{"multipoint", "MULTIPOINT ((0 0), (1 1))", 0.0},
+
+        // Linestrings
+        UnaryDoubleScalarParam{"linestring_one_segment",
+                               "LINESTRING (0 0, 0 1)", 111195.10117748393},
+        UnaryDoubleScalarParam{"linestring_two_segments",
+                               "LINESTRING (0 0, 0 1, 1 1)",
+                               222373.26637265272},
+        UnaryDoubleScalarParam{"multilinestring",
+                               "MULTILINESTRING ((0 0, 0 1), (1 0, 1 1))",
+                               222390.20235496786},
+
+        // Polygons (zero length — perimeter is separate)
+        UnaryDoubleScalarParam{"triangle", "POLYGON ((0 0, 0 1, 1 0, 0 0))",
+                               0.0},
+        UnaryDoubleScalarParam{"square", "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+                               0.0}
+
+        ),
+    [](const ::testing::TestParamInfo<UnaryDoubleScalarParam>& info) {
+      return info.param.name;
+    });
+
+class PerimeterScalarTest
+    : public ::testing::TestWithParam<UnaryDoubleScalarParam> {};
+
+TEST_P(PerimeterScalarTest, SedonaUdf) {
+  ASSERT_NO_FATAL_FAILURE(TestUnaryScalarDouble(
+      s2geography::sedona_udf::PerimeterKernel, GetParam()));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Accessors, PerimeterScalarTest,
+    ::testing::Values(
+        // Nulls
+        UnaryDoubleScalarParam{"null_perimeter", std::nullopt, std::nullopt},
+
+        // Empties
+        UnaryDoubleScalarParam{"point_empty", "POINT EMPTY", 0.0},
+        UnaryDoubleScalarParam{"linestring_empty", "LINESTRING EMPTY", 0.0},
+        UnaryDoubleScalarParam{"polygon_empty", "POLYGON EMPTY", 0.0},
+
+        // Points (zero perimeter)
+        UnaryDoubleScalarParam{"point", "POINT (0 0)", 0.0},
+
+        // Linestrings (zero perimeter)
+        UnaryDoubleScalarParam{"linestring", "LINESTRING (0 0, 0 1)", 0.0},
+
+        // Polygons
+        UnaryDoubleScalarParam{"triangle", "POLYGON ((0 0, 0 1, 1 0, 0 0))",
+                               379639.83044747578},
+        UnaryDoubleScalarParam{"square", "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+                               444763.46872762055},
+
+        // Multipolygon
+        UnaryDoubleScalarParam{
+            "multipolygon",
+            "MULTIPOLYGON (((0 0, 0 1, 1 0, 0 0)), ((10 10, 10 11, 11 10, 10 "
+            "10)))",
+            756282.14701838186},
+
+        // Polygon with hole
+        UnaryDoubleScalarParam{
+            "polygon_with_hole",
+            "POLYGON ((0 0, 0 2, 2 0, 0 0), (0.1 0.1, 0.1 0.5, 0.5 0.1, 0.1 "
+            "0.1))",
+            911112.66968130425}
+
+        ),
+    [](const ::testing::TestParamInfo<UnaryDoubleScalarParam>& info) {
       return info.param.name;
     });

--- a/src/s2geography/accessors-geog_test.cc
+++ b/src/s2geography/accessors-geog_test.cc
@@ -86,6 +86,6 @@ TEST(AccessorsGeog, SedonaUdfConvexHull) {
   kernel.release(&kernel);
 
   ASSERT_NO_FATAL_FAILURE(TestResultGeography(
-      out_array.get(), {"POINT (0 1)", "POLYGON ((0 0, 0 1, 0 0))",
-                        "POLYGON ((0 0, 0 1, 1 0, 0 0))", std::nullopt}));
+      out_array.get(), {"POINT (0 1)", "LINESTRING (0 0, 0 1)",
+                        "POLYGON ((0 0, 1 0, 0 1, 0 0))", std::nullopt}));
 }

--- a/src/s2geography/accessors-geog_test.cc
+++ b/src/s2geography/accessors-geog_test.cc
@@ -6,7 +6,7 @@
 #include "nanoarrow/nanoarrow.hpp"
 #include "s2geography/sedona_udf/sedona_udf_test_internal.h"
 
-TEST(Accessors, SedonaUdfArea) {
+TEST(Accessors, SedonaUdfAreaArray) {
   struct SedonaCScalarKernel kernel;
   s2geography::sedona_udf::AreaKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
@@ -27,7 +27,7 @@ TEST(Accessors, SedonaUdfArea) {
                       {0.0, 0.0, 6182489130.9071951, std::nullopt}));
 }
 
-TEST(Accessors, SedonaUdfLength) {
+TEST(Accessors, SedonaUdfLengthArray) {
   struct SedonaCScalarKernel kernel;
   s2geography::sedona_udf::LengthKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
@@ -48,7 +48,7 @@ TEST(Accessors, SedonaUdfLength) {
                       {0.0, 111195.10117748393, 0.0, std::nullopt}));
 }
 
-TEST(AccessorsGeog, SedonaUdfCentroid) {
+TEST(AccessorsGeog, SedonaUdfCentroidArray) {
   struct SedonaCScalarKernel kernel;
   s2geography::sedona_udf::CentroidKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
@@ -69,7 +69,7 @@ TEST(AccessorsGeog, SedonaUdfCentroid) {
                         "POINT (0.33335 0.333344)", std::nullopt}));
 }
 
-TEST(AccessorsGeog, SedonaUdfConvexHull) {
+TEST(AccessorsGeog, SedonaUdfConvexHullArray) {
   struct SedonaCScalarKernel kernel;
   s2geography::sedona_udf::ConvexHullKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
@@ -269,5 +269,159 @@ INSTANTIATE_TEST_SUITE_P(
 
         ),
     [](const ::testing::TestParamInfo<UnaryDoubleScalarParam>& info) {
+      return info.param.name;
+    });
+
+struct UnaryGeographyScalarParam {
+  std::string name;
+  std::optional<std::string> input;
+  std::optional<std::string> expected;
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const UnaryGeographyScalarParam& p) {
+    os << (p.input ? *p.input : "null") << " -> ";
+    if (p.expected) {
+      os << *p.expected;
+    } else {
+      os << "null";
+    }
+    return os;
+  }
+};
+
+void TestUnaryScalarGeography(void (*init_kernel)(struct SedonaCScalarKernel*),
+                              const UnaryGeographyScalarParam& p) {
+  struct SedonaCScalarKernel kernel;
+  init_kernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(
+      TestInitKernel(&kernel, &impl, {ARROW_TYPE_WKB}, ARROW_TYPE_WKB));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(&impl, {ARROW_TYPE_WKB},
+                                            {{p.input}}, {}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(TestResultGeography(out_array.get(), {p.expected}));
+}
+
+class CentroidScalarTest
+    : public ::testing::TestWithParam<UnaryGeographyScalarParam> {};
+
+TEST_P(CentroidScalarTest, SedonaUdf) {
+  ASSERT_NO_FATAL_FAILURE(TestUnaryScalarGeography(
+      s2geography::sedona_udf::CentroidKernel, GetParam()));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AccessorsGeog, CentroidScalarTest,
+    ::testing::Values(
+        // Nulls
+        UnaryGeographyScalarParam{"null_centroid", std::nullopt, std::nullopt},
+
+        // Empties
+        UnaryGeographyScalarParam{"point_empty", "POINT EMPTY", "POINT EMPTY"},
+        UnaryGeographyScalarParam{"linestring_empty", "LINESTRING EMPTY",
+                                  "POINT EMPTY"},
+        UnaryGeographyScalarParam{"polygon_empty", "POLYGON EMPTY",
+                                  "POINT EMPTY"},
+
+        // Points
+        UnaryGeographyScalarParam{"point", "POINT (0 1)", "POINT (0 1)"},
+        UnaryGeographyScalarParam{"multipoint", "MULTIPOINT ((0 0), (0 1))",
+                                  "POINT (0 0.5)"},
+
+        // Linestrings
+        UnaryGeographyScalarParam{"linestring", "LINESTRING (0 0, 0 1)",
+                                  "POINT (0 0.5)"},
+        UnaryGeographyScalarParam{"linestring_two_segments",
+                                  "LINESTRING (0 0, 0 1, 0 5)",
+                                  "POINT (0 2.5)"},
+        UnaryGeographyScalarParam{"multilinestring",
+                                  "MULTILINESTRING ((0 0, 0 1), (10 0, 10 5))",
+                                  "POINT (8.336347 2.171205)"},
+
+        // Polygons
+        UnaryGeographyScalarParam{"triangle", "POLYGON ((0 0, 0 1, 1 0, 0 0))",
+                                  "POINT (0.33335 0.333344)"},
+        UnaryGeographyScalarParam{
+            "polygon_with_hole",
+            "POLYGON ((0 0, 0 2, 2 0, 0 0), (0.1 0.1, 0.1 0.5, 0.5 "
+            "0.1, 0.1 0.1))",
+            "POINT (0.684859 0.68481)"},
+        UnaryGeographyScalarParam{
+            "multipolygon",
+            "MULTIPOLYGON (((0 0, 0 1, 1 0, 0 0)), ((10 10, 10 11, "
+            "11 10, 10 10)))",
+            "POINT (5.254205 5.315242)"},
+        UnaryGeographyScalarParam{
+            "multipolygon_with_hole",
+            "MULTIPOLYGON (((0 0, 0 2, 2 0, 0 0), (0.1 0.1, 0.1 0.5, "
+            "0.5 0.1, 0.1 0.1)), ((10 10, 10 11, 11 10, 10 10)))",
+            "POINT (2.624356 2.655749)"}
+
+        ),
+    [](const ::testing::TestParamInfo<UnaryGeographyScalarParam>& info) {
+      return info.param.name;
+    });
+
+class ConvexHullScalarTest
+    : public ::testing::TestWithParam<UnaryGeographyScalarParam> {};
+
+TEST_P(ConvexHullScalarTest, SedonaUdf) {
+  ASSERT_NO_FATAL_FAILURE(TestUnaryScalarGeography(
+      s2geography::sedona_udf::ConvexHullKernel, GetParam()));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AccessorsGeog, ConvexHullScalarTest,
+    ::testing::Values(
+        // Nulls
+        UnaryGeographyScalarParam{"null_convex_hull", std::nullopt,
+                                  std::nullopt},
+
+        // Empties
+        UnaryGeographyScalarParam{"point_empty", "POINT EMPTY",
+                                  "GEOMETRYCOLLECTION EMPTY"},
+        UnaryGeographyScalarParam{"linestring_empty", "LINESTRING EMPTY",
+                                  "GEOMETRYCOLLECTION EMPTY"},
+        UnaryGeographyScalarParam{"polygon_empty", "POLYGON EMPTY",
+                                  "GEOMETRYCOLLECTION EMPTY"},
+
+        // Points
+        UnaryGeographyScalarParam{"point", "POINT (0 1)", "POINT (0 1)"},
+        UnaryGeographyScalarParam{"multipoint_two", "MULTIPOINT ((0 0), (0 1))",
+                                  "LINESTRING (0 0, 0 1)"},
+        UnaryGeographyScalarParam{"multipoint_three",
+                                  "MULTIPOINT ((0 0), (0 1), (1 0))",
+                                  "POLYGON ((0 0, 1 0, 0 1, 0 0))"},
+
+        // Linestrings
+        UnaryGeographyScalarParam{"linestring", "LINESTRING (0 0, 0 1)",
+                                  "LINESTRING (0 0, 0 1)"},
+        UnaryGeographyScalarParam{"linestring_colinear",
+                                  "LINESTRING (0 0, 0 1, 0 2)",
+                                  "LINESTRING (0 0, 0 2)"},
+        UnaryGeographyScalarParam{"linestring_non_colinear",
+                                  "LINESTRING (0 0, 0 1, 1 0)",
+                                  "POLYGON ((0 0, 1 0, 0 1, 0 0))"},
+
+        // Polygons
+        UnaryGeographyScalarParam{"triangle", "POLYGON ((0 0, 0 1, 1 0, 0 0))",
+                                  "POLYGON ((0 0, 1 0, 0 1, 0 0))"},
+        UnaryGeographyScalarParam{
+            "polygon_with_hole",
+            "POLYGON ((0 0, 0 2, 2 0, 0 0), (0.1 0.1, 0.1 0.5, 0.5 "
+            "0.1, 0.1 0.1))",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))"},
+        UnaryGeographyScalarParam{
+            "multipolygon_with_hole",
+            "MULTIPOLYGON (((0 0, 0 2, 2 0, 0 0), (0.1 0.1, 0.1 0.5, "
+            "0.5 0.1, 0.1 0.1)), ((10 10, 10 11, 11 10, 10 10)))",
+            "POLYGON ((0 0, 2 0, 11 10, 10 11, 0 2, 0 0))"}
+
+        ),
+    [](const ::testing::TestParamInfo<UnaryGeographyScalarParam>& info) {
       return info.param.name;
     });

--- a/src/s2geography/accessors-geog_test.cc
+++ b/src/s2geography/accessors-geog_test.cc
@@ -89,3 +89,84 @@ TEST(AccessorsGeog, SedonaUdfConvexHull) {
       out_array.get(), {"POINT (0 1)", "LINESTRING (0 0, 0 1)",
                         "POLYGON ((0 0, 1 0, 0 1, 0 0))", std::nullopt}));
 }
+
+
+struct AreaScalarParam {
+  std::string name;
+  std::optional<std::string> input;
+  std::optional<double> expected;
+
+  friend std::ostream& operator<<(std::ostream& os, const AreaScalarParam& p) {
+    os << (p.input ? *p.input : "null") << " -> ";
+    if (p.expected) {
+      os << *p.expected;
+    } else {
+      os << "null";
+    }
+    return os;
+  }
+};
+
+class AreaScalarTest : public ::testing::TestWithParam<AreaScalarParam> {};
+
+TEST_P(AreaScalarTest, SedonaUdf) {
+  const auto& p = GetParam();
+
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::AreaKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(
+      TestInitKernel(&kernel, &impl, {ARROW_TYPE_WKB}, NANOARROW_TYPE_DOUBLE));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(&impl, {ARROW_TYPE_WKB},
+                                            {{p.input}}, {}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(
+      TestResultArrow(out_array.get(), NANOARROW_TYPE_DOUBLE, {p.expected}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Accessors, AreaScalarTest,
+    ::testing::Values(
+        // Nulls
+        AreaScalarParam{"null_area", std::nullopt, std::nullopt},
+
+        // Empties
+        AreaScalarParam{"point_empty", "POINT EMPTY", 0.0},
+        AreaScalarParam{"linestring_empty", "LINESTRING EMPTY", 0.0},
+        AreaScalarParam{"polygon_empty", "POLYGON EMPTY", 0.0},
+
+        // Points (zero area)
+        AreaScalarParam{"point", "POINT (0 0)", 0.0},
+        AreaScalarParam{"multipoint", "MULTIPOINT ((0 0), (1 1))", 0.0},
+
+        // Linestrings (zero area)
+        AreaScalarParam{"linestring", "LINESTRING (0 0, 0 1)", 0.0},
+        AreaScalarParam{"multilinestring",
+                        "MULTILINESTRING ((0 0, 0 1), (1 0, 1 1))", 0.0},
+
+        // Polygons
+        AreaScalarParam{"triangle", "POLYGON ((0 0, 0 1, 1 0, 0 0))",
+                        6182489130.9071951},
+        AreaScalarParam{"square", "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+                        12364036567.076418},
+
+        // Multipolygon
+        AreaScalarParam{
+            "multipolygon",
+            "MULTIPOLYGON (((0 0, 0 1, 1 0, 0 0)), ((10 10, 10 11, 11 10, 10 10)))",
+            12271037686.230379},
+
+        // Polygon with hole
+        AreaScalarParam{
+            "polygon_with_hole",
+            "POLYGON ((0 0, 0 2, 2 0, 0 0), (0.1 0.1, 0.1 0.5, 0.5 0.1, 0.1 0.1))",
+            23744568445.094166}
+
+        ),
+    [](const ::testing::TestParamInfo<AreaScalarParam>& info) {
+      return info.param.name;
+    });

--- a/src/s2geography/accessors-geog_test.cc
+++ b/src/s2geography/accessors-geog_test.cc
@@ -321,11 +321,12 @@ INSTANTIATE_TEST_SUITE_P(
         UnaryGeographyScalarParam{"null_centroid", std::nullopt, std::nullopt},
 
         // Empties
-        UnaryGeographyScalarParam{"point_empty", "POINT EMPTY", "POINT EMPTY"},
+        UnaryGeographyScalarParam{"point_empty", "POINT EMPTY",
+                                  "GEOMETRYCOLLECTION EMPTY"},
         UnaryGeographyScalarParam{"linestring_empty", "LINESTRING EMPTY",
-                                  "POINT EMPTY"},
+                                  "GEOMETRYCOLLECTION EMPTY"},
         UnaryGeographyScalarParam{"polygon_empty", "POLYGON EMPTY",
-                                  "POINT EMPTY"},
+                                  "GEOMETRYCOLLECTION EMPTY"},
 
         // Points
         UnaryGeographyScalarParam{"point", "POINT (0 1)", "POINT (0 1)"},

--- a/src/s2geography/accessors-geog_test.cc
+++ b/src/s2geography/accessors-geog_test.cc
@@ -69,22 +69,23 @@ TEST(AccessorsGeog, SedonaUdfCentroid) {
                         "POINT (0.33335 0.333344)", std::nullopt}));
 }
 
-TEST(AccessorsGeog, SedonaUdfInterpolateNormalized) {
+TEST(AccessorsGeog, SedonaUdfConvexHull) {
   struct SedonaCScalarKernel kernel;
-  s2geography::sedona_udf::LineInterpolatePointKernel(&kernel);
+  s2geography::sedona_udf::ConvexHullKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
-  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
-      &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
+  ASSERT_NO_FATAL_FAILURE(
+      TestInitKernel(&kernel, &impl, {ARROW_TYPE_WKB}, ARROW_TYPE_WKB));
 
   nanoarrow::UniqueArray out_array;
   ASSERT_NO_FATAL_FAILURE(
-      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE},
-                        {{"LINESTRING (0 0, 0 1)"}},
-                        {{0.0, 0.5, 1.0, std::nullopt}}, out_array.get()));
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB},
+                        {{"POINT (0 1)", "LINESTRING (0 0, 0 1)",
+                          "POLYGON ((0 0, 0 1, 1 0, 0 0))", std::nullopt}},
+                        {}, out_array.get()));
   impl.release(&impl);
   kernel.release(&kernel);
 
   ASSERT_NO_FATAL_FAILURE(TestResultGeography(
-      out_array.get(),
-      {"POINT (0 0)", "POINT (0 0.5)", "POINT (0 1)", std::nullopt}));
+      out_array.get(), {"POINT (0 1)", "POLYGON ((0 0, 0 1, 0 0))",
+                        "POLYGON ((0 0, 0 1, 1 0, 0 0))", std::nullopt}));
 }

--- a/src/s2geography/accessors.cc
+++ b/src/s2geography/accessors.cc
@@ -273,36 +273,54 @@ bool s2_find_validation_error(const Geography& geog, S2Error* error) {
 }
 
 namespace sedona_udf {
+
 struct S2LengthExec {
-  using arg0_t = GeographyInputView;
+  using arg0_t = GeoArrowGeographyInputView;
   using out_t = DoubleOutputBuilder;
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value) {
-    return s2_length(value) * S2Earth::RadiusMeters();
+    double length = 0.0;
+    value.lines()->geom().VisitEdges([&](const S2Shape::Edge& e) {
+      length += S1ChordAngle(e.v0, e.v1).radians();
+      return true;
+    });
+    return length * S2Earth::RadiusMeters();
   }
 };
 
 struct S2AreaExec {
-  using arg0_t = GeographyInputView;
+  using arg0_t = GeoArrowGeographyInputView;
   using out_t = DoubleOutputBuilder;
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value) {
-    return s2_area(value) * S2Earth::RadiusMeters() * S2Earth::RadiusMeters();
+    double area = 0.0;
+    value.polygons()->geom().VisitLoops(&scratch_, [&](GeoArrowLoop loop) {
+      area += loop.GetSignedArea();
+      return true;
+    });
+    return area * S2Earth::RadiusMeters() * S2Earth::RadiusMeters();
   }
+
+  std::vector<S2Point> scratch_;
 };
 
 struct S2PerimeterExec {
-  using arg0_t = GeographyInputView;
+  using arg0_t = GeoArrowGeographyInputView;
   using out_t = DoubleOutputBuilder;
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value) {
-    return s2_perimeter(value) * S2Earth::RadiusMeters();
+    double perimeter = 0.0;
+    value.polygons()->geom().VisitEdges([&](const S2Shape::Edge& e) {
+      perimeter += S1ChordAngle(e.v0, e.v1).radians();
+      return true;
+    });
+    return perimeter * S2Earth::RadiusMeters();
   }
 };
 
@@ -317,6 +335,7 @@ void AreaKernel(struct SedonaCScalarKernel* out) {
 void PerimeterKernel(struct SedonaCScalarKernel* out) {
   InitUnaryKernel<S2PerimeterExec>(out, "st_perimeter");
 }
+
 }  // namespace sedona_udf
 
 }  // namespace s2geography

--- a/src/s2geography/accessors.h
+++ b/src/s2geography/accessors.h
@@ -22,6 +22,7 @@ namespace sedona_udf {
 void LengthKernel(struct SedonaCScalarKernel* out);
 void AreaKernel(struct SedonaCScalarKernel* out);
 void PerimeterKernel(struct SedonaCScalarKernel* out);
+
 }  // namespace sedona_udf
 
 }  // namespace s2geography

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -19,9 +19,6 @@ namespace s2geography {
 
 namespace {
 
-static constexpr uint8_t kFlagS2GeographyIsHole =
-    (static_cast<uint8_t>(1) << 7);
-
 void ReverseNodeInPlace(struct GeoArrowGeometryNode* node) {
   if (node->size <= 1) return;
   for (int i = 0; i < 4; ++i) {
@@ -287,7 +284,7 @@ void GeoArrowLaxPolygonShape::Init(struct GeoArrowGeometryView geom) {
             loops_.push_back(*node);
 
             if (is_hole) {
-              loops_.back().flags |= kFlagS2GeographyIsHole;
+              loops_.back().flags |= internal::kFlagS2GeographyIsHole;
             }
 
             ++num_loops_;
@@ -308,7 +305,7 @@ void GeoArrowLaxPolygonShape::NormalizeOrientation() {
   for (auto& node : loops_) {
     GeoArrowLoop loop(&node, &point_scratch_);
     double curvature = loop.GetCurvature();
-    bool is_hole = (node.flags & kFlagS2GeographyIsHole) != 0;
+    bool is_hole = (node.flags & internal::kFlagS2GeographyIsHole) != 0;
     if (is_hole != (curvature < 0)) {
       ReverseNodeInPlace(&node);
     }

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -15,6 +15,14 @@ namespace s2geography {
 
 namespace internal {
 
+/// \brief Internal flag we set to mark holes as we process polygon input
+///
+/// For the purposes of this flag, this is set purely by position (i.e.,
+/// the first ring in each polygon is a shell and the rest are holes). This
+/// is not validated.
+static constexpr uint8_t kFlagS2GeographyIsHole =
+    (static_cast<uint8_t>(1) << 7);
+
 /// \brief Visit "nodes" of a GeoArrowGeometryView
 ///
 /// Briefly, a GeoArrowGeometryNode is either a sequence (if geometry_type
@@ -304,11 +312,18 @@ class GeoArrowChain {
 struct GeoArrowLoop : public GeoArrowChain {
  public:
   /// \brief Construct a loop and clear the scratch space
+  ///
+  /// Optionally tracks shell/hole for algorithms that require it; however,
+  /// note that the loops provided by VisitLoops() are oriented correctly such
+  /// that the curvature, signed area, centroid, and containment checks do not
+  /// require checking the hole status.
   GeoArrowLoop(const struct GeoArrowGeometryNode* node,
-               std::vector<S2Point>* scratch)
-      : GeoArrowChain(node), scratch_(scratch) {
+               std::vector<S2Point>* scratch, bool is_hole = false)
+      : GeoArrowChain(node), scratch_(scratch), is_hole_(is_hole) {
     scratch_->clear();
   }
+
+  bool is_hole() const { return is_hole_; }
 
   /// \brief Get the sum of the turning angles
   ///
@@ -339,6 +354,7 @@ struct GeoArrowLoop : public GeoArrowChain {
 
  protected:
   std::vector<S2Point>* scratch_{};
+  bool is_hole_;
 
   void BuildScratch();
 };
@@ -397,7 +413,9 @@ class GeoArrowGeom {
         geom_, [&](const struct GeoArrowGeometryNode* node) {
           switch (node->geometry_type) {
             case GEOARROW_GEOMETRY_TYPE_LINESTRING:
-              return visit(GeoArrowLoop(node, scratch));
+              return visit(
+                  GeoArrowLoop(node, scratch,
+                               node->flags & internal::kFlagS2GeographyIsHole));
             default:
               return true;
           }

--- a/src/s2geography/linear-referencing_test.cc
+++ b/src/s2geography/linear-referencing_test.cc
@@ -46,3 +46,23 @@ TEST(LinearReferencing, SedonaUdfLineInterpolatePoint) {
       out_array.get(),
       {"POINT (0 0)", "POINT (0 0.5)", "POINT (0 1)", std::nullopt}));
 }
+
+TEST(AccessorsGeog, SedonaUdfInterpolateNormalized) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::LineInterpolatePointKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE},
+                        {{"LINESTRING (0 0, 0 1)"}},
+                        {{0.0, 0.5, 1.0, std::nullopt}}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(TestResultGeography(
+      out_array.get(),
+      {"POINT (0 0)", "POINT (0 0.5)", "POINT (0 1)", std::nullopt}));
+}

--- a/src/s2geography/linear-referencing_test.cc
+++ b/src/s2geography/linear-referencing_test.cc
@@ -46,23 +46,3 @@ TEST(LinearReferencing, SedonaUdfLineInterpolatePoint) {
       out_array.get(),
       {"POINT (0 0)", "POINT (0 0.5)", "POINT (0 1)", std::nullopt}));
 }
-
-TEST(AccessorsGeog, SedonaUdfInterpolateNormalized) {
-  struct SedonaCScalarKernel kernel;
-  s2geography::sedona_udf::LineInterpolatePointKernel(&kernel);
-  struct SedonaCScalarKernelImpl impl;
-  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
-      &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
-
-  nanoarrow::UniqueArray out_array;
-  ASSERT_NO_FATAL_FAILURE(
-      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE},
-                        {{"LINESTRING (0 0, 0 1)"}},
-                        {{0.0, 0.5, 1.0, std::nullopt}}, out_array.get()));
-  impl.release(&impl);
-  kernel.release(&kernel);
-
-  ASSERT_NO_FATAL_FAILURE(TestResultGeography(
-      out_array.get(),
-      {"POINT (0 0)", "POINT (0 0.5)", "POINT (0 1)", std::nullopt}));
-}


### PR DESCRIPTION
This includes ST_Length(), ST_Perimeter(), ST_Area(), ST_Centroid(), and ST_ConvexHull().

```
s2geography-st_area-Array(geog(Polygon(10)))
                        time:   [93.289 ms 93.921 ms 94.227 ms]
                        change: [−80.324% −80.191% −80.058%] (p = 0.00 < 0.05)
                        Performance has improved.

s2geography-st_length-Array(geog(LineString(10)))
                        time:   [26.634 ms 26.684 ms 26.716 ms]
                        change: [−45.079% −44.772% −44.455%] (p = 0.00 < 0.05)
                        Performance has improved.

s2geography-st_centroid-Array(geog(Polygon(10)))
                        time:   [91.825 ms 92.128 ms 92.409 ms]
                        change: [−80.998% −80.837% −80.698%] (p = 0.00 < 0.05)
                        Performance has improved.

s2geography-st_convexhull-Array(geog(Polygon(10)))
                        time:   [400.98 ms 401.66 ms 402.30 ms]
                        change: [−50.620% −50.461% −50.308%] (p = 0.00 < 0.05)
                        Performance has improved.
```