### PR TITLE
perf: Improve performance of linear referencing functions

### DIFF
--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -211,12 +211,20 @@ bool VisitEdges(const struct GeoArrowGeometryNode* node, int64_t offset,
   }
 
   S2Shape::Edge e;
-  return VisitLngLatEdges(
-      node, offset, n, [&](double lng0, double lat0, double lng1, double lat1) {
-        e.v0 = S2LatLng::FromDegrees(lat0, lng0).ToPoint();
-        e.v1 = S2LatLng::FromDegrees(lat1, lng1).ToPoint();
-        return visit(e);
-      });
+  VisitVertices(node, offset, 1, [&](const S2Point& v) {
+    e.v0 = v;
+    return true;
+  });
+
+  return VisitVertices(node, offset + 1, n, [&](const S2Point& v) {
+    e.v1 = v;
+    if (!visit(e)) {
+      return false;
+    }
+
+    e.v0 = e.v1;
+    return true;
+  });
 }
 
 /// \brief Visit all edges in a sequence as S2Shape::Edges

--- a/src/s2geography/linear-referencing.cc
+++ b/src/s2geography/linear-referencing.cc
@@ -89,10 +89,10 @@ struct S2LineInterpolatePointExec {
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
-  out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type fraction) {
+  std::optional<optional_storable_t<out_t::c_type>> Exec(
+      arg0_t::c_type value0, arg1_t::c_type fraction) {
     if (value0.is_empty()) {
-      stashed_ = PointGeography();
-      return stashed_;
+      return std::nullopt;
     }
 
     if (!value0.points()->is_empty() || !value0.polygons()->is_empty() ||

--- a/src/s2geography/linear-referencing.cc
+++ b/src/s2geography/linear-referencing.cc
@@ -154,13 +154,52 @@ struct S2LineInterpolatePointExec {
 };
 
 struct S2LineLocatePointExec {
-  using arg0_t = GeographyInputView;
-  using arg1_t = GeographyInputView;
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = GeoArrowGeographyInputView;
   using out_t = DoubleOutputBuilder;
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
-  out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
+  std::optional<out_t::c_type> Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
+    if (value0.is_empty() || value1.is_empty()) {
+      return std::nullopt;
+    }
+
+    if (!value0.points()->is_empty() || !value0.polygons()->is_empty() ||
+        value0.lines()->num_chains() != 1) {
+      throw Exception(
+          "First argument to ST_LineLocatePoint must be a single linestring");
+    }
+
+    auto maybe_point = value1.Point();
+    if (!maybe_point) {
+      throw Exception("Second argument to ST_LineLocatePoint must be a point");
+    }
+
+    S2Point pt = *maybe_point;
+
+    S1Angle min_distance_to_segment = S1Angle::Infinity();
+    int closest_edge_id = -1;
+
+    S1Angle length_sum;
+    cumulative_lengths_.clear();
+    cumulative_lengths_.push_back(length_sum);
+    int edge_id = -1;
+    value0.VisitEdges([&](const S2Shape::Edge& e) {
+      ++edge_id;
+
+      length_sum += S1Angle(e.v0, e.v1);
+      cumulative_lengths_.push_back(length_sum);
+
+      S1Angle distance_to_segment = S2::GetDistance(pt, e.v0, e.v1);
+      if (distance_to_segment < min_distance_to_segment) {
+        closest_edge_id = edge_id;
+      }
+      return true;
+    });
+
+
+
     //   ABSL_DCHECK_GT(num_vertices(), 0);
 
     // if (num_vertices() == 1) {
@@ -191,8 +230,11 @@ struct S2LineLocatePointExec {
     // return closest_point;
     // stashed_ = PointGeography(s2_interpolate_normalized(value0, value1));
 
-    return s2_project_normalized(value0, value1);
+    // return s2_project_normalized(value0, value1);
+    return 0.0;
   }
+
+  std::vector<S1Angle> cumulative_lengths_;
 };
 
 void LineInterpolatePointKernel(struct SedonaCScalarKernel* out) {

--- a/src/s2geography/linear-referencing.cc
+++ b/src/s2geography/linear-referencing.cc
@@ -124,6 +124,15 @@ struct S2LineInterpolatePointExec {
       return true;
     });
 
+    if (length_sum.radians() == 0) {
+      value0.VisitVertices([&](const S2Point& v) {
+        pt = v;
+        return false;
+      });
+      stashed_ = PointGeography(pt);
+      return stashed_;
+    }
+
     S1Angle target = fraction * length_sum;
     int num_edges = value0.lines()->num_edges();
     int edge_idx;

--- a/src/s2geography/linear-referencing.cc
+++ b/src/s2geography/linear-referencing.cc
@@ -204,11 +204,16 @@ struct S2LineLocatePointExec {
       return true;
     });
 
+    if (length_sum == S1Angle::Zero()) {
+      return 0.0;
+    }
+
     S2GEOGRAPHY_DCHECK_GE(closest_edge_id, 0);
     S2Shape::Edge e = value0.lines()->edge(closest_edge_id);
     S2Point pt_on_edge = S2::Project(pt, e.v0, e.v1);
     S1Angle e_distance(e.v0, pt_on_edge);
     S1Angle total_distance = cumulative_lengths_[closest_edge_id] + e_distance;
+
     return (total_distance / length_sum);
   }
 

--- a/src/s2geography/linear-referencing.cc
+++ b/src/s2geography/linear-referencing.cc
@@ -160,7 +160,8 @@ struct S2LineLocatePointExec {
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
-  std::optional<out_t::c_type> Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
+  std::optional<out_t::c_type> Exec(arg0_t::c_type value0,
+                                    arg1_t::c_type value1) {
     if (value0.is_empty() || value1.is_empty()) {
       return std::nullopt;
     }
@@ -178,6 +179,9 @@ struct S2LineLocatePointExec {
 
     S2Point pt = *maybe_point;
 
+    // This section always does a linear search. In theory some of this search
+    // could be reused for a scalar input across multiple query points; however,
+    // it's unclear that this would be a common query pattern.
     S1Angle min_distance_to_segment = S1Angle::Infinity();
     int closest_edge_id = -1;
 
@@ -194,44 +198,18 @@ struct S2LineLocatePointExec {
       S1Angle distance_to_segment = S2::GetDistance(pt, e.v0, e.v1);
       if (distance_to_segment < min_distance_to_segment) {
         closest_edge_id = edge_id;
+        min_distance_to_segment = distance_to_segment;
       }
+
       return true;
     });
 
-
-
-    //   ABSL_DCHECK_GT(num_vertices(), 0);
-
-    // if (num_vertices() == 1) {
-    //   // If there is only one vertex, it is always closest to any given
-    //   point. *next_vertex = 1; return vertex(0);
-    // }
-
-    // // Initial value larger than any possible distance on the unit sphere.
-    // S1Angle min_distance = S1Angle::Radians(10);
-    // int min_index = -1;
-
-    // // Find the line segment in the polyline that is closest to the point
-    // given. for (int i = 1; i < num_vertices(); ++i) {
-    //   S1Angle distance_to_segment = S2::GetDistance(point, vertex(i-1),
-    //                                                         vertex(i));
-    //   if (distance_to_segment < min_distance) {
-    //     min_distance = distance_to_segment;
-    //     min_index = i;
-    //   }
-    // }
-    // ABSL_DCHECK_NE(min_index, -1);
-
-    // // Compute the point on the segment found that is closest to the point
-    // given. S2Point closest_point =
-    //     S2::Project(point, vertex(min_index - 1), vertex(min_index));
-
-    // *next_vertex = min_index + (closest_point == vertex(min_index) ? 1 : 0);
-    // return closest_point;
-    // stashed_ = PointGeography(s2_interpolate_normalized(value0, value1));
-
-    // return s2_project_normalized(value0, value1);
-    return 0.0;
+    S2GEOGRAPHY_DCHECK_GE(closest_edge_id, 0);
+    S2Shape::Edge e = value0.lines()->edge(closest_edge_id);
+    S2Point pt_on_edge = S2::Project(pt, e.v0, e.v1);
+    S1Angle e_distance(e.v0, pt_on_edge);
+    S1Angle total_distance = cumulative_lengths_[closest_edge_id] + e_distance;
+    return (total_distance / length_sum);
   }
 
   std::vector<S1Angle> cumulative_lengths_;

--- a/src/s2geography/linear-referencing.cc
+++ b/src/s2geography/linear-referencing.cc
@@ -1,6 +1,10 @@
 
 #include "s2geography/linear-referencing.h"
 
+#include <s2/s2edge_distances.h>
+
+#include <algorithm>
+
 #include "s2geography/accessors.h"
 #include "s2geography/build.h"
 #include "s2geography/geography.h"
@@ -76,19 +80,77 @@ S2Point s2_interpolate_normalized(const Geography& geog, double distance_norm) {
 
 namespace sedona_udf {
 
+static constexpr int kMaxEdgesLinearSearch = 32;
+
 struct S2LineInterpolatePointExec {
-  using arg0_t = GeographyInputView;
+  using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = DoubleInputView;
   using out_t = WkbGeographyOutputBuilder;
 
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
-  out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
-    stashed_ = PointGeography(s2_interpolate_normalized(value0, value1));
+  out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type fraction) {
+    if (value0.is_empty()) {
+      stashed_ = PointGeography();
+      return stashed_;
+    }
+
+    if (!value0.points()->is_empty() || !value0.polygons()->is_empty() ||
+        value0.lines()->num_chains() != 1) {
+      throw Exception(
+          "Input to ST_LineInterpolatePoint must be a single linestring");
+    }
+
+    S2Point pt;
+    if (fraction <= 0) {
+      value0.VisitVertices([&](const S2Point& v) {
+        pt = v;
+        return false;
+      });
+      stashed_ = PointGeography(pt);
+      return stashed_;
+    } else if (fraction >= 1) {
+      stashed_ = PointGeography(
+          value0.lines()->edge(value0.lines()->num_edges() - 1).v1);
+      return stashed_;
+    }
+
+    S1Angle length_sum;
+    cumulative_lengths_.clear();
+    cumulative_lengths_.push_back(length_sum);
+    value0.VisitEdges([&](const S2Shape::Edge& e) {
+      length_sum += S1Angle(e.v0, e.v1);
+      cumulative_lengths_.push_back(length_sum);
+      return true;
+    });
+
+    S1Angle target = fraction * length_sum;
+    int num_edges = value0.lines()->num_edges();
+    int edge_idx;
+    if (num_edges <= kMaxEdgesLinearSearch) {
+      for (size_t i = 1; i < cumulative_lengths_.size(); ++i) {
+        if (target < cumulative_lengths_[i]) {
+          edge_idx = static_cast<int>(i) - 1;
+          break;
+        }
+      }
+    } else {
+      auto it = std::lower_bound(cumulative_lengths_.begin(),
+                                 cumulative_lengths_.end(), target);
+      edge_idx = static_cast<int>(it - cumulative_lengths_.begin()) - 1;
+    }
+
+    S1Angle prev_length = cumulative_lengths_[edge_idx];
+    S2Shape::Edge e = value0.lines()->edge(edge_idx);
+    S1Angle remaining = target - prev_length;
+    pt = S2::GetPointOnLine(e.v0, e.v1, remaining);
+
+    stashed_ = PointGeography(pt);
     return stashed_;
   }
 
   PointGeography stashed_;
+  std::vector<S1Angle> cumulative_lengths_;
 };
 
 struct S2LineLocatePointExec {
@@ -99,6 +161,36 @@ struct S2LineLocatePointExec {
   void Init(const std::unordered_map<std::string, std::string>& options) {}
 
   out_t::c_type Exec(arg0_t::c_type value0, arg1_t::c_type value1) {
+    //   ABSL_DCHECK_GT(num_vertices(), 0);
+
+    // if (num_vertices() == 1) {
+    //   // If there is only one vertex, it is always closest to any given
+    //   point. *next_vertex = 1; return vertex(0);
+    // }
+
+    // // Initial value larger than any possible distance on the unit sphere.
+    // S1Angle min_distance = S1Angle::Radians(10);
+    // int min_index = -1;
+
+    // // Find the line segment in the polyline that is closest to the point
+    // given. for (int i = 1; i < num_vertices(); ++i) {
+    //   S1Angle distance_to_segment = S2::GetDistance(point, vertex(i-1),
+    //                                                         vertex(i));
+    //   if (distance_to_segment < min_distance) {
+    //     min_distance = distance_to_segment;
+    //     min_index = i;
+    //   }
+    // }
+    // ABSL_DCHECK_NE(min_index, -1);
+
+    // // Compute the point on the segment found that is closest to the point
+    // given. S2Point closest_point =
+    //     S2::Project(point, vertex(min_index - 1), vertex(min_index));
+
+    // *next_vertex = min_index + (closest_point == vertex(min_index) ? 1 : 0);
+    // return closest_point;
+    // stashed_ = PointGeography(s2_interpolate_normalized(value0, value1));
+
     return s2_project_normalized(value0, value1);
   }
 };

--- a/src/s2geography/linear-referencing_test.cc
+++ b/src/s2geography/linear-referencing_test.cc
@@ -15,16 +15,18 @@ TEST(LinearReferencing, SedonaUdfLineLocatePoint) {
       &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, NANOARROW_TYPE_DOUBLE));
 
   nanoarrow::UniqueArray out_array;
-  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
-      &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
-      {{"LINESTRING (0 0, 0 1)"},
-       {"POINT (0 0)", "POINT (0 0.5)", "POINT (0 1)", std::nullopt}},
-      {}, out_array.get()));
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                        {{"LINESTRING (0 0, 0 1, 0 2)"},
+                         {"POINT (0 0)", "POINT (0 0.5)", "POINT (0 1)",
+                          "POINT (0 1.5)", "POINT (0 2)", std::nullopt}},
+                        {}, out_array.get()));
   impl.release(&impl);
   kernel.release(&kernel);
 
