### PR TITLE
feat: Add native (non S2) edge extractors for shapes

### DIFF
--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -600,7 +600,7 @@ int GeoArrowGeography::num_shapes() const {
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
       return 1;
     default:
-      return 0;
+      return 3;
   }
 }
 
@@ -618,8 +618,19 @@ const S2Shape* GeoArrowGeography::Shape(int id) const {
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
       return &polygons_;
 
+    case GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION:
+      switch (id) {
+        case 0:
+          return &points_;
+        case 1:
+          return &lines_;
+        case 2:
+          return &polygons_;
+        default:
+          throw Exception("GeometryCollection shape ids must be 0, 1, or 2");
+      }
     default:
-      throw Exception("unsupported geometry type");
+      throw Exception("Unsupported geometry type in Shape()");
   }
 }
 
@@ -661,6 +672,68 @@ void GeoArrowGeography::InitIndex() {
   }
 
   indexed_ = true;
+}
+
+std::pair<int, int> GeoArrowGeography::ResolveGlobalEdgeId(
+    int global_edge_id) const {
+  if (geom_.size_nodes == 0) {
+    return std::make_pair(-1, -1);
+  }
+
+  switch (geom_.root->geometry_type) {
+    case GEOARROW_GEOMETRY_TYPE_POINT:
+    case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
+    case GEOARROW_GEOMETRY_TYPE_LINESTRING:
+    case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
+    case GEOARROW_GEOMETRY_TYPE_POLYGON:
+    case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
+      return std::make_pair(0, global_edge_id);
+    case GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION:
+      break;
+    default:
+      throw Exception("unsupported geometry type");
+  }
+
+  if (global_edge_id < points_.num_edges()) {
+    return std::make_pair(0, global_edge_id);
+  }
+
+  global_edge_id -= points_.num_edges();
+  if (global_edge_id < lines_.num_edges()) {
+    return std::make_pair(1, global_edge_id);
+  }
+
+  global_edge_id -= lines_.num_edges();
+  return std::make_pair(2, global_edge_id);
+}
+
+internal::GeoArrowEdge GeoArrowGeography::native_edge(int shape_id,
+                                                      int edge_id) const {
+  S2GEOGRAPHY_DCHECK_GE(geom_.size_nodes, 0);
+  switch (geom_.root->geometry_type) {
+    case GEOARROW_GEOMETRY_TYPE_POINT:
+    case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
+      return points_.native_edge(edge_id);
+    case GEOARROW_GEOMETRY_TYPE_LINESTRING:
+    case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
+      return lines_.native_edge(edge_id);
+    case GEOARROW_GEOMETRY_TYPE_POLYGON:
+    case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
+      return polygons_.native_edge(edge_id);
+    case GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION:
+      switch (shape_id) {
+        case 0:
+          return points_.native_edge(edge_id);
+        case 1:
+          return lines_.native_edge(edge_id);
+        case 2:
+          return polygons_.native_edge(edge_id);
+        default:
+          throw Exception("shape index out of bounds");
+      }
+    default:
+      throw Exception("unsupported geometry type");
+  }
 }
 
 double GeoArrowLoop::GetSignedArea() {
@@ -706,39 +779,6 @@ void GeoArrowLoop::BuildScratch() {
       return true;
     });
   }