-  ASSERT_NO_FATAL_FAILURE(TestResultArrow(
-      out_array.get(), NANOARROW_TYPE_DOUBLE, {0.0, 0.5, 1.0, std::nullopt}));
+  ASSERT_NO_FATAL_FAILURE(
+      TestResultArrow(out_array.get(), NANOARROW_TYPE_DOUBLE,
+                      {0.0, 0.25, 0.5, 0.75, 1.0, std::nullopt}));
 }
 
 TEST(LinearReferencing, SedonaUdfLineInterpolatePoint) {

--- a/src/s2geography/linear-referencing_test.cc
+++ b/src/s2geography/linear-referencing_test.cc
@@ -35,14 +35,14 @@ TEST(LinearReferencing, SedonaUdfLineInterpolatePoint) {
       &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
 
   nanoarrow::UniqueArray out_array;
-  ASSERT_NO_FATAL_FAILURE(
-      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE},
-                        {{"LINESTRING (0 0, 0 1)"}},
-                        {{0.0, 0.5, 1.0, std::nullopt}}, out_array.get()));
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
+      &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE},
+      {{"LINESTRING (0 0, 0 1, 0 2)"}},
+      {{0.0, 0.25, 0.5, 0.75, 1.0, std::nullopt}}, out_array.get()));
   impl.release(&impl);
   kernel.release(&kernel);
 
   ASSERT_NO_FATAL_FAILURE(TestResultGeography(
-      out_array.get(),
-      {"POINT (0 0)", "POINT (0 0.5)", "POINT (0 1)", std::nullopt}));
+      out_array.get(), {"POINT (0 0)", "POINT (0 0.5)", "POINT (0 1)",
+                        "POINT (0 1.5)", "POINT (0 2)", std::nullopt}));
 }