-}
-
-std::pair<int, int> GeoArrowGeography::ResolveGlobalEdgeId(
-    int global_edge_id) const {
-  if (geom_.size_nodes == 0) {
-    return std::make_pair(-1, -1);
-  }
-
-  switch (geom_.root->geometry_type) {
-    case GEOARROW_GEOMETRY_TYPE_POINT:
-    case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
-    case GEOARROW_GEOMETRY_TYPE_LINESTRING:
-    case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
-    case GEOARROW_GEOMETRY_TYPE_POLYGON:
-    case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
-      return std::make_pair(0, global_edge_id);
-    case GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION:
-      break;
-    default:
-      throw Exception("unsupported geometry type");
-  }
-
-  if (global_edge_id < points_.num_edges()) {
-    return std::make_pair(0, global_edge_id);
-  }
-
-  global_edge_id -= points_.num_edges();
-  if (global_edge_id < lines_.num_edges()) {
-    return std::make_pair(1, global_edge_id);
-  }
-
-  global_edge_id -= lines_.num_edges();
-  return std::make_pair(2, global_edge_id);
 }
 
 }  // namespace s2geography

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -142,6 +142,17 @@ S2Shape::ChainPosition GeoArrowPointShape::chain_position(int e) const {
 
 S2Shape::TypeTag GeoArrowPointShape::type_tag() const { return kTypeTag; }
 
+internal::GeoArrowEdge GeoArrowPointShape::native_edge(int e) const {
+  internal::GeoArrowVertex v = GeoArrowChain(geom_.root() + e).native_vertex(0);
+  return internal::GeoArrowEdge{v, v};
+}
+
+internal::GeoArrowEdge GeoArrowPointShape::native_chain_edge(int /*i*/,
+                                                             int j) const {
+  internal::GeoArrowVertex v = GeoArrowChain(geom_.root() + j).native_vertex(0);
+  return internal::GeoArrowEdge{v, v};
+}
+
 GeoArrowLaxPolylineShape::GeoArrowLaxPolylineShape(
     struct GeoArrowGeometryView geom) {
   Init(geom);
@@ -237,6 +248,16 @@ S2Shape::ChainPosition GeoArrowLaxPolylineShape::chain_position(int e) const {
 }
 
 S2Shape::TypeTag GeoArrowLaxPolylineShape::type_tag() const { return kTypeTag; }
+
+internal::GeoArrowEdge GeoArrowLaxPolylineShape::native_edge(int e) const {
+  ChainPosition pos = GeoArrowLaxPolylineShape::chain_position(e);
+  return GeoArrowLaxPolylineShape::native_chain_edge(pos.chain_id, pos.offset);
+}
+
+internal::GeoArrowEdge GeoArrowLaxPolylineShape::native_chain_edge(int i,
+                                                                   int j) const {
+  return GeoArrowChain(geom_.root() + i).native_edge(j);
+}
 
 // --- GeoArrowLaxPolygonShape ---
 
@@ -347,6 +368,16 @@ S2Shape::ChainPosition GeoArrowLaxPolygonShape::chain_position(int e) const {
 }
 
 S2Shape::TypeTag GeoArrowLaxPolygonShape::type_tag() const { return kTypeTag; }
+
+internal::GeoArrowEdge GeoArrowLaxPolygonShape::native_edge(int e) const {
+  ChainPosition pos = GeoArrowLaxPolygonShape::chain_position(e);
+  return GeoArrowLaxPolygonShape::native_chain_edge(pos.chain_id, pos.offset);
+}
+
+internal::GeoArrowEdge GeoArrowLaxPolygonShape::native_chain_edge(int i,
+                                                                  int j) const {
+  return GeoArrowChain(&loops_[i]).native_edge(j);
+}
 
 bool GeoArrowLaxPolygonShape::BruteForceContains(
     const S2Point& pt, const S2Shape::ReferencePoint& reference) const {

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -599,12 +599,15 @@ int GeoArrowGeography::num_shapes() const {
     case GEOARROW_GEOMETRY_TYPE_POLYGON:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
       return 1;
-    default:
+    case GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION:
       return 3;
+    default:
+      throw Exception("Unsupported geometry type");
   }
 }
 
 const S2Shape* GeoArrowGeography::Shape(int id) const {
+  S2GEOGRAPHY_DCHECK_GE(geom_.size_nodes, 0);
   switch (geom_.root->geometry_type) {
     case GEOARROW_GEOMETRY_TYPE_POINT:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -254,8 +254,8 @@ internal::GeoArrowEdge GeoArrowLaxPolylineShape::native_edge(int e) const {
   return GeoArrowLaxPolylineShape::native_chain_edge(pos.chain_id, pos.offset);
 }
 
-internal::GeoArrowEdge GeoArrowLaxPolylineShape::native_chain_edge(int i,
-                                                                   int j) const {
+internal::GeoArrowEdge GeoArrowLaxPolylineShape::native_chain_edge(
+    int i, int j) const {
   return GeoArrowChain(geom_.root() + i).native_edge(j);
 }
 

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -71,7 +71,7 @@ class GeoArrowPointShape : public S2Shape {
   ChainPosition chain_position(int e) const override;
   TypeTag type_tag() const override;
 
-internal::GeoArrowEdge native_edge(int e) const;
+  internal::GeoArrowEdge native_edge(int e) const;
   internal::GeoArrowEdge native_chain_edge(int i, int j) const;
 
  private:

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -71,6 +71,9 @@ class GeoArrowPointShape : public S2Shape {
   ChainPosition chain_position(int e) const override;
   TypeTag type_tag() const override;
 
+internal::GeoArrowEdge native_edge(int e) const;
+  internal::GeoArrowEdge native_chain_edge(int i, int j) const;
+
  private:
   GeoArrowGeom geom_;
 };
@@ -113,6 +116,9 @@ class GeoArrowLaxPolylineShape : public S2Shape {
   Edge chain_edge(int i, int j) const override;
   ChainPosition chain_position(int e) const override;
   TypeTag type_tag() const override;
+
+  internal::GeoArrowEdge native_edge(int e) const;
+  internal::GeoArrowEdge native_chain_edge(int i, int j) const;
 
  private:
   GeoArrowGeom geom_{};
@@ -182,6 +188,9 @@ class GeoArrowLaxPolygonShape : public S2Shape {
   Edge chain_edge(int i, int j) const override;
   ChainPosition chain_position(int e) const override;
   TypeTag type_tag() const override;
+
+  internal::GeoArrowEdge native_edge(int e) const;
+  internal::GeoArrowEdge native_chain_edge(int i, int j) const;
 
   /// \brief Check containment using a brute force edge crossing approach
   ///

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -71,7 +71,14 @@ class GeoArrowPointShape : public S2Shape {
   ChainPosition chain_position(int e) const override;
   TypeTag type_tag() const override;
 
+  /// \brief Extract a native edge with a given identifier
+  ///
+  /// Unlike edge(), the native edge is a faithful representation of the source
+  /// (e.g., does not drop ZM information or roundtrip lon/lat values to
+  /// S2Point space)
   internal::GeoArrowEdge native_edge(int e) const;
+
+  /// \brief Extract a native edge within a chain
   internal::GeoArrowEdge native_chain_edge(int i, int j) const;
 
  private:
@@ -117,7 +124,14 @@ class GeoArrowLaxPolylineShape : public S2Shape {
   ChainPosition chain_position(int e) const override;
   TypeTag type_tag() const override;
 
+  /// \brief Extract a native edge with a given identifier
+  ///
+  /// Unlike edge(), the native edge is a faithful representation of the source
+  /// (e.g., does not drop ZM information or roundtrip lon/lat values to
+  /// S2Point space)
   internal::GeoArrowEdge native_edge(int e) const;
+
+  /// \brief Extract a native edge within a chain
   internal::GeoArrowEdge native_chain_edge(int i, int j) const;
 
  private:
@@ -189,7 +203,18 @@ class GeoArrowLaxPolygonShape : public S2Shape {
   ChainPosition chain_position(int e) const override;
   TypeTag type_tag() const override;
 
+  /// \brief Extract a native edge with a given identifier
+  ///
+  /// Unlike edge(), the native edge is a faithful representation of the source
+  /// (e.g., does not drop ZM information or roundtrip lon/lat values to
+  /// S2Point space).
+  ///
+  /// Note that for polygons specifically, this will correctly refer to the
+  /// source edge but that the source edge may have been reoriented when
+  /// constructing the shape to ensure consistent winding order.
   internal::GeoArrowEdge native_edge(int e) const;
+
+  /// \brief Extract a native edge within a chain
   internal::GeoArrowEdge native_chain_edge(int i, int j) const;
 
   /// \brief Check containment using a brute force edge crossing approach
@@ -376,7 +401,19 @@ class GeoArrowGeography {
     return true;
   }
 
+  /// \brief Resolve a shape_id/edge_id pair
+  ///
+  /// Given an edge identifier derived from a sequential visit of all edges
+  /// (e.g., VisitEdges()), derive a shape_id/edge_id pair. This is to support
+  /// brute force shortcuts that give identical information as what would be
+  /// derived from obtaining an edge from an S2ShapeIndex.
   std::pair<int, int> ResolveGlobalEdgeId(int global_edge_id) const;
+
+  /// \brief Resolve the source edge given a shape_id and edge_id
+  ///
+  /// This is useful to reconstruct ZM information after querying a shape index
+  /// for an edge.
+  internal::GeoArrowEdge native_edge(int shape_id, int edge_id) const;
 
  private:
   struct GeoArrowGeometryView geom_{};

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -1314,6 +1314,26 @@ TEST_F(GeoArrowGeographyTest, MultiPoint) {
   auto shape = geog.Shape(0);
   ASSERT_NE(shape, nullptr);
   EXPECT_EQ(shape->num_edges(), 3);
+
+  EXPECT_EQ(geog.ResolveGlobalEdgeId(0), std::make_pair(0, 0));
+}
+
+TEST_F(GeoArrowGeographyTest, PointNativeEdge) {
+  auto geog = MakeGeography(
+      "MULTIPOINT ZM ((0 1 100 200), (2 3 101 201), (4 5 103 203))");
+  auto e_first = geog.native_edge(0, 0);
+  EXPECT_DOUBLE_EQ(e_first.v0.lng, 0);
+  EXPECT_DOUBLE_EQ(e_first.v0.lat, 1);
+  EXPECT_DOUBLE_EQ(e_first.v0.zm[0], 100);
+  EXPECT_DOUBLE_EQ(e_first.v0.zm[1], 200);
+  EXPECT_EQ(e_first.v0, e_first.v1);
+
+  auto e_last = geog.native_edge(0, 2);
+  EXPECT_DOUBLE_EQ(e_last.v0.lng, 4);
+  EXPECT_DOUBLE_EQ(e_last.v0.lat, 5);
+  EXPECT_DOUBLE_EQ(e_last.v0.zm[0], 103);
+  EXPECT_DOUBLE_EQ(e_last.v0.zm[1], 203);
+  EXPECT_EQ(e_last.v0, e_last.v1);
 }
 
 TEST_F(GeoArrowGeographyTest, EmptyPoint) {
@@ -1337,6 +1357,32 @@ TEST_F(GeoArrowGeographyTest, Linestring) {
   ASSERT_NE(shape, nullptr);
   EXPECT_EQ(shape->dimension(), 1);
   EXPECT_EQ(shape->num_edges(), 2);
+
+  EXPECT_EQ(geog.ResolveGlobalEdgeId(0), std::make_pair(0, 0));
+}
+
+TEST_F(GeoArrowGeographyTest, LinestringNativeEdge) {
+  auto geog =
+      MakeGeography("LINESTRING ZM (0 1 100 200, 2 3 101 201, 4 5 103 203)");
+  auto e_first = geog.native_edge(0, 0);
+  EXPECT_DOUBLE_EQ(e_first.v0.lng, 0);
+  EXPECT_DOUBLE_EQ(e_first.v0.lat, 1);
+  EXPECT_DOUBLE_EQ(e_first.v0.zm[0], 100);
+  EXPECT_DOUBLE_EQ(e_first.v0.zm[1], 200);
+  EXPECT_DOUBLE_EQ(e_first.v1.lng, 2);
+  EXPECT_DOUBLE_EQ(e_first.v1.lat, 3);
+  EXPECT_DOUBLE_EQ(e_first.v1.zm[0], 101);
+  EXPECT_DOUBLE_EQ(e_first.v1.zm[1], 201);
+
+  auto e_last = geog.native_edge(0, 1);
+  EXPECT_DOUBLE_EQ(e_last.v0.lng, 2);
+  EXPECT_DOUBLE_EQ(e_last.v0.lat, 3);
+  EXPECT_DOUBLE_EQ(e_last.v0.zm[0], 101);
+  EXPECT_DOUBLE_EQ(e_last.v0.zm[1], 201);
+  EXPECT_DOUBLE_EQ(e_last.v1.lng, 4);
+  EXPECT_DOUBLE_EQ(e_last.v1.lat, 5);
+  EXPECT_DOUBLE_EQ(e_last.v1.zm[0], 103);
+  EXPECT_DOUBLE_EQ(e_last.v1.zm[1], 203);
 }
 
 TEST_F(GeoArrowGeographyTest, MultiLinestring) {
@@ -1360,6 +1406,34 @@ TEST_F(GeoArrowGeographyTest, Polygon) {
   ASSERT_NE(shape, nullptr);
   EXPECT_EQ(shape->dimension(), 2);
   EXPECT_EQ(shape->num_edges(), 3);
+
+  EXPECT_EQ(geog.ResolveGlobalEdgeId(0), std::make_pair(0, 0));
+}
+
+TEST_F(GeoArrowGeographyTest, PolygonNativeEdge) {
+  // Note: the input ring (0 0, 0 1, 1 0, 0 0) is clockwise on the sphere,
+  // so it gets reversed to (0 0, 1 0, 0 1, 0 0).
+  auto geog = MakeGeography(
+      "POLYGON ZM ((0 0 100 200, 0 1 101 201, 1 0 103 203, 0 0 100 200))");
+  auto e_first = geog.native_edge(0, 0);
+  EXPECT_DOUBLE_EQ(e_first.v0.lng, 0);
+  EXPECT_DOUBLE_EQ(e_first.v0.lat, 0);
+  EXPECT_DOUBLE_EQ(e_first.v0.zm[0], 100);
+  EXPECT_DOUBLE_EQ(e_first.v0.zm[1], 200);
+  EXPECT_DOUBLE_EQ(e_first.v1.lng, 1);
+  EXPECT_DOUBLE_EQ(e_first.v1.lat, 0);
+  EXPECT_DOUBLE_EQ(e_first.v1.zm[0], 103);
+  EXPECT_DOUBLE_EQ(e_first.v1.zm[1], 203);
+
+  auto e_last = geog.native_edge(0, 2);
+  EXPECT_DOUBLE_EQ(e_last.v0.lng, 0);
+  EXPECT_DOUBLE_EQ(e_last.v0.lat, 1);
+  EXPECT_DOUBLE_EQ(e_last.v0.zm[0], 101);
+  EXPECT_DOUBLE_EQ(e_last.v0.zm[1], 201);
+  EXPECT_DOUBLE_EQ(e_last.v1.lng, 0);
+  EXPECT_DOUBLE_EQ(e_last.v1.lat, 0);
+  EXPECT_DOUBLE_EQ(e_last.v1.zm[0], 100);
+  EXPECT_DOUBLE_EQ(e_last.v1.zm[1], 200);
 }
 
 TEST_F(GeoArrowGeographyTest, MultiPolygon) {

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -280,6 +280,140 @@ TEST(GeoArrowGeom, DefaultConstructor) {
   EXPECT_EQ(count, 0);
 }
 
+TEST(GeoArrowGeom, VisitNativeVerticesPoint) {
+  auto geom = TestGeometry::FromWKT("POINT ZM (1 2 3 4)");
+  GeoArrowGeom g(geom.geom());
+
+  std::vector<internal::GeoArrowVertex> vertices;
+  g.VisitNativeVertices([&](const internal::GeoArrowVertex& v) {
+    vertices.push_back(v);
+    return true;
+  });
+  ASSERT_EQ(vertices.size(), 1);
+  EXPECT_DOUBLE_EQ(vertices[0].lng, 1);
+  EXPECT_DOUBLE_EQ(vertices[0].lat, 2);
+  EXPECT_DOUBLE_EQ(vertices[0].zm[0], 3);
+  EXPECT_DOUBLE_EQ(vertices[0].zm[1], 4);
+}
+
+TEST(GeoArrowGeom, VisitNativeVerticesLineString) {
+  auto geom =
+      TestGeometry::FromWKT("LINESTRING ZM (0 0 10 20, 1 1 11 21, 2 2 12 22)");
+  GeoArrowGeom g(geom.geom());
+
+  std::vector<internal::GeoArrowVertex> vertices;
+  g.VisitNativeVertices([&](const internal::GeoArrowVertex& v) {
+    vertices.push_back(v);
+    return true;
+  });
+  ASSERT_EQ(vertices.size(), 3);
+  EXPECT_DOUBLE_EQ(vertices[0].lng, 0);
+  EXPECT_DOUBLE_EQ(vertices[0].lat, 0);
+  EXPECT_DOUBLE_EQ(vertices[0].zm[0], 10);
+  EXPECT_DOUBLE_EQ(vertices[0].zm[1], 20);
+  EXPECT_DOUBLE_EQ(vertices[1].lng, 1);
+  EXPECT_DOUBLE_EQ(vertices[1].lat, 1);
+  EXPECT_DOUBLE_EQ(vertices[1].zm[0], 11);
+  EXPECT_DOUBLE_EQ(vertices[1].zm[1], 21);
+  EXPECT_DOUBLE_EQ(vertices[2].lng, 2);
+  EXPECT_DOUBLE_EQ(vertices[2].lat, 2);
+  EXPECT_DOUBLE_EQ(vertices[2].zm[0], 12);
+  EXPECT_DOUBLE_EQ(vertices[2].zm[1], 22);
+}
+
+TEST(GeoArrowGeom, VisitNativeEdgesLineString) {
+  auto geom =
+      TestGeometry::FromWKT("LINESTRING ZM (0 0 10 20, 1 1 11 21, 2 2 12 22)");
+  GeoArrowGeom g(geom.geom());
+
+  std::vector<internal::GeoArrowEdge> edges;
+  g.VisitNativeEdges([&](const internal::GeoArrowEdge& e) {
+    edges.push_back(e);
+    return true;
+  });
+  ASSERT_EQ(edges.size(), 2);
+  EXPECT_DOUBLE_EQ(edges[0].v0.lng, 0);
+  EXPECT_DOUBLE_EQ(edges[0].v0.lat, 0);
+  EXPECT_DOUBLE_EQ(edges[0].v0.zm[0], 10);
+  EXPECT_DOUBLE_EQ(edges[0].v0.zm[1], 20);
+  EXPECT_DOUBLE_EQ(edges[0].v1.lng, 1);
+  EXPECT_DOUBLE_EQ(edges[0].v1.lat, 1);
+  EXPECT_DOUBLE_EQ(edges[0].v1.zm[0], 11);
+  EXPECT_DOUBLE_EQ(edges[0].v1.zm[1], 21);
+  EXPECT_DOUBLE_EQ(edges[1].v0.lng, 1);
+  EXPECT_DOUBLE_EQ(edges[1].v0.lat, 1);
+  EXPECT_DOUBLE_EQ(edges[1].v0.zm[0], 11);
+  EXPECT_DOUBLE_EQ(edges[1].v0.zm[1], 21);
+  EXPECT_DOUBLE_EQ(edges[1].v1.lng, 2);
+  EXPECT_DOUBLE_EQ(edges[1].v1.lat, 2);
+  EXPECT_DOUBLE_EQ(edges[1].v1.zm[0], 12);
+  EXPECT_DOUBLE_EQ(edges[1].v1.zm[1], 22);
+}
+
+TEST(GeoArrowGeom, VisitNativeEdgesSingleVertex) {
+  auto geom = TestGeometry::FromWKT("POINT ZM (5 10 15 20)");
+  GeoArrowGeom g(geom.geom());
+
+  int count = 0;
+  g.VisitNativeEdges([&](const internal::GeoArrowEdge&) {
+    ++count;
+    return true;
+  });
+  EXPECT_EQ(count, 0);
+}
+
+TEST(GeoArrowGeom, VisitNativeEdgesPolygon) {
+  auto geom = TestGeometry::FromWKT(
+      "POLYGON ZM ((0 0 1 2, 10 0 3 4, 10 10 5 6, 0 10 7 8, 0 0 1 2))");
+  GeoArrowGeom g(geom.geom());
+
+  std::vector<internal::GeoArrowEdge> edges;
+  g.VisitNativeEdges([&](const internal::GeoArrowEdge& e) {
+    edges.push_back(e);
+    return true;
+  });
+  ASSERT_EQ(edges.size(), 4);
+
+  EXPECT_DOUBLE_EQ(edges[0].v0.lng, 0);
+  EXPECT_DOUBLE_EQ(edges[0].v0.lat, 0);
+  EXPECT_DOUBLE_EQ(edges[0].v0.zm[0], 1);
+  EXPECT_DOUBLE_EQ(edges[0].v0.zm[1], 2);
+  EXPECT_DOUBLE_EQ(edges[0].v1.lng, 10);
+  EXPECT_DOUBLE_EQ(edges[0].v1.lat, 0);
+  EXPECT_DOUBLE_EQ(edges[0].v1.zm[0], 3);
+  EXPECT_DOUBLE_EQ(edges[0].v1.zm[1], 4);
+  EXPECT_DOUBLE_EQ(edges[3].v0.lng, 0);
+  EXPECT_DOUBLE_EQ(edges[3].v0.lat, 10);
+  EXPECT_DOUBLE_EQ(edges[3].v0.zm[0], 7);
+  EXPECT_DOUBLE_EQ(edges[3].v0.zm[1], 8);
+  EXPECT_DOUBLE_EQ(edges[3].v1.lng, 0);
+  EXPECT_DOUBLE_EQ(edges[3].v1.lat, 0);
+  EXPECT_DOUBLE_EQ(edges[3].v1.zm[0], 1);
+  EXPECT_DOUBLE_EQ(edges[3].v1.zm[1], 2);
+}
+
+TEST(GeoArrowChain, NativeVertexAndEdge) {
+  auto geom = TestGeometry::FromWKT(
+      "LINESTRING ZM (3 4 100 200, 5 6 101 201, 7 8 102 202)");
+  GeoArrowChain chain(geom.geom().root);
+
+  auto v = chain.native_vertex(1);
+  EXPECT_DOUBLE_EQ(v.lng, 5);
+  EXPECT_DOUBLE_EQ(v.lat, 6);
+  EXPECT_DOUBLE_EQ(v.zm[0], 101);
+  EXPECT_DOUBLE_EQ(v.zm[1], 201);
+
+  auto e = chain.native_edge(0);
+  EXPECT_DOUBLE_EQ(e.v0.lng, 3);
+  EXPECT_DOUBLE_EQ(e.v0.lat, 4);
+  EXPECT_DOUBLE_EQ(e.v0.zm[0], 100);
+  EXPECT_DOUBLE_EQ(e.v0.zm[1], 200);
+  EXPECT_DOUBLE_EQ(e.v1.lng, 5);
+  EXPECT_DOUBLE_EQ(e.v1.lat, 6);
+  EXPECT_DOUBLE_EQ(e.v1.zm[0], 101);
+  EXPECT_DOUBLE_EQ(e.v1.zm[1], 201);
+}
+
 // Specifically check loop functions
 
 TEST(GeoArrowLoop, LoopMetrics) {

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -294,6 +294,14 @@ TEST(GeoArrowGeom, VisitNativeVerticesPoint) {
   EXPECT_DOUBLE_EQ(vertices[0].lat, 2);
   EXPECT_DOUBLE_EQ(vertices[0].zm[0], 3);
   EXPECT_DOUBLE_EQ(vertices[0].zm[1], 4);
+
+  // Early termination
+  int count = 0;
+  EXPECT_FALSE(g.VisitNativeVertices([&](const internal::GeoArrowVertex&) {
+    ++count;
+    return false;
+  }));
+  EXPECT_EQ(count, 1);
 }
 
 TEST(GeoArrowGeom, VisitNativeVerticesLineString) {
@@ -319,6 +327,14 @@ TEST(GeoArrowGeom, VisitNativeVerticesLineString) {
   EXPECT_DOUBLE_EQ(vertices[2].lat, 2);
   EXPECT_DOUBLE_EQ(vertices[2].zm[0], 12);
   EXPECT_DOUBLE_EQ(vertices[2].zm[1], 22);
+
+  // Early termination: stop after first vertex
+  int count = 0;
+  EXPECT_FALSE(g.VisitNativeVertices([&](const internal::GeoArrowVertex&) {
+    ++count;
+    return false;
+  }));
+  EXPECT_EQ(count, 1);
 }
 
 TEST(GeoArrowGeom, VisitNativeEdgesLineString) {
@@ -348,6 +364,14 @@ TEST(GeoArrowGeom, VisitNativeEdgesLineString) {
   EXPECT_DOUBLE_EQ(edges[1].v1.lat, 2);
   EXPECT_DOUBLE_EQ(edges[1].v1.zm[0], 12);
   EXPECT_DOUBLE_EQ(edges[1].v1.zm[1], 22);
+
+  // Early termination: stop after first edge
+  int count = 0;
+  EXPECT_FALSE(g.VisitNativeEdges([&](const internal::GeoArrowEdge&) {
+    ++count;
+    return false;
+  }));
+  EXPECT_EQ(count, 1);
 }
 
 TEST(GeoArrowGeom, VisitNativeEdgesSingleVertex) {
@@ -390,6 +414,30 @@ TEST(GeoArrowGeom, VisitNativeEdgesPolygon) {
   EXPECT_DOUBLE_EQ(edges[3].v1.lat, 0);
   EXPECT_DOUBLE_EQ(edges[3].v1.zm[0], 1);
   EXPECT_DOUBLE_EQ(edges[3].v1.zm[1], 2);
+
+  // Early termination: stop after first edge
+  int count = 0;
+  EXPECT_FALSE(g.VisitNativeEdges([&](const internal::GeoArrowEdge&) {
+    ++count;
+    return false;
+  }));
+  EXPECT_EQ(count, 1);
+}
+
+TEST(GeoArrowChain, VertexAndEdge) {
+  auto geom = TestGeometry::FromWKT("LINESTRING (3 4, 5 6, 7 8)");
+  GeoArrowChain chain(geom.geom().root);
+
+  auto v = chain.vertex(1);
+  EXPECT_EQ(v, S2LatLng::FromDegrees(6, 5).ToPoint());
+
+  auto e = chain.edge(0);
+  EXPECT_EQ(e.v0, S2LatLng::FromDegrees(4, 3).ToPoint());
+  EXPECT_EQ(e.v1, S2LatLng::FromDegrees(6, 5).ToPoint());
+
+  e = chain.edge(1);
+  EXPECT_EQ(e.v0, S2LatLng::FromDegrees(6, 5).ToPoint());
+  EXPECT_EQ(e.v1, S2LatLng::FromDegrees(8, 7).ToPoint());
 }
 
 TEST(GeoArrowChain, NativeVertexAndEdge) {
@@ -412,6 +460,16 @@ TEST(GeoArrowChain, NativeVertexAndEdge) {
   EXPECT_DOUBLE_EQ(e.v1.lat, 6);
   EXPECT_DOUBLE_EQ(e.v1.zm[0], 101);
   EXPECT_DOUBLE_EQ(e.v1.zm[1], 201);
+
+  e = chain.native_edge(1);
+  EXPECT_DOUBLE_EQ(e.v0.lng, 5);
+  EXPECT_DOUBLE_EQ(e.v0.lat, 6);
+  EXPECT_DOUBLE_EQ(e.v0.zm[0], 101);
+  EXPECT_DOUBLE_EQ(e.v0.zm[1], 201);
+  EXPECT_DOUBLE_EQ(e.v1.lng, 7);
+  EXPECT_DOUBLE_EQ(e.v1.lat, 8);
+  EXPECT_DOUBLE_EQ(e.v1.zm[0], 102);
+  EXPECT_DOUBLE_EQ(e.v1.zm[1], 202);
 }
 
 // Specifically check loop functions
@@ -554,12 +612,14 @@ TEST(GeoArrowPointShape, MultiPoint) {
 
 TEST(GeoArrowPointShape, BigEndianWKB) {
   // clang-format off
-  // Big-endian WKB for POINT (30 10)
+  // Big-endian WKB for POINT ZM (30 10 5 15)
   std::vector<uint8_t> wkb = {
     0x00,                                      // big endian
-    0x00, 0x00, 0x00, 0x01,                    // type: Point
+    0x00, 0x00, 0x0b, 0xb9,                    // type: Point ZM (3001)
     0x40, 0x3e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // x: 30.0
     0x40, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // y: 10.0
+    0x40, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // z: 5.0
+    0x40, 0x2e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // m: 15.0
   };
   // clang-format on
 
@@ -568,6 +628,17 @@ TEST(GeoArrowPointShape, BigEndianWKB) {
   EXPECT_EQ(shape.num_vertices(), 1);
   EXPECT_EQ(shape.num_edges(), 1);
   EXPECT_EQ(shape.num_chains(), 1);
+
+  // The point's degenerate edge should have correct native coordinates
+  auto e = shape.native_edge(0);
+  EXPECT_DOUBLE_EQ(e.v0.lng, 30);
+  EXPECT_DOUBLE_EQ(e.v0.lat, 10);
+  EXPECT_DOUBLE_EQ(e.v0.zm[0], 5);
+  EXPECT_DOUBLE_EQ(e.v0.zm[1], 15);
+  EXPECT_DOUBLE_EQ(e.v1.lng, 30);
+  EXPECT_DOUBLE_EQ(e.v1.lat, 10);
+  EXPECT_DOUBLE_EQ(e.v1.zm[0], 5);
+  EXPECT_DOUBLE_EQ(e.v1.zm[1], 15);
 
   ValidateShape(shape);
 }
@@ -823,6 +894,16 @@ TEST(GeoArrowLaxPolygonShape, SimpleTriangle) {
   EXPECT_TRUE(shape.BruteForceContains(
       S2LatLng::FromDegrees(0.1, 0.1).ToPoint(), reference_out));
 
+  // Check loops for hole status
+  std::vector<S2Point> scratch;
+  std::vector<bool> hole_flags;
+  shape.geom().VisitLoops(&scratch, [&](GeoArrowLoop loop) {
+    hole_flags.push_back(loop.is_hole());
+    return true;
+  });
+  ASSERT_EQ(hole_flags.size(), 1);
+  EXPECT_FALSE(hole_flags[0]);  // shell
+
   ValidateShape(shape);
 }
 
@@ -878,6 +959,17 @@ TEST(GeoArrowLaxPolygonShape, PolygonWithHole) {
   EXPECT_FALSE(shape.BruteForceContains(S2LatLng::FromDegrees(3, 3).ToPoint(),
                                         reference_out));
 
+  // Check loops for hole status
+  std::vector<S2Point> scratch;
+  std::vector<bool> hole_flags;
+  shape.geom().VisitLoops(&scratch, [&](GeoArrowLoop loop) {
+    hole_flags.push_back(loop.is_hole());
+    return true;
+  });
+  ASSERT_EQ(hole_flags.size(), 2);
+  EXPECT_FALSE(hole_flags[0]);  // shell
+  EXPECT_TRUE(hole_flags[1]);   // hole
+
   ValidateShape(shape);
 }
 
@@ -895,6 +987,17 @@ TEST(GeoArrowLaxPolygonShape, MultiPolygon2Components) {
   EXPECT_EQ(pos.chain_id, 1);
   EXPECT_EQ(pos.offset, 2);
 
+  // Check loops for hole status
+  std::vector<S2Point> scratch;
+  std::vector<bool> hole_flags;
+  shape.geom().VisitLoops(&scratch, [&](GeoArrowLoop loop) {
+    hole_flags.push_back(loop.is_hole());
+    return true;
+  });
+  ASSERT_EQ(hole_flags.size(), 2);
+  EXPECT_FALSE(hole_flags[0]);  // shell
+  EXPECT_FALSE(hole_flags[1]);  // shell
+
   ValidateShape(shape);
 }
 
@@ -906,6 +1009,18 @@ TEST(GeoArrowLaxPolygonShape, MultiPolygon3Components) {
   GeoArrowLaxPolygonShape shape(geom.geom());
   EXPECT_EQ(shape.num_edges(), 9);  // 3 + 3 + 3
   EXPECT_EQ(shape.num_chains(), 3);
+
+  // Check loops for hole status
+  std::vector<S2Point> scratch;
+  std::vector<bool> hole_flags;
+  shape.geom().VisitLoops(&scratch, [&](GeoArrowLoop loop) {
+    hole_flags.push_back(loop.is_hole());
+    return true;
+  });
+  ASSERT_EQ(hole_flags.size(), 3);
+  EXPECT_FALSE(hole_flags[0]);  // shell
+  EXPECT_FALSE(hole_flags[1]);  // shell
+  EXPECT_FALSE(hole_flags[2]);  // shell
 
   ValidateShape(shape);
 }
@@ -955,6 +1070,18 @@ TEST(GeoArrowLaxPolygonShape, MultiPolygonWithHoles) {
                                         reference_out));
   EXPECT_TRUE(shape.BruteForceContains(
       S2LatLng::FromDegrees(20.1, 20.1).ToPoint(), reference_out));
+
+  // Check loops for hole status
+  std::vector<S2Point> scratch;
+  std::vector<bool> hole_flags;
+  shape.geom().VisitLoops(&scratch, [&](GeoArrowLoop loop) {
+    hole_flags.push_back(loop.is_hole());
+    return true;
+  });
+  ASSERT_EQ(hole_flags.size(), 3);
+  EXPECT_FALSE(hole_flags[0]);  // shell
+  EXPECT_TRUE(hole_flags[1]);   // hole
+  EXPECT_FALSE(hole_flags[2]);  // shell
 
   ValidateShape(shape);
 }

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -113,7 +113,10 @@ class TestGeometry {
 
 /// \brief Utility to sanity check an S2Shape, which has global edge ids
 /// but also has edges organized into chains.
-void ValidateShape(const S2Shape& shape) {
+template <typename T>
+void ValidateShape(const T& shape) {
+  EXPECT_EQ(shape.type_tag(), T::kTypeTag);
+
   int num_edges = shape.num_edges();
   int num_chains = shape.num_chains();
 
@@ -143,6 +146,17 @@ void ValidateShape(const S2Shape& shape) {
     auto ce = shape.chain_edge(pos.chain_id, pos.offset);
     EXPECT_EQ(edge.v0, ce.v0) << "edge " << e;
     EXPECT_EQ(edge.v1, ce.v1) << "edge " << e;
+
+    auto native_edge = shape.native_edge(e);
+    auto native_ce = shape.native_chain_edge(pos.chain_id, pos.offset);
+    EXPECT_EQ(native_edge.v0, native_ce.v0) << "edge " << e;
+    EXPECT_EQ(native_edge.v1, native_ce.v1) << "edge " << e;
+
+    auto edge_check = S2Shape::Edge{
+        S2LatLng::FromDegrees(native_edge.v0.lat, native_edge.v0.lng).ToPoint(),
+        S2LatLng::FromDegrees(native_edge.v1.lat, native_edge.v1.lng).ToPoint(),
+    };
+    EXPECT_EQ(edge_check, edge);
   }
 }
 
@@ -639,6 +653,10 @@ TEST(GeoArrowPointShape, BigEndianWKB) {
   EXPECT_DOUBLE_EQ(e.v1.lat, 10);
   EXPECT_DOUBLE_EQ(e.v1.zm[0], 5);
   EXPECT_DOUBLE_EQ(e.v1.zm[1], 15);
+
+  // Also check the chain edge
+  auto chain_e = shape.native_chain_edge(0, 0);
+  EXPECT_EQ(chain_e, e);
 
   ValidateShape(shape);
 }

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -104,79 +104,73 @@ bool VisitLngLat(const struct GeoArrowGeometryNode* node, int64_t offset,
   return true;
 }
 
-/// \brief Visit sequential longitudes and latitudes of a single node
-///
-/// This is a building block for other visitors. This utility visits each
-/// pair of sequential vertices (i.e., "edges").
+struct GeoArrowVertex {
+  double lng;
+  double lat;
+  double zm[2];
+};
+
+struct GeoArrowEdge {
+  GeoArrowVertex v0;
+  GeoArrowVertex v1;
+};
+
+/// \brief Visit native vertices
 template <typename Visit>
-bool VisitLngLatEdges(const struct GeoArrowGeometryNode* node, int64_t offset,
-                      int64_t n, Visit&& visit) {
+bool VisitLngLatZM(const struct GeoArrowGeometryNode* node, int64_t offset,
+                   int64_t n, Visit&& visit) {
   S2GEOGRAPHY_DCHECK_GE(offset, 0);
   S2GEOGRAPHY_DCHECK_GE(n, 0);
   if (n == 0) {
     return true;
   }
 
-  S2GEOGRAPHY_DCHECK_LT(offset + n, static_cast<int64_t>(node->size));
+  S2GEOGRAPHY_DCHECK_LE(offset + n, static_cast<int64_t>(node->size));
 
   const uint8_t* lngs = node->coords[0] + offset * node->coord_stride[0];
   const uint8_t* lats = node->coords[1] + offset * node->coord_stride[1];
-  double lng0, lat0, lng1, lat1;
+  const uint8_t* zm0s = node->coords[2] + offset * node->coord_stride[2];
+  const uint8_t* zm1s = node->coords[3] + offset * node->coord_stride[3];
+  struct GeoArrowVertex v;
 
   if (node->flags & GEOARROW_GEOMETRY_NODE_FLAG_SWAP_ENDIAN) {
     uint64_t tmp;
-
-    // Extract the first vertex
-    memcpy(&tmp, lngs, sizeof(double));
-    tmp = GEOARROW_BSWAP64(tmp);
-    memcpy(&lng0, &tmp, sizeof(double));
-
-    memcpy(&tmp, lats, sizeof(double));
-    tmp = GEOARROW_BSWAP64(tmp);
-    memcpy(&lat0, &tmp, sizeof(double));
-
-    lngs += node->coord_stride[0];
-    lats += node->coord_stride[1];
-
     for (int64_t i = 0; i < n; ++i) {
-      // Extract the next vertex
       memcpy(&tmp, lngs, sizeof(double));
       tmp = GEOARROW_BSWAP64(tmp);
-      memcpy(&lng1, &tmp, sizeof(double));
+      memcpy(&v.lng, &tmp, sizeof(double));
 
       memcpy(&tmp, lats, sizeof(double));
       tmp = GEOARROW_BSWAP64(tmp);
-      memcpy(&lat1, &tmp, sizeof(double));
+      memcpy(&v.lat, &tmp, sizeof(double));
 
-      // Visit
-      if (!visit(lng0, lat0, lng1, lat1)) return false;
+      memcpy(&tmp, zm0s, sizeof(double));
+      tmp = GEOARROW_BSWAP64(tmp);
+      memcpy(&v.zm[0], &tmp, sizeof(double));
 
-      // Move this vertex to the previous vertex and advance
-      lng0 = lng1;
-      lat0 = lat1;
+      memcpy(&tmp, zm1s, sizeof(double));
+      tmp = GEOARROW_BSWAP64(tmp);
+      memcpy(&v.zm[1], &tmp, sizeof(double));
+
+      if (!visit(v)) return false;
+
       lngs += node->coord_stride[0];
       lats += node->coord_stride[1];
+      zm0s += node->coord_stride[2];
+      zm1s += node->coord_stride[3];
     }
   } else {
-    // Extract the first vertex
-    memcpy(&lng0, lngs, sizeof(double));
-    memcpy(&lat0, lats, sizeof(double));
-    lngs += node->coord_stride[0];
-    lats += node->coord_stride[1];
-
     for (int64_t i = 0; i < n; ++i) {
-      // Extract the next vertex
-      memcpy(&lng1, lngs, sizeof(double));
-      memcpy(&lat1, lats, sizeof(double));
+      memcpy(&v.lng, lngs, sizeof(double));
+      memcpy(&v.lat, lats, sizeof(double));
+      memcpy(&v.zm[0], zm0s, sizeof(double));
+      memcpy(&v.zm[1], zm1s, sizeof(double));
+      if (!visit(v)) return false;
 
-      // Visit
-      if (!visit(lng0, lat0, lng1, lat1)) return false;
-
-      // Move this vertex to the previous vertex and advance
-      lng0 = lng1;
-      lat0 = lat1;
       lngs += node->coord_stride[0];
       lats += node->coord_stride[1];
+      zm0s += node->coord_stride[2];
+      zm1s += node->coord_stride[3];
     }
   }
   return true;
@@ -237,6 +231,60 @@ bool VisitEdges(const struct GeoArrowGeometryNode* node, Visit&& visit) {
   return VisitEdges(node, 0, node->size - 1, visit);
 }
 
+/// \brief Visit a subset of vertices in a sequence as GeoArrowVertex
+template <typename Visit>
+bool VisitNativeVertices(const struct GeoArrowGeometryNode* node,
+                         int64_t offset, int64_t n, Visit&& visit) {
+  return VisitLngLatZM(node, offset, n,
+                       [&](const GeoArrowVertex& v) { return visit(v); });
+}
+
+/// \brief Visit all vertices in a sequence as GeoArrowVertex
+template <typename Visit>
+bool VisitNativeVertices(const struct GeoArrowGeometryNode* node,
+                         Visit&& visit) {
+  return VisitLngLatZM(node, 0, node->size,
+                       [&](const GeoArrowVertex& v) { return visit(v); });
+}
+
+/// \brief Visit a subset of edges in a sequence as GeoArrowEdge
+template <typename Visit>
+bool VisitNativeEdges(const struct GeoArrowGeometryNode* node, int64_t offset,
+                      int64_t n, Visit&& visit) {
+  S2GEOGRAPHY_DCHECK_GE(offset, 0);
+  S2GEOGRAPHY_DCHECK_GE(n, 0);
+
+  if (static_cast<int64_t>(node->size) < offset + n + 1) {
+    return true;
+  }
+
+  GeoArrowEdge e;
+  VisitNativeVertices(node, offset, 1, [&](const GeoArrowVertex& v) {
+    e.v0 = v;
+    return true;
+  });
+
+  return VisitNativeVertices(node, offset + 1, n, [&](const GeoArrowVertex& v) {
+    e.v1 = v;
+    if (!visit(e)) {
+      return false;
+    }
+
+    e.v0 = e.v1;
+    return true;
+  });
+}
+
+/// \brief Visit all edges in a sequence as GeoArrowEdge
+template <typename Visit>
+bool VisitNativeEdges(const struct GeoArrowGeometryNode* node, Visit&& visit) {
+  if (node->size <= 1) {
+    return true;
+  }
+
+  return VisitNativeEdges(node, 0, node->size - 1, visit);
+}
+
 }  // namespace internal
 
 /// \brief A sequence of coordinates
@@ -295,6 +343,51 @@ class GeoArrowChain {
   S2Shape::Edge edge(int64_t i) {
     S2Shape::Edge e{};
     this->VisitEdges(i, 1, [&](const S2Shape::Edge& edge) {
+      e = edge;
+      return true;
+    });
+    return e;
+  }
+
+  /// \brief Call a function for each GeoArrowVertex in this sequence
+  template <typename Visit>
+  bool VisitNativeVertices(Visit&& visit) const {
+    return internal::VisitNativeVertices(node, visit);
+  }
+
+  /// \brief Call a function for each GeoArrowVertex in a slice of this sequence
+  template <typename Visit>
+  bool VisitNativeVertices(int64_t offset, int64_t n, Visit&& visit) const {
+    return internal::VisitNativeVertices(node, offset, n, visit);
+  }
+
+  /// \brief Call a function for each pair of GeoArrowVertex in this sequence
+  template <typename Visit>
+  bool VisitNativeEdges(Visit&& visit) const {
+    return internal::VisitNativeEdges(node, visit);
+  }
+
+  /// \brief Call a function for each pair of GeoArrowVertex in a slice of this
+  /// sequence
+  template <typename Visit>
+  bool VisitNativeEdges(int64_t offset, int64_t n, Visit&& visit) const {
+    return internal::VisitNativeEdges(node, offset, n, visit);
+  }
+
+  /// \brief Copy a single native vertex out of this sequence
+  internal::GeoArrowVertex native_vertex(int64_t i) const {
+    internal::GeoArrowVertex v{};
+    this->VisitNativeVertices(i, 1, [&](const internal::GeoArrowVertex& vtx) {
+      v = vtx;
+      return true;
+    });
+    return v;
+  }
+
+  /// \brief Copy a single pair of native vertices out of this sequence
+  internal::GeoArrowEdge native_edge(int64_t i) const {
+    internal::GeoArrowEdge e{};
+    this->VisitNativeEdges(i, 1, [&](const internal::GeoArrowEdge& edge) {
       e = edge;
       return true;
     });
@@ -449,6 +542,27 @@ class GeoArrowGeom {
   bool VisitEdges(Visit&& visit) {
     return VisitChains(
         [&](GeoArrowChain chain) { return chain.VisitEdges(visit); });
+  }
+
+  /// \brief Call a function for each native vertex in this node set
+  ///
+  /// This visits all chains and all vertices, including the duplicate closed
+  /// ring vertex in a polygon ring.
+  template <typename Visit>
+  bool VisitNativeVertices(Visit&& visit) {
+    return VisitChains(
+        [&](GeoArrowChain chain) { return chain.VisitNativeVertices(visit); });
+  }
+
+  /// \brief Call a function for each pair of native vertices in this node set
+  ///
+  /// This visits all chains and all edges. Note that point geometries are not
+  /// included in this visitation (i.e., only sequences with 2 or more
+  /// coordinates are visited).
+  template <typename Visit>
+  bool VisitNativeEdges(Visit&& visit) {
+    return VisitChains(
+        [&](GeoArrowChain chain) { return chain.VisitNativeEdges(visit); });
   }
 
  private:

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -4,6 +4,7 @@
 #include <s2/s2latlng.h>
 #include <s2/s2shape.h>
 
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <vector>
@@ -104,15 +105,55 @@ bool VisitLngLat(const struct GeoArrowGeometryNode* node, int64_t offset,
   return true;
 }
 
+/// \brief A lossless vertex in lon/lat/z/m coordinates
+///
+/// Unlike an S2Point, this version of a vertex (1) does not incur rounding
+/// errors from the roundtrip between S2LatLng and S2Point and (2) propagates
+/// Z and M values.
 struct GeoArrowVertex {
+  /// \brief The longitude (X) value
   double lng;
+  /// \brief The latitude (Y) values
   double lat;
+  /// \brief The ZM portion of the coordinate
+  ///
+  /// Whether these values are missing, Z, M, or ZM depends on the
+  /// dimensions of the sequence. These will be NaN in the event that
+  /// there is no Z or M present in the source sequence.
   double zm[2];
+
+  friend bool operator==(const GeoArrowVertex& a, const GeoArrowVertex& b) {
+    // Treat NaNs as equal so that missing ZM information does not affect
+    // inequality (as long as it is consistently missing for both)
+    auto eq = [](double x, double y) {
+      return x == y || (std::isnan(x) && std::isnan(y));
+    };
+    return eq(a.lng, b.lng) && eq(a.lat, b.lat) && eq(a.zm[0], b.zm[0]) &&
+           eq(a.zm[1], b.zm[1]);
+  }
+
+  friend bool operator!=(const GeoArrowVertex& a, const GeoArrowVertex& b) {
+    return !(a == b);
+  }
 };
 
+/// \brief A lossless edge in lon/lat/z/m coordinates
+///
+/// Similar to an S2Shape::Edge except propagates exact vertices and ZM
+/// information.
 struct GeoArrowEdge {
+  /// \brief The first vertex of the edge
   GeoArrowVertex v0;
+  /// \brief The second vertex of the edge
   GeoArrowVertex v1;
+
+  friend bool operator==(const GeoArrowEdge& a, const GeoArrowEdge& b) {
+    return a.v0 == b.v0 && a.v1 == b.v1;
+  }
+
+  friend bool operator!=(const GeoArrowEdge& a, const GeoArrowEdge& b) {
+    return !(a == b);
+  }
 };
 
 /// \brief Visit native vertices


### PR DESCRIPTION
This is the first step to #94 (support ZM values in some output). Because S2's vertices are S2Points, they don't carry the Z or M information. However, S2 is quite good at reporting the shape/edge identifier and we can usually look up a specific edge to inspect what we need to inspect.