--- a/src/s2geography/linear-referencing_test.cc
+++ b/src/s2geography/linear-referencing_test.cc
@@ -7,7 +7,7 @@
 
 using namespace s2geography;
 
-TEST(LinearReferencing, SedonaUdfLineLocatePoint) {
+TEST(LinearReferencing, SedonaUdfLineLocatePointArray) {
   struct SedonaCScalarKernel kernel;
   s2geography::sedona_udf::LineLocatePointKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
@@ -29,7 +29,7 @@ TEST(LinearReferencing, SedonaUdfLineLocatePoint) {
                       {0.0, 0.25, 0.5, 0.75, 1.0, std::nullopt}));
 }
 
-TEST(LinearReferencing, SedonaUdfLineInterpolatePoint) {
+TEST(LinearReferencing, SedonaUdfLineInterpolatePointArray) {
   struct SedonaCScalarKernel kernel;
   s2geography::sedona_udf::LineInterpolatePointKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
@@ -48,3 +48,158 @@ TEST(LinearReferencing, SedonaUdfLineInterpolatePoint) {
       out_array.get(), {"POINT (0 0)", "POINT (0 0.5)", "POINT (0 1)",
                         "POINT (0 1.5)", "POINT (0 2)", std::nullopt}));
 }
+
+struct LineLocatePointParam {
+  std::string name;
+  std::optional<std::string> line;
+  std::optional<std::string> point;
+  std::optional<double> expected;
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const LineLocatePointParam& p) {
+    os << (p.line ? *p.line : "null") << " locate "
+       << (p.point ? *p.point : "null") << " -> ";
+    if (p.expected) {
+      os << *p.expected;
+    } else {
+      os << "null";
+    }
+    return os;
+  }
+};
+
+class LineLocatePointTest
+    : public ::testing::TestWithParam<LineLocatePointParam> {};
+
+TEST_P(LineLocatePointTest, SedonaUdf) {
+  const auto& p = GetParam();
+
+  struct SedonaCScalarKernel kernel;
+  struct SedonaCScalarKernelImpl impl;
+  s2geography::sedona_udf::LineLocatePointKernel(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, NANOARROW_TYPE_DOUBLE));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                        {{p.line}, {p.point}}, {}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(
+      TestResultArrow(out_array.get(), NANOARROW_TYPE_DOUBLE, {p.expected}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LinearReferencing, LineLocatePointTest,
+    ::testing::Values(
+        // Nulls
+        LineLocatePointParam{"null_line", std::nullopt, "POINT (0 0)",
+                             std::nullopt},
+        LineLocatePointParam{"null_point", "LINESTRING (0 0, 0 1)",
+                             std::nullopt, std::nullopt},
+        LineLocatePointParam{"null_both", std::nullopt, std::nullopt,
+                             std::nullopt},
+
+        // Endpoints and midpoints
+        LineLocatePointParam{"start", "LINESTRING (0 0, 0 2)", "POINT (0 0)",
+                             0.0},
+        LineLocatePointParam{"end", "LINESTRING (0 0, 0 2)", "POINT (0 2)",
+                             1.0},
+        LineLocatePointParam{"midpoint", "LINESTRING (0 0, 0 2)", "POINT (0 1)",
+                             0.5},
+
+        // Multi-segment line
+        LineLocatePointParam{"multi_seg_quarter", "LINESTRING (0 0, 0 1, 0 2)",
+                             "POINT (0 0.5)", 0.25},
+        LineLocatePointParam{"multi_seg_three_quarter",
+                             "LINESTRING (0 0, 0 1, 0 2)", "POINT (0 1.5)",
+                             0.75},
+
+        // Point off the line (projects to nearest)
+        LineLocatePointParam{"off_line_start", "LINESTRING (0 0, 0 2)",
+                             "POINT (1 0)", 0.0},
+        LineLocatePointParam{"off_line_mid", "LINESTRING (0 0, 0 2)",
+                             "POINT (1 1)", 0.50007614855210425}),
+    [](const ::testing::TestParamInfo<LineLocatePointParam>& info) {
+      return info.param.name;
+    });
+
+struct LineInterpolatePointParam {
+  std::string name;
+  std::optional<std::string> line;
+  std::optional<double> fraction;
+  std::optional<std::string> expected;
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const LineInterpolatePointParam& p) {
+    os << (p.line ? *p.line : "null") << " interpolate ";
+    if (p.fraction) {
+      os << *p.fraction;
+    } else {
+      os << "null";
+    }
+    os << " -> " << (p.expected ? *p.expected : "null");
+    return os;
+  }
+};
+
+class LineInterpolatePointTest
+    : public ::testing::TestWithParam<LineInterpolatePointParam> {};
+
+TEST_P(LineInterpolatePointTest, SedonaUdf) {
+  const auto& p = GetParam();
+
+  struct SedonaCScalarKernel kernel;
+  struct SedonaCScalarKernelImpl impl;
+  s2geography::sedona_udf::LineInterpolatePointKernel(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE},
+                        {{p.line}}, {{p.fraction}}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(TestResultGeography(out_array.get(), {p.expected}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LinearReferencing, LineInterpolatePointTest,
+    ::testing::Values(
+        // Nulls
+        LineInterpolatePointParam{"null_line", std::nullopt, 0.5, std::nullopt},
+        LineInterpolatePointParam{"null_fraction", "LINESTRING (0 0, 0 2)",
+                                  std::nullopt, std::nullopt},
+        LineInterpolatePointParam{"null_both", std::nullopt, std::nullopt,
+                                  std::nullopt},
+
+        // Endpoints and midpoints
+        LineInterpolatePointParam{"start", "LINESTRING (0 0, 0 2)", 0.0,
+                                  "POINT (0 0)"},
+        LineInterpolatePointParam{"end", "LINESTRING (0 0, 0 2)", 1.0,
+                                  "POINT (0 2)"},
+        LineInterpolatePointParam{"midpoint", "LINESTRING (0 0, 0 2)", 0.5,
+                                  "POINT (0 1)"},
+
+        // Multi-segment line
+        LineInterpolatePointParam{"multi_seg_quarter",
+                                  "LINESTRING (0 0, 0 1, 0 2)", 0.25,
+                                  "POINT (0 0.5)"},
+        LineInterpolatePointParam{"multi_seg_three_quarter",
+                                  "LINESTRING (0 0, 0 1, 0 2)", 0.75,
+                                  "POINT (0 1.5)"},
+
+        // Boundary fractions
+        LineInterpolatePointParam{"fraction_zero", "LINESTRING (0 0, 0 2)", 0.0,
+                                  "POINT (0 0)"},
+        LineInterpolatePointParam{"fraction_one", "LINESTRING (0 0, 0 2)", 1.0,
+                                  "POINT (0 2)"}),
+    [](const ::testing::TestParamInfo<LineInterpolatePointParam>& info) {
+      return info.param.name;
+    });

--- a/src/s2geography/linear-referencing_test.cc
+++ b/src/s2geography/linear-referencing_test.cc
@@ -92,6 +92,22 @@ TEST_P(LineLocatePointTest, SedonaUdf) {
       TestResultArrow(out_array.get(), NANOARROW_TYPE_DOUBLE, {p.expected}));
 }
 
+// Create a linestring with n vertices roughly spaced between 0 0 and 180 90
+std::string VeryLongLinestring(int n) {
+  std::stringstream ss;
+
+  ss << "LINESTRING (0 0";
+  double dlon = 180.0 / n;
+  double dlat = 90.0 / n;
+  for (int i = 1; i < n; i++) {
+    ss << ", " << (i * dlon) << " " << (i * dlat);
+  }
+
+  ss << ")";
+
+  return ss.str();
+}
+
 INSTANTIATE_TEST_SUITE_P(
     LinearReferencing, LineLocatePointTest,
     ::testing::Values(
@@ -134,7 +150,17 @@ INSTANTIATE_TEST_SUITE_P(
         LineLocatePointParam{"off_line_start", "LINESTRING (0 0, 0 2)",
                              "POINT (1 0)", 0.0},
         LineLocatePointParam{"off_line_mid", "LINESTRING (0 0, 0 2)",
-                             "POINT (1 1)", 0.50007614855210425}),
+                             "POINT (1 1)", 0.50007614855210425},
+        // A few points on a very long linestring
+        LineLocatePointParam{"long_line_start", VeryLongLinestring(100),
+                             "POINT (0 0)", 0.0},
+        LineLocatePointParam{"long_line_midish", VeryLongLinestring(100),
+                             "POINT (44 38)", 0.38060699282822169},
+        LineLocatePointParam{"long_line_endish", VeryLongLinestring(100),
+                             "POINT (180 89)", 0.99935140921752641}
+
+        ),
+
     [](const ::testing::TestParamInfo<LineLocatePointParam>& info) {
       return info.param.name;
     });
@@ -199,7 +225,7 @@ INSTANTIATE_TEST_SUITE_P(
         LineInterpolatePointParam{"zero_length_line", "LINESTRING (1 1, 1 1)",
                                   0.5, "POINT (1 1)"},
         LineInterpolatePointParam{"invalid_line", "LINESTRING (1 1)", 0.5,
-                                  "POINT (1 1)"},
+                                  std::nullopt},
 
         // Endpoints and midpoints
         LineInterpolatePointParam{"start", "LINESTRING (0 0, 0 2)", 0.0,
@@ -221,7 +247,17 @@ INSTANTIATE_TEST_SUITE_P(
         LineInterpolatePointParam{"fraction_zero", "LINESTRING (0 0, 0 2)", 0.0,
                                   "POINT (0 0)"},
         LineInterpolatePointParam{"fraction_one", "LINESTRING (0 0, 0 2)", 1.0,
-                                  "POINT (0 2)"}),
+                                  "POINT (0 2)"},
+
+        // A few points on a very long linestring
+        LineInterpolatePointParam{"long_line_start", VeryLongLinestring(100),
+                                  0.0, "POINT (0 0)"},
+        LineInterpolatePointParam{"long_line_midish", VeryLongLinestring(100),
+                                  0.4, "POINT (55.384968 27.695838)"},
+        LineInterpolatePointParam{"long_line_endish", VeryLongLinestring(100),
+                                  0.9, "POINT (149.533768 74.771147)"}
+
+        ),
     [](const ::testing::TestParamInfo<LineInterpolatePointParam>& info) {
       return info.param.name;
     });

--- a/src/s2geography/linear-referencing_test.cc
+++ b/src/s2geography/linear-referencing_test.cc
@@ -103,6 +103,18 @@ INSTANTIATE_TEST_SUITE_P(
         LineLocatePointParam{"null_both", std::nullopt, std::nullopt,
                              std::nullopt},
 
+        // Empties
+        LineLocatePointParam{"empty_line", "LINESTRING EMPTY", "POINT (0 0)",
+                             std::nullopt},
+        LineLocatePointParam{"empty_point", "LINESTRING (0 1, 2 3)",
+                             "POINT EMPTY", std::nullopt},
+
+        // Degenerate
+        LineLocatePointParam{"zero_length_line", "LINESTRING (1 1, 1 1)",
+                             "POINT (0 0)", 0.0},
+        LineLocatePointParam{"invalid_line", "LINESTRING (1 1)", "POINT (0 0)",
+                             std::nullopt},
+
         // Endpoints and midpoints
         LineLocatePointParam{"start", "LINESTRING (0 0, 0 2)", "POINT (0 0)",
                              0.0},
@@ -178,6 +190,16 @@ INSTANTIATE_TEST_SUITE_P(
                                   std::nullopt, std::nullopt},
         LineInterpolatePointParam{"null_both", std::nullopt, std::nullopt,
                                   std::nullopt},
+
+        // Empties
+        LineInterpolatePointParam{"empty_line", "LINESTRING EMPTY", 0.0,
+                                  std::nullopt},
+
+        // Degenerate
+        LineInterpolatePointParam{"zero_length_line", "LINESTRING (1 1, 1 1)",
+                                  0.5, "POINT (1 1)"},
+        LineInterpolatePointParam{"invalid_line", "LINESTRING (1 1)", 0.5,
+                                  "POINT (1 1)"},
 
         // Endpoints and midpoints
         LineInterpolatePointParam{"start", "LINESTRING (0 0, 0 2)", 0.0,

--- a/src/s2geography/sedona_udf/sedona_udf_test_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_test_internal.h
@@ -244,9 +244,12 @@ inline void TestResultGeography(
   for (int64_t i = 0; i < result->length; i++) {
     SCOPED_TRACE("expected[" + std::to_string(i) + "]");
     if (geogs[i].get() == nullptr) {
-      ASSERT_FALSE(expected[i].has_value());
+      ASSERT_FALSE(expected[i].has_value())
+          << "Expected " << ::testing::PrintToString(*expected[i])
+          << " but got NULL";
     } else {
-      ASSERT_TRUE(expected[i].has_value());
+      ASSERT_TRUE(expected[i].has_value())
+          << "Expected NULL but got " << ::testing::PrintToString(*geogs[i]);
       ASSERT_THAT(*geogs[i], s2geography::WktEquals6(*expected[i]));
     }
   }


### PR DESCRIPTION
This PR updates ST_LineLocatePoint and ST_LineInterpolatePoint to use the zero copy WKB source. These functions almost always require a full loop over the input edges to calculate the length. The improved version minimizes this to exactly one loop, although the benchmarks highlighted that `S2LngLat::ToPoint()` is a bottleneck for these functions (notably, LineString(100)): even though we'd been doing a single iteration, we were converting each vertex twice in `VisitEdges()`. I fixed this and it's now faster.

```
s2geography-st_linelocatepoint-ArrayArray(geog(LineString(10)), geog(Point))
                        time:   [49.770 ms 49.859 ms 50.000 ms]
                        change: [−36.623% −36.165% −35.701%] (p = 0.00 < 0.05)
                        Performance has improved.

s2geography-st_linelocatepoint-ArrayArray(geog(LineString(100)), geog(Point))
                        time:   [297.98 ms 298.83 ms 299.71 ms]
                        change: [−18.552% −18.231% −17.871%] (p = 0.00 < 0.05)
                        Performance has improved.

s2geography-st_lineinterpolatepoint-ArrayArray(geog(LineString(10)), Float64(0.0, 1.0))
                        time:   [38.724 ms 38.867 ms 38.951 ms]
                        change: [−43.681% −43.336% −42.944%] (p = 0.00 < 0.05)
                        Performance has improved.

s2geography-st_lineinterpolatepoint-ArrayArray(geog(LineString(100)), Float64(0.0, 1.0))
                        time:   [221.25 ms 222.24 ms 223.32 ms]
                        change: [−34.750% −34.363% −33.968%] (p = 0.00 < 0.05)
                        Performance has improved.
```