### PR TITLE
feat: Add ZM support to ClosestPoint and ShortestLine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,8 +391,7 @@ if(S2GEOGRAPHY_BUILD_TESTS)
     GTest::gtest_main GTest::gmock)
   target_link_libraries(wkt_writer_test s2geography GTest::gtest_main)
   target_link_libraries(wkb_test s2geography GTest::gtest_main)
-  target_link_libraries(geoarrow_geography_test s2geography GTest::gtest_main
-                        GTest::gmock)
+  target_link_libraries(geoarrow_geography_test s2geography GTest::gtest_main)
 
   target_include_directories(sedona_udf_internal_test PRIVATE src/vendored)
   target_include_directories(accessors_geog_test PRIVATE src/vendored)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,7 +391,8 @@ if(S2GEOGRAPHY_BUILD_TESTS)
     GTest::gtest_main GTest::gmock)
   target_link_libraries(wkt_writer_test s2geography GTest::gtest_main)
   target_link_libraries(wkb_test s2geography GTest::gtest_main)
-  target_link_libraries(geoarrow_geography_test s2geography GTest::gtest_main GTest::gmock)
+  target_link_libraries(geoarrow_geography_test s2geography GTest::gtest_main
+                        GTest::gmock)
 
   target_include_directories(sedona_udf_internal_test PRIVATE src/vendored)
   target_include_directories(accessors_geog_test PRIVATE src/vendored)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,7 +391,7 @@ if(S2GEOGRAPHY_BUILD_TESTS)
     GTest::gtest_main GTest::gmock)
   target_link_libraries(wkt_writer_test s2geography GTest::gtest_main)
   target_link_libraries(wkb_test s2geography GTest::gtest_main)
-  target_link_libraries(geoarrow_geography_test s2geography GTest::gtest_main)
+  target_link_libraries(geoarrow_geography_test s2geography GTest::gtest_main GTest::gmock)
 
   target_include_directories(sedona_udf_internal_test PRIVATE src/vendored)
   target_include_directories(accessors_geog_test PRIVATE src/vendored)

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -453,17 +453,17 @@ struct S2ClosestPointExec {
   using out_t = GeoArrowOutputBuilder;
 
   void Exec(arg0_t::c_type value0, arg1_t::c_type value1, out_t* out) {
-    ClearanceLine(value0, value1, &edge_pair_, kFlagComputePoints);
-    if (edge_pair_.is_empty()) {
-      out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_POINT);
-      return;
-    }
-
     // The output usually consists of a vertex derived from the first
     // input. In extreme cases this could result in a NaN written to
     // Z or M (e.g., if value0 is a polygon Z/M and value1 is fully
     // contained and only contains XY values),
     out->SetDimensions(value0.dimensions());
+
+    ClearanceLine(value0, value1, &edge_pair_, kFlagComputePoints);
+    if (edge_pair_.is_empty()) {
+      out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_POINT);
+      return;
+    }
 
     internal::GeoArrowVertex v;
     if (edge_pair_.is_interior()) {
@@ -521,15 +521,15 @@ struct S2ShortestLineExec {
   using out_t = GeoArrowOutputBuilder;
 
   void Exec(arg0_t::c_type value0, arg1_t::c_type value1, out_t* out) {
+    // The output usually consists of one vertex from each side, so
+    // use the common dimensions as the output dimensionality
+    out->SetDimensionsCommon(value0.dimensions(), value1.dimensions());
+
     ClearanceLine(value0, value1, &edge_pair_, kFlagComputePoints);
     if (edge_pair_.is_empty()) {
       out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_LINESTRING);
       return;
     }
-
-    // The output usually consists of one vertex from each side, so
-    // use the common dimensions as the output dimensionality
-    out->SetDimensionsCommon(value0.dimensions(), value1.dimensions());
 
     if (edge_pair_.is_interior()) {
       auto native_vertex = edge_pair_.ResolveInteriorVertex(value0, value1);

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -423,23 +423,31 @@ void ClearanceLine(GeoArrowGeography& value0, GeoArrowGeography& value1,
 struct S2ClosestPointExec {
   using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = GeoArrowGeographyInputView;
-  using out_t = WkbGeographyOutputBuilder;
+  using out_t = GeoArrowOutputBuilder;
 
   void Exec(arg0_t::c_type value0, arg1_t::c_type value1, out_t* out) {
     ClearanceLine(value0, value1, &edge_pair_, kFlagComputePoints);
     if (edge_pair_.shape_id0 == -1) {
-      out->Append(PointGeography());
+      out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_POINT);
       return;
     }
 
-    auto native_edge =
-        value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
-    auto native_vertex =
-        native_edge.Interpolate(edge_pair_.closest_points.first);
+    // internal::GeoArrowVertex v;
+    // if (edge_pair_.closest_points.first == edge_pair_.closest_points.second) {
 
-    // TODO: fix writing the output
+    // } else if (edge_pair_.edge_id0 == -1) {
+    //   S2GEOGRAPHY_DCHECK(false);
+    // } else {
+    //   auto native_edge =
+    //       value1.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
+    //   v = native_edge.Interpolate(edge_pair_.closest_points.first);
+    // }
 
-    out->Append(PointGeography(edge_pair_.closest_points.first));
+    out->FeatureStart();
+    out->GeomStart(GEOARROW_GEOMETRY_TYPE_POINT);
+    out->WriteCoord(edge_pair_.closest_points.first);
+    out->GeomEnd();
+    out->FeatureEnd();
   }
 
   EdgePair edge_pair_;
@@ -478,32 +486,31 @@ struct S2MaxDistanceExec {
 struct S2ShortestLineExec {
   using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = GeoArrowGeographyInputView;
-  using out_t = WkbGeographyOutputBuilder;
+  using out_t = GeoArrowOutputBuilder;
 
   void Exec(arg0_t::c_type value0, arg1_t::c_type value1, out_t* out) {
     ClearanceLine(value0, value1, &edge_pair_, kFlagComputePoints);
     if (edge_pair_.shape_id0 == -1) {
-      out->Append(PolylineGeography());
+      out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_LINESTRING);
       return;
     }
 
-    auto native_edge0 =
-        value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
-    auto native_vertex0 =
-        native_edge0.Interpolate(edge_pair_.closest_points.first);
+    // auto native_edge0 =
+    //     value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
+    // auto native_vertex0 =
+    //     native_edge0.Interpolate(edge_pair_.closest_points.first);
 
-    auto native_edge1 =
-        value1.native_edge(edge_pair_.shape_id1, edge_pair_.edge_id1);
-    auto native_vertex1 =
-        native_edge0.Interpolate(edge_pair_.closest_points.second);
+    // auto native_edge1 =
+    //     value1.native_edge(edge_pair_.shape_id1, edge_pair_.edge_id1);
+    // auto native_vertex1 =
+    //     native_edge1.Interpolate(edge_pair_.closest_points.second);
 
-    // TODO: writing
-
-    PolylineGeography result(std::make_unique<S2Polyline>(
-        std::vector<S2Point>{edge_pair_.closest_points.first,
-                             edge_pair_.closest_points.second},
-        S2Debug::DISABLE));
-    out->Append(result);
+    out->FeatureStart();
+    out->GeomStart(GEOARROW_GEOMETRY_TYPE_LINESTRING);
+    out->WriteCoord(edge_pair_.closest_points.first);
+    out->WriteCoord(edge_pair_.closest_points.second);
+    out->GeomEnd();
+    out->FeatureEnd();
   }
 
   EdgePair edge_pair_;

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -115,7 +115,7 @@ struct EdgePair {
 
   /// \brief Resolve the native vertex of an interior match, which may
   /// come from the first or second input. The returned vertex is normalized
-  /// to take into acccount the dimensionality of the input.
+  /// to take into account the dimensionality of the input.
   internal::GeoArrowVertex ResolveInteriorVertex(
       const GeoArrowGeography& geog0, const GeoArrowGeography& geog1) const {
     if (edge_id0 == -1) {

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -114,10 +114,10 @@ struct EdgePair {
       const GeoArrowGeography& geog0, const GeoArrowGeography& geog1) const {
     if (edge_id0 == -1) {
       auto e = geog1.native_edge(shape_id1, edge_id1);
-      return e.Interpolate(closest_points.second);
+      return e.Interpolate(closest_points.second).Normalize(geog1.dimensions());
     } else if (edge_id1 == -1) {
       auto e = geog0.native_edge(shape_id0, edge_id0);
-      return e.Interpolate(closest_points.first);
+      return e.Interpolate(closest_points.first).Normalize(geog0.dimensions());
     } else {
       throw Exception(
           "Can't resolve interior vertex of EdgePair where neither result is "
@@ -461,7 +461,8 @@ struct S2ClosestPointExec {
     } else {
       auto native_edge =
           value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
-      v = native_edge.Interpolate(edge_pair_.closest_points.first);
+      v = native_edge.Interpolate(edge_pair_.closest_points.first)
+              .Normalize(value0.dimensions());
     }
 
     out->FeatureStart();
@@ -533,12 +534,14 @@ struct S2ShortestLineExec {
     auto native_edge0 =
         value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
     auto native_vertex0 =
-        native_edge0.Interpolate(edge_pair_.closest_points.first);
+        native_edge0.Interpolate(edge_pair_.closest_points.first)
+            .Normalize(value0.dimensions());
 
     auto native_edge1 =
         value1.native_edge(edge_pair_.shape_id1, edge_pair_.edge_id1);
     auto native_vertex1 =
-        native_edge1.Interpolate(edge_pair_.closest_points.second);
+        native_edge1.Interpolate(edge_pair_.closest_points.second)
+            .Normalize(value0.dimensions());
 
     out->FeatureStart();
     out->GeomStart(GEOARROW_GEOMETRY_TYPE_LINESTRING);

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -553,7 +553,7 @@ struct S2ShortestLineExec {
         value1.native_edge(edge_pair_.shape_id1, edge_pair_.edge_id1);
     auto native_vertex1 =
         native_edge1.Interpolate(edge_pair_.closest_points.second)
-            .Normalize(value0.dimensions());
+            .Normalize(value1.dimensions());
 
     out->FeatureStart();
     out->GeomStart(GEOARROW_GEOMETRY_TYPE_LINESTRING);

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -453,6 +453,8 @@ struct S2ClosestPointExec {
       return;
     }
 
+    out->SetDimensionsCommon(value0.dimensions(), value1.dimensions());
+
     internal::GeoArrowVertex v;
     if (edge_pair_.is_interior()) {
       v = edge_pair_.ResolveInteriorVertex(value0, value1);
@@ -513,6 +515,8 @@ struct S2ShortestLineExec {
       out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_LINESTRING);
       return;
     }
+
+    out->SetDimensionsCommon(value0.dimensions(), value1.dimensions());
 
     if (edge_pair_.is_interior()) {
       auto native_vertex = edge_pair_.ResolveInteriorVertex(value0, value1);

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -484,6 +484,7 @@ struct S2ShortestLineExec {
     ClearanceLine(value0, value1, &edge_pair_, kFlagComputePoints);
     if (edge_pair_.shape_id0 == -1) {
       out->Append(PolylineGeography());
+      return;
     }
 
     auto native_edge0 =

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -104,12 +104,18 @@ struct EdgePair {
   std::pair<S2Point, S2Point> closest_points{};
   S1ChordAngle distance{S1ChordAngle::Infinity()};
 
+  /// \brief Return true if this represents an empty match
   bool is_empty() const { return shape_id0 == -1; }
 
+  /// \brief Return true if one side of this match is an interior
+  /// (i.e., is not an actual vertex on one side of the match)
   bool is_interior() const {
     return !is_empty() && (edge_id0 == -1 || edge_id1 == -1);
   }
 
+  /// \brief Resolve the native vertex of an interior match, which may
+  /// come from the first or second input. The returned vertex is normalized
+  /// to take into acccount the dimensionality of the input.
   internal::GeoArrowVertex ResolveInteriorVertex(
       const GeoArrowGeography& geog0, const GeoArrowGeography& geog1) const {
     if (edge_id0 == -1) {
@@ -453,7 +459,11 @@ struct S2ClosestPointExec {
       return;
     }
 
-    out->SetDimensionsCommon(value0.dimensions(), value1.dimensions());
+    // The output usually consists of a vertex derived from the first
+    // input. In extreme cases this could result in a NaN written to
+    // Z or M (e.g., if value0 is a polygon Z/M and value1 is fully
+    // contained and only contains XY values),
+    out->SetDimensions(value0.dimensions());
 
     internal::GeoArrowVertex v;
     if (edge_pair_.is_interior()) {
@@ -517,6 +527,8 @@ struct S2ShortestLineExec {
       return;
     }
 
+    // The output usually consists of one vertex from each side, so
+    // use the common dimensions as the output dimensionality
     out->SetDimensionsCommon(value0.dimensions(), value1.dimensions());
 
     if (edge_pair_.is_interior()) {

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -103,6 +103,27 @@ struct EdgePair {
   int edge_id1{-1};
   std::pair<S2Point, S2Point> closest_points{};
   S1ChordAngle distance{S1ChordAngle::Infinity()};
+
+  bool is_empty() const { return shape_id0 == -1; }
+
+  bool is_interior() const {
+    return !is_empty() && (edge_id0 == -1 || edge_id1 == -1);
+  }
+
+  internal::GeoArrowVertex ResolveInteriorVertex(
+      const GeoArrowGeography& geog0, const GeoArrowGeography& geog1) const {
+    if (edge_id0 == -1) {
+      auto e = geog1.native_edge(shape_id1, edge_id1);
+      return e.Interpolate(closest_points.second);
+    } else if (edge_id1 == -1) {
+      auto e = geog0.native_edge(shape_id0, edge_id0);
+      return e.Interpolate(closest_points.first);
+    } else {
+      throw Exception(
+          "Can't resolve interior vertex of EdgePair where neither result is "
+          "an interior result");
+    }
+  }
 };
 
 void ClearanceLineOnlyEdgesBruteForce(const GeoArrowGeography& value0,
@@ -427,25 +448,23 @@ struct S2ClosestPointExec {
 
   void Exec(arg0_t::c_type value0, arg1_t::c_type value1, out_t* out) {
     ClearanceLine(value0, value1, &edge_pair_, kFlagComputePoints);
-    if (edge_pair_.shape_id0 == -1) {
+    if (edge_pair_.is_empty()) {
       out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_POINT);
       return;
     }
 
-    // internal::GeoArrowVertex v;
-    // if (edge_pair_.closest_points.first == edge_pair_.closest_points.second) {
-
-    // } else if (edge_pair_.edge_id0 == -1) {
-    //   S2GEOGRAPHY_DCHECK(false);
-    // } else {
-    //   auto native_edge =
-    //       value1.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
-    //   v = native_edge.Interpolate(edge_pair_.closest_points.first);
-    // }
+    internal::GeoArrowVertex v;
+    if (edge_pair_.is_interior()) {
+      v = edge_pair_.ResolveInteriorVertex(value0, value1);
+    } else {
+      auto native_edge =
+          value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
+      v = native_edge.Interpolate(edge_pair_.closest_points.first);
+    }
 
     out->FeatureStart();
     out->GeomStart(GEOARROW_GEOMETRY_TYPE_POINT);
-    out->WriteCoord(edge_pair_.closest_points.first);
+    out->WriteCoord(v);
     out->GeomEnd();
     out->FeatureEnd();
   }
@@ -460,7 +479,7 @@ struct S2DistanceExec {
 
   void Exec(arg0_t::c_type value0, arg1_t::c_type value1, out_t* out) {
     ClearanceLine(value0, value1, &edge_pair_, kFlagComputeDistance);
-    if (edge_pair_.shape_id0 == -1) {
+    if (edge_pair_.is_empty()) {
       out->AppendNull();
     } else {
       out->Append(edge_pair_.distance.radians() * S2Earth::RadiusMeters());
@@ -490,25 +509,37 @@ struct S2ShortestLineExec {
 
   void Exec(arg0_t::c_type value0, arg1_t::c_type value1, out_t* out) {
     ClearanceLine(value0, value1, &edge_pair_, kFlagComputePoints);
-    if (edge_pair_.shape_id0 == -1) {
+    if (edge_pair_.is_empty()) {
       out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_LINESTRING);
       return;
     }
 
-    // auto native_edge0 =
-    //     value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
-    // auto native_vertex0 =
-    //     native_edge0.Interpolate(edge_pair_.closest_points.first);
+    if (edge_pair_.is_interior()) {
+      auto native_vertex = edge_pair_.ResolveInteriorVertex(value0, value1);
 
-    // auto native_edge1 =
-    //     value1.native_edge(edge_pair_.shape_id1, edge_pair_.edge_id1);
-    // auto native_vertex1 =
-    //     native_edge1.Interpolate(edge_pair_.closest_points.second);
+      out->FeatureStart();
+      out->GeomStart(GEOARROW_GEOMETRY_TYPE_LINESTRING);
+      out->WriteCoord(native_vertex);
+      out->WriteCoord(native_vertex);
+      out->GeomEnd();
+      out->FeatureEnd();
+      return;
+    }
+
+    auto native_edge0 =
+        value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
+    auto native_vertex0 =
+        native_edge0.Interpolate(edge_pair_.closest_points.first);
+
+    auto native_edge1 =
+        value1.native_edge(edge_pair_.shape_id1, edge_pair_.edge_id1);
+    auto native_vertex1 =
+        native_edge1.Interpolate(edge_pair_.closest_points.second);
 
     out->FeatureStart();
     out->GeomStart(GEOARROW_GEOMETRY_TYPE_LINESTRING);
-    out->WriteCoord(edge_pair_.closest_points.first);
-    out->WriteCoord(edge_pair_.closest_points.second);
+    out->WriteCoord(native_vertex0);
+    out->WriteCoord(native_vertex1);
     out->GeomEnd();
     out->FeatureEnd();
   }

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -429,9 +429,17 @@ struct S2ClosestPointExec {
     ClearanceLine(value0, value1, &edge_pair_, kFlagComputePoints);
     if (edge_pair_.shape_id0 == -1) {
       out->Append(PointGeography());
-    } else {
-      out->Append(PointGeography(edge_pair_.closest_points.first));
+      return;
     }
+
+    auto native_edge =
+        value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
+    auto native_vertex =
+        native_edge.Interpolate(edge_pair_.closest_points.first);
+
+    // TODO: fix writing the output
+
+    out->Append(PointGeography(edge_pair_.closest_points.first));
   }
 
   EdgePair edge_pair_;
@@ -476,13 +484,25 @@ struct S2ShortestLineExec {
     ClearanceLine(value0, value1, &edge_pair_, kFlagComputePoints);
     if (edge_pair_.shape_id0 == -1) {
       out->Append(PolylineGeography());
-    } else {
-      PolylineGeography result(std::make_unique<S2Polyline>(
-          std::vector<S2Point>{edge_pair_.closest_points.first,
-                               edge_pair_.closest_points.second},
-          S2Debug::DISABLE));
-      out->Append(result);
     }
+
+    auto native_edge0 =
+        value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
+    auto native_vertex0 =
+        native_edge0.Interpolate(edge_pair_.closest_points.first);
+
+    auto native_edge1 =
+        value1.native_edge(edge_pair_.shape_id1, edge_pair_.edge_id1);
+    auto native_vertex1 =
+        native_edge0.Interpolate(edge_pair_.closest_points.second);
+
+    // TODO: writing
+
+    PolylineGeography result(std::make_unique<S2Polyline>(
+        std::vector<S2Point>{edge_pair_.closest_points.first,
+                             edge_pair_.closest_points.second},
+        S2Debug::DISABLE));
+    out->Append(result);
   }
 
   EdgePair edge_pair_;

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -176,6 +176,21 @@ INSTANTIATE_TEST_SUITE_P(
                                   "POLYGON ((0 0, 2 0, 0 2, 0 0))",
                                   111195.10117748393, "LINESTRING (-1 0, 0 0)"},
 
+         // Z Point x polygon (point inside)
+        DistanceScalarScalarParam{"point_z_distance_polygon_inside",
+                                  "POINT Z (0.25 0.25 10)",
+                                  "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 0.0,
+                                  "LINESTRING Z (0.25 0.25 10, 0.25 0.25 10)"},
+        // Z Point x polygon (point on boundary)
+        DistanceScalarScalarParam{
+            "point_z_distance_polygon_boundary", "POINT Z (0 0 10)",
+            "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 0.0, "LINESTRING Z (0 0 10, 0 0 12)"},
+        // Z Point x polygon (point outside)
+        DistanceScalarScalarParam{"point_z_distance_polygon_outside",
+                                  "POINT Z (-1 0 10)",
+                                  "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))",
+                                  111195.10117748393, "LINESTRING Z (-1 0 10, 0 0 12)"},
+
         // Linestring x polygon (linestring fully inside)
         DistanceScalarScalarParam{"linestring_distance_polygon_inside",
                                   "LINESTRING (0.25 0.25, 0.5 0.5)",

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -68,26 +68,26 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
       SCOPED_TRACE("prepare_arg0: " + std::to_string(prepare_arg0) +
                    ", prepare_arg1: " + std::to_string(prepare_arg1));
       // Test ST_Distance()
-    //   {
-    //     struct SedonaCScalarKernel kernel;
-    //     struct SedonaCScalarKernelImpl impl;
-    //     s2geography::sedona_udf::DistanceKernel(&kernel, prepare_arg0,
-    //                                             prepare_arg1);
+      {
+        struct SedonaCScalarKernel kernel;
+        struct SedonaCScalarKernelImpl impl;
+        s2geography::sedona_udf::DistanceKernel(&kernel, prepare_arg0,
+                                                prepare_arg1);
 
-    //     ASSERT_NO_FATAL_FAILURE(TestInitKernel(&kernel, &impl,
-    //                                            {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
-    //                                            NANOARROW_TYPE_DOUBLE));
+        ASSERT_NO_FATAL_FAILURE(TestInitKernel(&kernel, &impl,
+                                               {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                                               NANOARROW_TYPE_DOUBLE));
 
-    //     nanoarrow::UniqueArray out_array;
-    //     ASSERT_NO_FATAL_FAILURE(
-    //         TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
-    //                           {{p.lhs}, {p.rhs}}, {}, out_array.get()));
-    //     impl.release(&impl);
-    //     kernel.release(&kernel);
+        nanoarrow::UniqueArray out_array;
+        ASSERT_NO_FATAL_FAILURE(
+            TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                              {{p.lhs}, {p.rhs}}, {}, out_array.get()));
+        impl.release(&impl);
+        kernel.release(&kernel);
 
-    //     ASSERT_NO_FATAL_FAILURE(TestResultArrow(
-    //         out_array.get(), NANOARROW_TYPE_DOUBLE, {p.expected}));
-    //   }
+        ASSERT_NO_FATAL_FAILURE(TestResultArrow(
+            out_array.get(), NANOARROW_TYPE_DOUBLE, {p.expected}));
+      }
 
       // Test ST_ShortestLine
       {

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -144,6 +144,14 @@ INSTANTIATE_TEST_SUITE_P(
                                   111195.10117748393,
                                   "LINESTRING ZM (0 0 1 2, 0 1 2 3)"},
 
+        DistanceScalarScalarParam{"point_distance_point_z", "POINT Z (0 0 1)",
+                                  "POINT Z (0 1 2)", 111195.10117748393,
+                                  "LINESTRING Z (0 0 1, 0 1 2)"},
+
+        DistanceScalarScalarParam{"point_distance_point_m", "POINT M (0 0 2)",
+                                  "POINT M (0 1 3)", 111195.10117748393,
+                                  "LINESTRING M (0 0 2, 0 1 3)"},
+
         // Point x linestring (point on linestring)
         DistanceScalarScalarParam{"point_distance_linestring_on", "POINT (0 0)",
                                   "LINESTRING (0 0, 0 1)", 0.0,

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -43,6 +43,7 @@ struct DistanceScalarScalarParam {
   std::optional<std::string> rhs;
   std::optional<double> expected;
   std::optional<std::string> expected_shortest_line;
+  std::optional<std::string> expected_closest_point;
 
   friend std::ostream& operator<<(std::ostream& os,
                                   const DistanceScalarScalarParam& p) {
@@ -109,6 +110,26 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
         ASSERT_NO_FATAL_FAILURE(
             TestResultGeography(out_array.get(), {p.expected_shortest_line}));
       }
+
+      // Test ST_ClosestPoint
+      {
+        struct SedonaCScalarKernel kernel;
+        struct SedonaCScalarKernelImpl impl;
+        s2geography::sedona_udf::ClosestPointKernel(&kernel);
+
+        ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+            &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, ARROW_TYPE_WKB));
+
+        nanoarrow::UniqueArray out_array;
+        ASSERT_NO_FATAL_FAILURE(
+            TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                              {{p.lhs}, {p.rhs}}, {}, out_array.get()));
+        impl.release(&impl);
+        kernel.release(&kernel);
+
+        ASSERT_NO_FATAL_FAILURE(
+            TestResultGeography(out_array.get(), {p.expected_closest_point}));
+      }
     }
   }
 }
@@ -118,159 +139,177 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         // Nulls
         DistanceScalarScalarParam{"null_distance", std::nullopt, "POINT EMPTY",
-                                  std::nullopt, std::nullopt},
-        DistanceScalarScalarParam{"distance_null", "POINT EMPTY", std::nullopt,
-                                  std::nullopt, std::nullopt},
-        DistanceScalarScalarParam{"null_distance_null", std::nullopt,
                                   std::nullopt, std::nullopt, std::nullopt},
+        DistanceScalarScalarParam{"distance_null", "POINT EMPTY", std::nullopt,
+                                  std::nullopt, std::nullopt, std::nullopt},
+        DistanceScalarScalarParam{"null_distance_null", std::nullopt,
+                                  std::nullopt, std::nullopt, std::nullopt,
+                                  std::nullopt},
 
         // Empties
         DistanceScalarScalarParam{"distance_empty", "POINT (0 0)",
                                   "POINT EMPTY", std::nullopt,
-                                  "LINESTRING EMPTY"},
+                                  "LINESTRING EMPTY", "POINT EMPTY"},
         DistanceScalarScalarParam{"empty_distance", "POINT EMPTY",
                                   "POINT (0 0)", std::nullopt,
-                                  "LINESTRING EMPTY"},
+                                  "LINESTRING EMPTY", "POINT EMPTY"},
+        DistanceScalarScalarParam{"distance_empty_zm", "POINT ZM (0 0 0 0)",
+                                  "POINT ZM EMPTY", std::nullopt,
+                                  "LINESTRING ZM EMPTY", "POINT ZM EMPTY"},
+        DistanceScalarScalarParam{"empty_distance_zm", "POINT ZM EMPTY",
+                                  "POINT ZM (0 0 0 0)", std::nullopt,
+                                  "LINESTRING ZM EMPTY", "POINT ZM EMPTY"},
 
         // Point x point
         DistanceScalarScalarParam{"point_distance_same_point", "POINT (0 0)",
-                                  "POINT (0 0)", 0.0, "LINESTRING (0 0, 0 0)"},
+                                  "POINT (0 0)", 0.0, "LINESTRING (0 0, 0 0)",
+                                  "POINT (0 0)"},
         DistanceScalarScalarParam{"point_distance_point", "POINT (0 0)",
                                   "POINT (0 1)", 111195.10117748393,
-                                  "LINESTRING (0 0, 0 1)"},
+                                  "LINESTRING (0 0, 0 1)", "POINT (0 0)"},
 
-        DistanceScalarScalarParam{"point_distance_point_zm",
-                                  "POINT ZM (0 0 1 2)", "POINT ZM (0 1 2 3)",
-                                  111195.10117748393,
-                                  "LINESTRING ZM (0 0 1 2, 0 1 2 3)"},
+        DistanceScalarScalarParam{
+            "point_distance_point_zm", "POINT ZM (0 0 1 2)",
+            "POINT ZM (0 1 2 3)", 111195.10117748393,
+            "LINESTRING ZM (0 0 1 2, 0 1 2 3)", "POINT ZM (0 0 1 2)"},
 
         DistanceScalarScalarParam{"point_distance_point_z", "POINT Z (0 0 1)",
                                   "POINT Z (0 1 2)", 111195.10117748393,
-                                  "LINESTRING Z (0 0 1, 0 1 2)"},
+                                  "LINESTRING Z (0 0 1, 0 1 2)",
+                                  "POINT Z (0 0 1)"},
 
         DistanceScalarScalarParam{"point_distance_point_m", "POINT M (0 0 2)",
                                   "POINT M (0 1 3)", 111195.10117748393,
-                                  "LINESTRING M (0 0 2, 0 1 3)"},
+                                  "LINESTRING M (0 0 2, 0 1 3)",
+                                  "POINT M (0 0 2)"},
 
         // Point x linestring (point on linestring)
         DistanceScalarScalarParam{"point_distance_linestring_on", "POINT (0 0)",
                                   "LINESTRING (0 0, 0 1)", 0.0,
-                                  "LINESTRING (0 0, 0 0)"},
+                                  "LINESTRING (0 0, 0 0)", "POINT (0 0)"},
         // Point x linestring (point off linestring)
         DistanceScalarScalarParam{"point_distance_linestring_off",
                                   "POINT (1 0)", "LINESTRING (0 0, 0 1)",
-                                  111195.10117748393, "LINESTRING (1 0, 0 0)"},
+                                  111195.10117748393, "LINESTRING (1 0, 0 0)",
+                                  "POINT (1 0)"},
 
         // Point x polygon (point inside)
-        DistanceScalarScalarParam{"point_distance_polygon_inside",
-                                  "POINT (0.25 0.25)",
-                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
-                                  "LINESTRING (0.25 0.25, 0.25 0.25)"},
-        // Point x polygon (point on boundary)
         DistanceScalarScalarParam{
-            "point_distance_polygon_boundary", "POINT (0 0)",
-            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0, "LINESTRING (0 0, 0 0)"},
+            "point_distance_polygon_inside", "POINT (0.25 0.25)",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
+            "LINESTRING (0.25 0.25, 0.25 0.25)", "POINT (0.25 0.25)"},
+        // Point x polygon (point on boundary)
+        DistanceScalarScalarParam{"point_distance_polygon_boundary",
+                                  "POINT (0 0)",
+                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
+                                  "LINESTRING (0 0, 0 0)", "POINT (0 0)"},
         // Point x polygon (point outside)
-        DistanceScalarScalarParam{"point_distance_polygon_outside",
-                                  "POINT (-1 0)",
-                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))",
-                                  111195.10117748393, "LINESTRING (-1 0, 0 0)"},
+        DistanceScalarScalarParam{
+            "point_distance_polygon_outside", "POINT (-1 0)",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 111195.10117748393,
+            "LINESTRING (-1 0, 0 0)", "POINT (-1 0)"},
 
-         // Z Point x polygon (point inside)
-        DistanceScalarScalarParam{"point_z_distance_polygon_inside",
-                                  "POINT Z (0.25 0.25 10)",
-                                  "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 0.0,
-                                  "LINESTRING Z (0.25 0.25 10, 0.25 0.25 10)"},
+        // Z Point x polygon (point inside)
+        DistanceScalarScalarParam{
+            "point_z_distance_polygon_inside", "POINT Z (0.25 0.25 10)",
+            "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 0.0,
+            "LINESTRING Z (0.25 0.25 10, 0.25 0.25 10)",
+            "POINT Z (0.25 0.25 10)"},
         // Z Point x polygon (point on boundary)
         DistanceScalarScalarParam{
             "point_z_distance_polygon_boundary", "POINT Z (0 0 10)",
-            "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 0.0, "LINESTRING Z (0 0 10, 0 0 12)"},
+            "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 0.0,
+            "LINESTRING Z (0 0 10, 0 0 12)", "POINT Z (0 0 10)"},
         // Z Point x polygon (point outside)
-        DistanceScalarScalarParam{"point_z_distance_polygon_outside",
-                                  "POINT Z (-1 0 10)",
-                                  "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))",
-                                  111195.10117748393, "LINESTRING Z (-1 0 10, 0 0 12)"},
+        DistanceScalarScalarParam{
+            "point_z_distance_polygon_outside", "POINT Z (-1 0 10)",
+            "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 111195.10117748393,
+            "LINESTRING Z (-1 0 10, 0 0 12)", "POINT Z (-1 0 10)"},
 
         // Linestring x polygon (linestring fully inside)
-        DistanceScalarScalarParam{"linestring_distance_polygon_inside",
-                                  "LINESTRING (0.25 0.25, 0.5 0.5)",
-                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
-                                  "LINESTRING (0.25 0.25, 0.25 0.25)"},
+        DistanceScalarScalarParam{
+            "linestring_distance_polygon_inside",
+            "LINESTRING (0.25 0.25, 0.5 0.5)", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+            0.0, "LINESTRING (0.25 0.25, 0.25 0.25)", "POINT (0.25 0.25)"},
         // Polygon x linestring (linestring fully inside)
-        DistanceScalarScalarParam{"polygon_distance_linestring_inside",
-                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))",
-                                  "LINESTRING (0.25 0.25, 0.5 0.5)", 0.0,
-                                  "LINESTRING (0.25 0.25, 0.25 0.25)"},
+        DistanceScalarScalarParam{
+            "polygon_distance_linestring_inside",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (0.25 0.25, 0.5 0.5)",
+            0.0, "LINESTRING (0.25 0.25, 0.25 0.25)", "POINT (0.25 0.25)"},
 
         // Linestring x polygon (linestring partially crosses boundary)
         DistanceScalarScalarParam{
             "linestring_distance_polygon_crossing",
             "LINESTRING (0.25 0.25, 3 3)", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
-            0.0, "LINESTRING (0.999743 1.000714, 0.999743 1.000714)"},
+            0.0, "LINESTRING (0.999743 1.000714, 0.999743 1.000714)",
+            "POINT (0.999743 1.000714)"},
         // Polygon x linestring (linestring partially crosses boundary)
         DistanceScalarScalarParam{
             "polygon_distance_linestring_crossing",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (0.25 0.25, 3 3)",
-            0.0, "LINESTRING (0.999743 1.000714, 0.999743 1.000714)"},
+            0.0, "LINESTRING (0.999743 1.000714, 0.999743 1.000714)",
+            "POINT (0.999743 1.000714)"},
 
         // Linestring x polygon (linestring crosses through, neither vertex
         // inside)
-        DistanceScalarScalarParam{"linestring_distance_polygon_through",
-                                  "LINESTRING (-1 0.5, 3 0.5)",
-                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
-                                  "LINESTRING (1.5 0.500286, 1.5 0.500286)"},
+        DistanceScalarScalarParam{
+            "linestring_distance_polygon_through", "LINESTRING (-1 0.5, 3 0.5)",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
+            "LINESTRING (1.5 0.500286, 1.5 0.500286)", "POINT (1.5 0.500286)"},
         // Polygon x linestring (linestring crosses through, neither vertex
         // inside)
-        DistanceScalarScalarParam{"polygon_distance_linestring_through",
-                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))",
-                                  "LINESTRING (-1 0.5, 3 0.5)", 0.0,
-                                  "LINESTRING (1.5 0.500286, 1.5 0.500286)"},
+        DistanceScalarScalarParam{
+            "polygon_distance_linestring_through",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (-1 0.5, 3 0.5)", 0.0,
+            "LINESTRING (1.5 0.500286, 1.5 0.500286)", "POINT (1.5 0.500286)"},
 
         // Linestring x polygon (linestring fully outside)
         DistanceScalarScalarParam{
             "linestring_distance_polygon_outside", "LINESTRING (3 3, 4 4)",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", 314367.35908786184,
-            "LINESTRING (3 3, 0.998247 1.00221)"},
+            "LINESTRING (3 3, 0.998247 1.00221)", "POINT (3 3)"},
         // Polygon x linestring (linestring fully outside)
         DistanceScalarScalarParam{"polygon_distance_linestring_outside",
                                   "POLYGON ((0 0, 2 0, 0 2, 0 0))",
                                   "LINESTRING (3 3, 4 4)", 314367.35908786184,
-                                  "LINESTRING (0.998247 1.00221, 3 3)"},
+                                  "LINESTRING (0.998247 1.00221, 3 3)",
+                                  "POINT (0.998247 1.00221)"},
 
         // Polygon x polygon (one fully inside the other)
         DistanceScalarScalarParam{
             "polygon_distance_polygon_inside", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
             "POLYGON ((0.1 0.1, 0.5 0.1, 0.1 0.5, 0.1 0.1))", 0.0,
-            "LINESTRING (0.1 0.1, 0.1 0.1)"},
+            "LINESTRING (0.1 0.1, 0.1 0.1)", "POINT (0.1 0.1)"},
         // Polygon x polygon (one fully inside, reversed)
         DistanceScalarScalarParam{
             "polygon_distance_polygon_inside_rev",
             "POLYGON ((0.1 0.1, 0.5 0.1, 0.1 0.5, 0.1 0.1))",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
-            "LINESTRING (0.1 0.1, 0.1 0.1)"},
+            "LINESTRING (0.1 0.1, 0.1 0.1)", "POINT (0.1 0.1)"},
 
         // Polygon x polygon (partially overlapping)
         DistanceScalarScalarParam{"polygon_distance_polygon_crossing",
                                   "POLYGON ((0 0, 2 0, 0 2, 0 0))",
                                   "POLYGON ((1 0, 3 0, 1 2, 1 0))", 0.0,
-                                  "LINESTRING (2 0, 2 0)"},
+                                  "LINESTRING (2 0, 2 0)", "POINT (2 0)"},
         // Polygon x polygon (partially overlapping, reversed)
         DistanceScalarScalarParam{"polygon_distance_polygon_crossing_rev",
                                   "POLYGON ((1 0, 3 0, 1 2, 1 0))",
                                   "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
-                                  "LINESTRING (2 0, 2 0)"},
+                                  "LINESTRING (2 0, 2 0)", "POINT (2 0)"},
 
         // Polygon x polygon (fully outside)
         DistanceScalarScalarParam{"polygon_distance_polygon_outside",
                                   "POLYGON ((0 0, 1 0, 0 1, 0 0))",
                                   "POLYGON ((30 30, 31 30, 30 31, 30 30))",
-                                  4520972.0955287321,
-                                  "LINESTRING (0 1, 30 30)"},
+                                  4520972.0955287321, "LINESTRING (0 1, 30 30)",
+                                  "POINT (0 1)"},
         // Polygon x polygon (fully outside, reversed)
         DistanceScalarScalarParam{"polygon_distance_polygon_outside_rev",
                                   "POLYGON ((30 30, 31 30, 30 31, 30 30))",
                                   "POLYGON ((0 0, 1 0, 0 1, 0 0))",
-                                  4520972.0955287321, "LINESTRING (30 30, 0 1)"}
+                                  4520972.0955287321, "LINESTRING (30 30, 0 1)",
+                                  "POINT (30 30)"}
 
         ),
     [](const ::testing::TestParamInfo<DistanceScalarScalarParam>& info) {

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -68,26 +68,26 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
       SCOPED_TRACE("prepare_arg0: " + std::to_string(prepare_arg0) +
                    ", prepare_arg1: " + std::to_string(prepare_arg1));
       // Test ST_Distance()
-      {
-        struct SedonaCScalarKernel kernel;
-        struct SedonaCScalarKernelImpl impl;
-        s2geography::sedona_udf::DistanceKernel(&kernel, prepare_arg0,
-                                                prepare_arg1);
+    //   {
+    //     struct SedonaCScalarKernel kernel;
+    //     struct SedonaCScalarKernelImpl impl;
+    //     s2geography::sedona_udf::DistanceKernel(&kernel, prepare_arg0,
+    //                                             prepare_arg1);
 
-        ASSERT_NO_FATAL_FAILURE(TestInitKernel(&kernel, &impl,
-                                               {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
-                                               NANOARROW_TYPE_DOUBLE));
+    //     ASSERT_NO_FATAL_FAILURE(TestInitKernel(&kernel, &impl,
+    //                                            {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+    //                                            NANOARROW_TYPE_DOUBLE));
 
-        nanoarrow::UniqueArray out_array;
-        ASSERT_NO_FATAL_FAILURE(
-            TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
-                              {{p.lhs}, {p.rhs}}, {}, out_array.get()));
-        impl.release(&impl);
-        kernel.release(&kernel);
+    //     nanoarrow::UniqueArray out_array;
+    //     ASSERT_NO_FATAL_FAILURE(
+    //         TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+    //                           {{p.lhs}, {p.rhs}}, {}, out_array.get()));
+    //     impl.release(&impl);
+    //     kernel.release(&kernel);
 
-        ASSERT_NO_FATAL_FAILURE(TestResultArrow(
-            out_array.get(), NANOARROW_TYPE_DOUBLE, {p.expected}));
-      }
+    //     ASSERT_NO_FATAL_FAILURE(TestResultArrow(
+    //         out_array.get(), NANOARROW_TYPE_DOUBLE, {p.expected}));
+    //   }
 
       // Test ST_ShortestLine
       {

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -139,6 +139,11 @@ INSTANTIATE_TEST_SUITE_P(
                                   "POINT (0 1)", 111195.10117748393,
                                   "LINESTRING (0 0, 0 1)"},
 
+        DistanceScalarScalarParam{"point_distance_point_zm",
+                                  "POINT ZM (0 0 1 2)", "POINT ZM (0 1 2 3)",
+                                  111195.10117748393,
+                                  "LINESTRING ZM (0 0 1 2, 0 1 2 3)"},
+
         // Point x linestring (point on linestring)
         DistanceScalarScalarParam{"point_distance_linestring_on", "POINT (0 0)",
                                   "LINESTRING (0 0, 0 1)", 0.0,

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -62,7 +62,10 @@ GeoArrowPointShape::GeoArrowPointShape(struct GeoArrowGeometryView geom) {
   Init(geom);
 }
 
-void GeoArrowPointShape::Clear() { geom_ = {nullptr, 0}; }
+void GeoArrowPointShape::Clear() {
+  geom_ = {nullptr, 0};
+  dimensions_ = GEOARROW_DIMENSIONS_XY;
+}
 
 void GeoArrowPointShape::Init(struct GeoArrowGeometryView geom) {
   switch (geom.root->geometry_type) {
@@ -101,7 +104,12 @@ void GeoArrowPointShape::Init(struct GeoArrowGeometryView geom) {
     }
     return true;
   });
+
+  // Ensure we keep a record of the source dimensions
+  dimensions_ = geom.root->dimensions;
 }
+
+uint8_t GeoArrowPointShape::dimensions() const { return dimensions_; }
 
 int GeoArrowPointShape::num_vertices() const {
   return static_cast<int>(geom_.size());
@@ -164,6 +172,7 @@ void GeoArrowLaxPolylineShape::Clear() {
   num_chains_ = 0;
   num_edges_.clear();
   num_edges_.push_back(0);
+  dimensions_ = GEOARROW_DIMENSIONS_XY;
 }
 
 void GeoArrowLaxPolylineShape::Init(struct GeoArrowGeometryView geom) {
@@ -212,7 +221,12 @@ void GeoArrowLaxPolylineShape::Init(struct GeoArrowGeometryView geom) {
     num_edges_[i++] = num_edges;
     return true;
   });
+
+  // Keep a record of the source dimensions
+  dimensions_ = geom.root->dimensions;
 }
+
+uint8_t GeoArrowLaxPolylineShape::dimensions() const { return dimensions_; }
 
 int GeoArrowLaxPolylineShape::num_edges() const { return num_edges_.back(); }
 
@@ -273,6 +287,7 @@ void GeoArrowLaxPolygonShape::Clear() {
   num_edges_.clear();
   num_edges_.push_back(0);
   loops_.clear();
+  dimensions_ = GEOARROW_DIMENSIONS_XY;
 }
 
 void GeoArrowLaxPolygonShape::Init(struct GeoArrowGeometryView geom) {
@@ -321,6 +336,9 @@ void GeoArrowLaxPolygonShape::Init(struct GeoArrowGeometryView geom) {
       });
 
   geom_ = {loops_.data(), static_cast<int64_t>(loops_.size())};
+
+  // Keep a record of the source dimensions
+  dimensions_ = geom.root->dimensions;
 }
 
 void GeoArrowLaxPolygonShape::NormalizeOrientation() {
@@ -333,6 +351,8 @@ void GeoArrowLaxPolygonShape::NormalizeOrientation() {
     }
   }
 }
+
+uint8_t GeoArrowLaxPolygonShape::dimensions() const { return dimensions_; }
 
 int GeoArrowLaxPolygonShape::num_edges() const { return num_edges_.back(); }
 
@@ -552,6 +572,26 @@ std::optional<S2Point> GeoArrowGeography::Point() const {
       }
     default:
       return std::nullopt;
+  }
+}
+
+uint8_t GeoArrowGeography::dimensions() const {
+  if (geom_.size_nodes == 0) {
+    return GEOARROW_DIMENSIONS_XY;
+  }
+
+  switch (geom_.root->geometry_type) {
+    case GEOARROW_GEOMETRY_TYPE_POINT:
+    case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
+      return points_.dimensions();
+    case GEOARROW_GEOMETRY_TYPE_LINESTRING:
+    case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
+      return lines_.dimensions();
+    case GEOARROW_GEOMETRY_TYPE_POLYGON:
+    case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
+      return polygons_.dimensions();
+    default:
+      return geom_.root->dimensions;
   }
 }
 

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -766,7 +766,7 @@ GeoArrowVertex GeoArrowEdge::Interpolate(const S2Point& point) {
   }
 
   // Otherwise, find the edge fraction and return the interpolated vertex
-  double fraction = S2::GetDistanceFraction(pt0, pt1, point);
+  double fraction = S2::GetDistanceFraction(point, pt0, pt1);
   return Interpolate(fraction);
 }
 

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -789,11 +789,18 @@ GeoArrowVertex GeoArrowEdge::Interpolate(double fraction) {
     return v1;
   }
 
-  double dlng = (v1.lng - v0.lng) * fraction;
-  double dlat = (v1.lat - v0.lat) * fraction;
+  S2Point pt0 = S2LatLng::FromDegrees(v0.lat, v0.lng).ToPoint();
+  S2Point pt1 = S2LatLng::FromDegrees(v1.lat, v1.lng).ToPoint();
+  if (pt0 == pt1) {
+    return v0;
+  }
+
+  S2LatLng out = S2LatLng(S2::Interpolate(pt0, pt1, fraction));
   double dzm0 = (v1.zm[0] - v0.zm[0]) * fraction;
   double dzm1 = (v1.zm[1] - v0.zm[1]) * fraction;
-  return {v0.lng + dlng, v0.lat + dlat, {v0.zm[0] + dzm0, v0.zm[1] + dzm1}};
+  return {out.lng().degrees(),
+          out.lat().degrees(),
+          {v0.zm[0] + dzm0, v0.zm[1] + dzm1}};
 }
 
 GeoArrowVertex GeoArrowEdge::Interpolate(const S2Point& point) {

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -2,6 +2,7 @@
 #include "s2geography/geoarrow-geography.h"
 
 #include <s2/s2edge_crosser.h>
+#include <s2/s2edge_distances.h>
 #include <s2/s2loop_measures.h>
 #include <s2/s2point.h>
 #include <s2/s2projections.h>
@@ -738,6 +739,38 @@ internal::GeoArrowEdge GeoArrowGeography::native_edge(int shape_id,
       throw Exception("unsupported geometry type");
   }
 }
+
+namespace internal {
+
+GeoArrowVertex GeoArrowEdge::Interpolate(double fraction) {
+  if (fraction <= 0) {
+    return v0;
+  } else if (fraction >= 1) {
+    return v1;
+  }
+
+  double dlng = (v1.lng - v0.lng) * fraction;
+  double dlat = (v1.lat - v0.lat) * fraction;
+  double dzm0 = (v1.zm[0] - v0.zm[0]) * fraction;
+  double dzm1 = (v1.zm[1] - v0.zm[1]) * fraction;
+  return {v0.lng + dlng, v0.lat + dlat, {v0.zm[0] + dzm0, v0.zm[1] + dzm1}};
+}
+
+GeoArrowVertex GeoArrowEdge::Interpolate(const S2Point& point) {
+  auto pt0 = S2LatLng::FromDegrees(v0.lat, v0.lng).ToPoint();
+  auto pt1 = S2LatLng::FromDegrees(v1.lat, v1.lng).ToPoint();
+
+  // If the start and end are the same in lon/lat space, return the first vertex
+  if (pt0 == pt1) {
+    return v0;
+  }
+
+  // Otherwise, find the edge fraction and return the interpolated vertex
+  double fraction = S2::GetDistanceFraction(pt0, pt1, point);
+  return Interpolate(fraction);
+}
+
+}  // namespace internal
 
 double GeoArrowLoop::GetSignedArea() {
   BuildScratch();

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -765,9 +765,24 @@ GeoArrowVertex GeoArrowEdge::Interpolate(const S2Point& point) {
     return v0;
   }
 
-  // Otherwise, find the edge fraction and return the interpolated vertex
+  // Find the edge fraction. Use this to interpolate ZM (or to directly return
+  // a source vertex if the fraction is 0 or 1).
   double fraction = S2::GetDistanceFraction(point, pt0, pt1);
-  return Interpolate(fraction);
+  if (fraction == 0) {
+    return v0;
+  } else if (fraction == 1) {
+    return v1;
+  }
+
+  // Otherwise, interpolate ZM values in linear space but use the original point
+  // to compute the output longitude and latitude.
+  double dzm0 = (v1.zm[0] - v0.zm[0]) * fraction;
+  double dzm1 = (v1.zm[1] - v0.zm[1]) * fraction;
+
+  S2LatLng ll(point);
+  return {ll.lng().degrees(),
+          ll.lat().degrees(),
+          {v0.zm[0] + dzm0, v0.zm[1] + dzm1}};
 }
 
 }  // namespace internal

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -88,7 +88,7 @@ class GeoArrowPointShape : public S2Shape {
 
  private:
   GeoArrowGeom geom_;
-  uint8_t dimensions_;
+  uint8_t dimensions_{GEOARROW_DIMENSIONS_XY};
 };
 
 /// \brief Linestring S2Shape implementation backed by a GeoArrowGeometryView
@@ -149,7 +149,7 @@ class GeoArrowLaxPolylineShape : public S2Shape {
   GeoArrowGeom geom_{};
   int num_chains_{};
   std::vector<int> num_edges_;
-  uint8_t dimensions_;
+  uint8_t dimensions_{GEOARROW_DIMENSIONS_XY};
 };
 
 /// \brief Polygon S2Shape implementation backed by a GeoArrowGeometryView
@@ -258,7 +258,7 @@ class GeoArrowLaxPolygonShape : public S2Shape {
   // Owned loops for O(1) lookup
   std::vector<struct GeoArrowGeometryNode> loops_;
   std::vector<S2Point> point_scratch_;
-  uint8_t dimensions_;
+  uint8_t dimensions_{GEOARROW_DIMENSIONS_XY};
 };
 
 /// \brief Reusable Geography-like wrapper around a GeoArrowGeometryNode

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -58,6 +58,8 @@ class GeoArrowPointShape : public S2Shape {
   /// that contains EMPTY children.
   void Init(struct GeoArrowGeometryView geom);
 
+  uint8_t dimensions() const;
+
   int num_vertices() const;
   S2Point vertex(int v) const;
 
@@ -83,6 +85,7 @@ class GeoArrowPointShape : public S2Shape {
 
  private:
   GeoArrowGeom geom_;
+  uint8_t dimensions_;
 };
 
 /// \brief Linestring S2Shape implementation backed by a GeoArrowGeometryView
@@ -114,6 +117,8 @@ class GeoArrowLaxPolylineShape : public S2Shape {
   /// Throws if geom neither a LINESTRING nor a MULTILINESTRING.
   void Init(struct GeoArrowGeometryView geom);
 
+  uint8_t dimensions() const;
+
   int num_edges() const override;
   Edge edge(int e) const override;
   int dimension() const override;
@@ -138,6 +143,7 @@ class GeoArrowLaxPolylineShape : public S2Shape {
   GeoArrowGeom geom_{};
   int num_chains_{};
   std::vector<int> num_edges_;
+  uint8_t dimensions_;
 };
 
 /// \brief Polygon S2Shape implementation backed by a GeoArrowGeometryView
@@ -193,6 +199,8 @@ class GeoArrowLaxPolygonShape : public S2Shape {
   /// array).
   void NormalizeOrientation();
 
+  uint8_t dimensions() const;
+
   int num_edges() const override;
   Edge edge(int e) const override;
   int dimension() const override;
@@ -241,6 +249,7 @@ class GeoArrowLaxPolygonShape : public S2Shape {
   // Owned loops for O(1) lookup
   std::vector<struct GeoArrowGeometryNode> loops_;
   std::vector<S2Point> point_scratch_;
+  uint8_t dimensions_;
 };
 
 /// \brief Reusable Geography-like wrapper around a GeoArrowGeometryNode
@@ -321,6 +330,13 @@ class GeoArrowGeography {
 
   /// \brief Returns true if this geography has no edges
   bool is_empty() const;
+
+  /// \brief Returns the coordinate dimensions (e.g., XY, XYZ, XYM, XYZM)
+  ///
+  /// For geometries with mixed dimension components (e.g., GEOMETRYCOLLECTION
+  /// (POINT Z (...))) this may give unpredictable results; however, is
+  /// guaranteed to be consistent for consistently annotated input.
+  uint8_t dimensions() const;
 
   /// \brief Returns the dimension (0 for point, 1 for linestring, 2 for
   /// polygon), or -1 for geometry collections

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -58,6 +58,9 @@ class GeoArrowPointShape : public S2Shape {
   /// that contains EMPTY children.
   void Init(struct GeoArrowGeometryView geom);
 
+  /// \brief Return the coordinate dimensions (e.g., XY, XYZ, XYM, or XYZM)
+  ///
+  /// The returned values match the integer constants in the GeoArrow header.
   uint8_t dimensions() const;
 
   int num_vertices() const;
@@ -117,6 +120,9 @@ class GeoArrowLaxPolylineShape : public S2Shape {
   /// Throws if geom neither a LINESTRING nor a MULTILINESTRING.
   void Init(struct GeoArrowGeometryView geom);
 
+  /// \brief Return the coordinate dimensions (e.g., XY, XYZ, XYM, or XYZM)
+  ///
+  /// The returned values match the integer constants in the GeoArrow header.
   uint8_t dimensions() const;
 
   int num_edges() const override;
@@ -199,6 +205,9 @@ class GeoArrowLaxPolygonShape : public S2Shape {
   /// array).
   void NormalizeOrientation();
 
+  /// \brief Return the coordinate dimensions (e.g., XY, XYZ, XYM, or XYZM)
+  ///
+  /// The returned values match the integer constants in the GeoArrow header.
   uint8_t dimensions() const;
 
   int num_edges() const override;

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -534,6 +534,98 @@ TEST(GeoArrowLoop, LoopMetrics) {
       S2LatLng::FromDegrees(5, 5).ToPoint(), reference_out));
 }
 
+// GeoArrowEdge::Interpolate tests
+
+TEST(GeoArrowEdge, InterpolateFractionClampedLow) {
+  internal::GeoArrowEdge edge{{0, 0, {10, 20}}, {10, 10, {30, 40}}};
+  auto result = edge.Interpolate(0.0);
+  EXPECT_EQ(result, edge.v0);
+
+  // Negative fraction should also return v0
+  result = edge.Interpolate(-0.5);
+  EXPECT_EQ(result, edge.v0);
+}
+
+TEST(GeoArrowEdge, InterpolateFractionClampedHigh) {
+  internal::GeoArrowEdge edge{{0, 0, {10, 20}}, {10, 10, {30, 40}}};
+  auto result = edge.Interpolate(1.0);
+  EXPECT_EQ(result, edge.v1);
+
+  // Fraction > 1 should also return v1
+  result = edge.Interpolate(2.0);
+  EXPECT_EQ(result, edge.v1);
+}
+
+TEST(GeoArrowEdge, InterpolateFractionMidpoint) {
+  internal::GeoArrowEdge edge{{0, 0, {10, 20}}, {10, 10, {30, 40}}};
+  auto result = edge.Interpolate(0.5);
+  EXPECT_DOUBLE_EQ(result.lng, 5);
+  EXPECT_DOUBLE_EQ(result.lat, 5);
+  EXPECT_DOUBLE_EQ(result.zm[0], 20);
+  EXPECT_DOUBLE_EQ(result.zm[1], 30);
+
+  // Quarter fraction
+  result = edge.Interpolate(0.25);
+  EXPECT_DOUBLE_EQ(result.lng, 2.5);
+  EXPECT_DOUBLE_EQ(result.lat, 2.5);
+  EXPECT_DOUBLE_EQ(result.zm[0], 15);
+  EXPECT_DOUBLE_EQ(result.zm[1], 25);
+}
+
+TEST(GeoArrowEdge, InterpolatePointDegenerateEdge) {
+  // When v0 and v1 map to the same S2Point, should return v0
+  internal::GeoArrowEdge edge{{5, 10, {100, 200}}, {5, 10, {300, 400}}};
+  S2Point any_point = S2LatLng::FromDegrees(10, 5).ToPoint();
+  auto result = edge.Interpolate(any_point);
+  EXPECT_EQ(result, edge.v0);
+}
+
+TEST(GeoArrowEdge, InterpolatePointOnEdge) {
+  internal::GeoArrowEdge edge{{0, 0, {10, 20}}, {10, 0, {30, 40}}};
+  // Point at the midpoint of a constant-latitude edge
+  S2Point midpoint = S2LatLng::FromDegrees(0, 5).ToPoint();
+  auto result = edge.Interpolate(midpoint);
+  EXPECT_DOUBLE_EQ(result.lng, 5);
+  EXPECT_DOUBLE_EQ(result.lat, 0);
+  EXPECT_DOUBLE_EQ(result.zm[0], 20);
+  EXPECT_DOUBLE_EQ(result.zm[1], 30);
+
+  // Point under halfway
+  S2Point quarter_point = S2LatLng::FromDegrees(0, 2.5).ToPoint();
+  result = edge.Interpolate(quarter_point);
+  EXPECT_DOUBLE_EQ(result.lng, 2.5);
+  EXPECT_DOUBLE_EQ(result.lat, 0);
+  EXPECT_DOUBLE_EQ(result.zm[0], 15);
+  EXPECT_DOUBLE_EQ(result.zm[1], 25);
+
+  // Point over halfway
+  S2Point three_quarter_point = S2LatLng::FromDegrees(0, 7.5).ToPoint();
+  result = edge.Interpolate(three_quarter_point);
+  EXPECT_DOUBLE_EQ(result.lng, 7.5);
+  EXPECT_DOUBLE_EQ(result.lat, 0);
+  EXPECT_DOUBLE_EQ(result.zm[0], 25);
+  EXPECT_DOUBLE_EQ(result.zm[1], 35);
+}
+
+TEST(GeoArrowEdge, InterpolatePointAtEndpoints) {
+  internal::GeoArrowEdge edge{{0, 0, {10, 20}}, {10, 0, {30, 40}}};
+  // Point at v0
+  S2Point pt0 = S2LatLng::FromDegrees(0, 0).ToPoint();
+  auto result = edge.Interpolate(pt0);
+  EXPECT_DOUBLE_EQ(result.lng, 0);
+  EXPECT_DOUBLE_EQ(result.lat, 0);
+  EXPECT_DOUBLE_EQ(result.zm[0], 10);
+  EXPECT_DOUBLE_EQ(result.zm[1], 20);
+
+  // Point at v1
+  S2Point pt1 = S2LatLng::FromDegrees(0, 10).ToPoint();
+  result = edge.Interpolate(pt1);
+  EXPECT_DOUBLE_EQ(result.lng, 10);
+  EXPECT_DOUBLE_EQ(result.lat, 0);
+  EXPECT_DOUBLE_EQ(result.zm[0], 30);
+  EXPECT_DOUBLE_EQ(result.zm[1], 40);
+}
+
 // Shape tests
 
 TEST(GeoArrowPointShape, DefaultConstructor) {

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -2,114 +2,24 @@
 
 #include <gtest/gtest.h>
 
-#include <string>
 #include <vector>
 
 #include "geoarrow/geoarrow.hpp"
 #include "s2geography/geography.h"
+#include "s2geography/sedona_udf/sedona_udf_test_internal.h"
 #include "s2geography/wkt-reader.h"
 
 using namespace s2geography;
 
-/// \brief An owning wrapper around a GeoArrowGeometry with utilities to
-/// construct from WKT or WKB
-class TestGeometry {
- public:
-  TestGeometry() : oriented_(false) {
-    GEOARROW_THROW_NOT_OK(nullptr, GeoArrowGeometryInit(&geom_));
+std::unique_ptr<GeoArrowLaxPolygonShape> TestGeometryToPolygonShape(
+    const TestGeometry& test_geom) {
+  auto out = std::make_unique<GeoArrowLaxPolygonShape>(test_geom.geom());
+  if (!test_geom.oriented()) {
+    out->NormalizeOrientation();
   }
 
-  ~TestGeometry() { GeoArrowGeometryReset(&geom_); }
-
-  TestGeometry(const TestGeometry&) = delete;
-  TestGeometry& operator=(const TestGeometry&) = delete;
-
-  TestGeometry(TestGeometry&& other) noexcept
-      : geom_(other.geom_),
-        label_(std::move(other.label_)),
-        oriented_(other.oriented_) {
-    GeoArrowGeometryInit(&other.geom_);
-  }
-
-  TestGeometry& operator=(TestGeometry&& other) noexcept {
-    if (this != &other) {
-      GeoArrowGeometryReset(&geom_);
-      geom_ = other.geom_;
-      GeoArrowGeometryInit(&other.geom_);
-      label_ = std::move(other.label_);
-      oriented_ = other.oriented_;
-    }
-    return *this;
-  }
-
-  static TestGeometry FromWKT(std::string_view wkt) {
-    TestGeometry result;
-    result.label_ = wkt;
-
-    struct GeoArrowStringView wkt_view{wkt.data(),
-                                       static_cast<int64_t>(wkt.size())};
-
-    struct GeoArrowVisitor v{};
-    GeoArrowGeometryInitVisitor(&result.geom_, &v);
-
-    struct GeoArrowWKTReader reader;
-    GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKTReaderInit(&reader));
-    GeoArrowErrorCode code = GeoArrowWKTReaderVisit(&reader, wkt_view, &v);
-    GeoArrowWKTReaderReset(&reader);
-    if (code != GEOARROW_OK) {
-      throw Exception("Invalid WKT");
-    }
-
-    return result;
-  }
-
-  static TestGeometry FromWKB(const std::vector<uint8_t>& wkb) {
-    TestGeometry result;
-    struct GeoArrowWKBReader reader;
-    GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKBReaderInit(&reader));
-    struct GeoArrowBufferView src{wkb.data(), static_cast<int64_t>(wkb.size())};
-    struct GeoArrowGeometryView view;
-    GeoArrowErrorCode code =
-        GeoArrowWKBReaderRead(&reader, src, &view, nullptr);
-    if (code != GEOARROW_OK) {
-      GeoArrowWKBReaderReset(&reader);
-      throw Exception("Invalid WKB");
-    }
-
-    // Copy the parsed geometry into our owned GeoArrowGeometry
-    code = GeoArrowGeometryShallowCopy(view, &result.geom_);
-    GeoArrowWKBReaderReset(&reader);
-    if (code != GEOARROW_OK) {
-      throw Exception("Failed to copy WKB geometry");
-    }
-
-    return result;
-  }
-
-  struct GeoArrowGeometryView geom() const {
-    return GeoArrowGeometryAsView(&geom_);
-  }
-
-  bool oriented() const { return oriented_; }
-
-  void set_oriented(bool oriented) { oriented_ = oriented; }
-
-  std::string_view label() const { return label_; }
-
-  std::unique_ptr<GeoArrowLaxPolygonShape> ToPolygonShape() const {
-    auto out = std::make_unique<GeoArrowLaxPolygonShape>(geom());
-    if (!oriented()) {
-      out->NormalizeOrientation();
-    }
-
-    return out;
-  }
-
- private:
-  struct GeoArrowGeometry geom_;
-  std::string label_;
-  bool oriented_;
-};
+  return out;
+}
 
 /// \brief Utility to sanity check an S2Shape, which has global edge ids
 /// but also has edges organized into chains.
@@ -1215,7 +1125,7 @@ TEST(GeoArrowLaxPolygonShape, ShapeIndexContains) {
       "(-5 -5, -5 5, 5 5, 5 -5, -5 -5))");
 
   MutableS2ShapeIndex poly_index;
-  poly_index.Add(poly_geom.ToPolygonShape());
+  poly_index.Add(TestGeometryToPolygonShape(poly_geom));
 
   WKTReader reader;
   S2BooleanOperation::Options options;
@@ -1257,7 +1167,7 @@ TEST(GeoArrowLaxPolygonShape, ShapeIndexContainsMultiPolygonWithHoles) {
     SCOPED_TRACE(test_geom->label());
 
     MutableS2ShapeIndex poly_index;
-    auto shape = test_geom->ToPolygonShape();
+    auto shape = TestGeometryToPolygonShape(*test_geom);
     ValidateShape(*shape);
     poly_index.Add(std::move(shape));
 

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -469,15 +469,17 @@ TEST(GeoArrowEdge, InterpolateFractionClampedHigh) {
 TEST(GeoArrowEdge, InterpolateFractionMidpoint) {
   internal::GeoArrowEdge edge{{0, 0, {10, 20}}, {10, 10, {30, 40}}};
   auto result = edge.Interpolate(0.5);
-  EXPECT_DOUBLE_EQ(result.lng, 5);
-  EXPECT_DOUBLE_EQ(result.lat, 5);
+  // Spherical interpolation: lng/lat won't be exactly linear
+  EXPECT_DOUBLE_EQ(result.lng, 4.9616312267025071);
+  EXPECT_DOUBLE_EQ(result.lat, 5.0190006978611486);
+  // ZM values are still linearly interpolated
   EXPECT_DOUBLE_EQ(result.zm[0], 20);
   EXPECT_DOUBLE_EQ(result.zm[1], 30);
 
   // Quarter fraction
   result = edge.Interpolate(0.25);
-  EXPECT_DOUBLE_EQ(result.lng, 2.5);
-  EXPECT_DOUBLE_EQ(result.lat, 2.5);
+  EXPECT_DOUBLE_EQ(result.lng, 2.476047452165361);
+  EXPECT_DOUBLE_EQ(result.lat, 2.5118515100847665);
   EXPECT_DOUBLE_EQ(result.zm[0], 15);
   EXPECT_DOUBLE_EQ(result.zm[1], 25);
 }

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -122,6 +122,8 @@ struct GeoArrowVertex {
   /// there is no Z or M present in the source sequence.
   double zm[2];
 
+  /// \brief Normalize the order of zm values such that this object
+  /// always represents, x, y, z, and m (in that order)
   GeoArrowVertex Normalize(uint8_t dimensions) {
     GeoArrowVertex v = *this;
     if (dimensions == 3) {
@@ -155,8 +157,19 @@ struct GeoArrowEdge {
   /// \brief The second vertex of the edge
   GeoArrowVertex v1;
 
+  /// \brief Interpolate a value along this edge
+  ///
+  /// - lng and lat values are interpolated along a spherical path
+  /// - z and m values are interpolated linearly
   GeoArrowVertex Interpolate(double fraction);
 
+  /// \brief Given an S2Point along this edge, interpolate
+  ///
+  /// - lng and lat values are derived directly from point unless
+  ///   the point falls exactly on the start or end of the edge (
+  ///   in which case the start or end vertex is returned directly
+  ///   to minimize roundtrip rounding errors)
+  /// - z and m values are interpolated linearly
   GeoArrowVertex Interpolate(const S2Point& point);
 
   friend bool operator==(const GeoArrowEdge& a, const GeoArrowEdge& b) {

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -147,6 +147,10 @@ struct GeoArrowEdge {
   /// \brief The second vertex of the edge
   GeoArrowVertex v1;
 
+  GeoArrowVertex Interpolate(double fraction);
+
+  GeoArrowVertex Interpolate(const S2Point& point);
+
   friend bool operator==(const GeoArrowEdge& a, const GeoArrowEdge& b) {
     return a.v0 == b.v0 && a.v1 == b.v1;
   }

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -122,6 +122,14 @@ struct GeoArrowVertex {
   /// there is no Z or M present in the source sequence.
   double zm[2];
 
+  GeoArrowVertex Normalize(uint8_t dimensions) {
+    GeoArrowVertex v = *this;
+    if (dimensions == 3) {
+      std::swap(v.zm[0], v.zm[1]);
+    }
+    return v;
+  }
+
   friend bool operator==(const GeoArrowVertex& a, const GeoArrowVertex& b) {
     // Treat NaNs as equal so that missing ZM information does not affect
     // inequality (as long as it is consistently missing for both)

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -126,7 +126,7 @@ struct GeoArrowVertex {
   /// always represents, x, y, z, and m (in that order)
   GeoArrowVertex Normalize(uint8_t dimensions) {
     GeoArrowVertex v = *this;
-    if (dimensions == 3) {
+    if (dimensions == GEOARROW_DIMENSIONS_XYM) {
       std::swap(v.zm[0], v.zm[1]);
     }
     return v;

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -168,13 +168,23 @@ class WkbGeographyOutputBuilder {
   geoarrow::Writer writer_;
 };
 
+/// \brief Low-level output builder for Geography as WKB
+///
+/// This builder handles output from functions that return geometry
+/// and exports the output as WKB. Unlike the WkbGeographyOutputBuilder,
+/// this builder exposes low-level building primitives for faster output
+/// (i.e., streaming output with minimal intermediary copying) and more
+/// feature-rich (e.g., ZM output and lossless point/multipoint semantics).
 class GeoArrowOutputBuilder {
  public:
   GeoArrowOutputBuilder() {
+    // Initialize the writer and wire it up to the visitor
     GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKBWriterInit(&writer_));
     GeoArrowWKBWriterInitVisitor(&writer_, &v_);
     v_.error = &error_;
 
+    // Wire up our coordinate buffer to a GeoArrowCoordView, which is what
+    // the visitor requires for coord visiting.
     coords_.coords_stride = 1;
     coords_.n_values = 2;
     coords_.n_coords = 0;
@@ -183,11 +193,17 @@ class GeoArrowOutputBuilder {
     coords_.values[2] = coord_buf_.data() + 2 * coord_buf_.size() / 4;
     coords_.values[3] = coord_buf_.data() + 3 * coord_buf_.size() / 4;
 
+    // Set the fill value for the unlikely event where the output is set to
+    // write more dimensions than exist in a coordinate.
     coord_src_[0] = std::numeric_limits<double>::quiet_NaN();
   }
 
+  // Not copyable
   GeoArrowOutputBuilder(const GeoArrowOutputBuilder&) = delete;
   GeoArrowOutputBuilder& operator=(const GeoArrowOutputBuilder&) = delete;
+
+  // Ensure we manage the C object we're wrapping correctly
+  ~GeoArrowOutputBuilder() { GeoArrowWKBWriterReset(&writer_); }
 
   void InitOutputType(struct ArrowSchema* out) {
     ::geoarrow::Wkb()
@@ -207,6 +223,10 @@ class GeoArrowOutputBuilder {
     // however, it does support multiple cylces of Append/Finish.
   }
 
+  /// \brief Set the dimensions of this writer to the common dimensions of dim0
+  /// and dim1
+  ///
+  /// For example, XYZM + XYM input will be written set to XYM output.
   void SetDimensionsCommon(uint8_t dim0, uint8_t dim1) {
     if (dim0 == GEOARROW_DIMENSIONS_XY || dim1 == GEOARROW_DIMENSIONS_XY) {
       SetDimensions(GEOARROW_DIMENSIONS_XY);
@@ -221,6 +241,13 @@ class GeoArrowOutputBuilder {
     }
   }
 
+  /// \brief Set the output dimensions
+  ///
+  /// Set the output to a specific dimensionality. Coordinates written with
+  /// more dimensions will have these dimensions dropped; coordinates written
+  /// with fewer dimensions will have these dimensions filled. The fill value
+  /// is currently hard-coded to NaN; however, this output should be unlikely
+  /// under normal input/output scenarios.
   void SetDimensions(uint8_t dim) {
     switch (dim) {
       case GEOARROW_DIMENSIONS_XY:
@@ -235,35 +262,51 @@ class GeoArrowOutputBuilder {
     }
   }
 
+  /// \brief Append a null value
   void AppendNull() {
     GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKBWriterAppendNull(&writer_));
   }
 
-  void AppendEmpty(enum GeoArrowGeometryType geometry_type) {
+  /// \brief Append an empty geometry of a specified type
+  void AppendEmpty(enum GeoArrowGeometryType geometry_type =
+                       GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION) {
     FeatureStart();
     GeomStart(geometry_type);
     GeomEnd();
     FeatureEnd();
   }
 
+  /// \brief Append a preexisting geometry verbatim as a complete (non null)
+  /// feature
   void AppendGeometry(struct GeoArrowGeometryView geom) {
     GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKBWriterAppend(&writer_, geom));
   }
 
+  /// \brief Start a feature (must be paired with FeatEnd())
   void FeatureStart() { GEOARROW_THROW_NOT_OK(&error_, v_.feat_start(&v_)); }
 
+  /// \brief Start a geometry (must be paired with GeomEnd())
   void GeomStart(enum GeoArrowGeometryType geometry_type) {
     GEOARROW_THROW_NOT_OK(&error_, v_.geom_start(&v_, geometry_type, dim_));
   }
 
+  /// \brief Start a ring (must be paired with RingEnd())
   void RingStart() { GEOARROW_THROW_NOT_OK(&error_, v_.ring_start(&v_)); }
 
+  /// \brief Write an S2Point coordinate as lon, lat
   void WriteCoord(const S2Point& v) { WriteCoord(S2LatLng(v)); }
 
+  /// \brief Write an S2LatLng coordinate as lon, lat
   void WriteCoord(const S2LatLng& v) {
     WriteCoord(v.lng().degrees(), v.lat().degrees());
   }
 
+  /// \brief Write a GeoArrowVertex
+  ///
+  /// Dimensions are mapped using dim_src and the value set for the output
+  /// (i.e., dimensions are mapped by name, not by position). It is usually
+  /// easier to call v.Normalize() and use the default dim_src than to pass
+  /// around the coordinate dimension separately.
   void WriteCoord(const internal::GeoArrowVertex& v,
                   uint8_t dim_src = GEOARROW_DIMENSIONS_XYZM) {
     if (coords_.n_coords == kCoordsCapcity) {
@@ -291,6 +334,40 @@ class GeoArrowOutputBuilder {
     ++coords_.n_coords;
   }
 
+  /// \brief End a ring
+  void RingEnd() {
+    FlushCoords();
+    GEOARROW_THROW_NOT_OK(&error_, v_.ring_end(&v_));
+  }
+
+  /// \brief End a geometry
+  void GeomEnd() {
+    FlushCoords();
+    GEOARROW_THROW_NOT_OK(&error_, v_.geom_end(&v_));
+  }
+
+  /// \brief End a feature
+  void FeatureEnd() { GEOARROW_THROW_NOT_OK(&error_, v_.feat_end(&v_)); }
+
+  /// \brief Finish the output
+  ///
+  /// The same output builder may be finished and appended to multiple times.
+  void Finish(struct ArrowArray* out) {
+    GEOARROW_THROW_NOT_OK(&error_,
+                          GeoArrowWKBWriterFinish(&writer_, out, &error_));
+  }
+
+ private:
+  GeoArrowWKBWriter writer_{};
+  GeoArrowVisitor v_{};
+  GeoArrowError error_{};
+  enum GeoArrowDimensions dim_ { GEOARROW_DIMENSIONS_XY };
+  struct GeoArrowCoordView coords_{};
+  std::array<double, 64> coord_buf_{};
+  static constexpr int64_t kCoordsCapcity = 64 / 4;
+  double coord_src_[5];
+  double coord_dst_[5];
+
   void WriteCoord(double x, double y) {
     if (coords_.n_coords == kCoordsCapcity) {
       FlushCoords();
@@ -313,34 +390,6 @@ class GeoArrowOutputBuilder {
     GEOARROW_THROW_NOT_OK(&error_, v_.coords(&v_, &coords_));
     coords_.n_coords = 0;
   }
-
-  void RingEnd() {
-    FlushCoords();
-    GEOARROW_THROW_NOT_OK(&error_, v_.ring_end(&v_));
-  }
-
-  void GeomEnd() {
-    FlushCoords();
-    GEOARROW_THROW_NOT_OK(&error_, v_.geom_end(&v_));
-  }
-
-  void FeatureEnd() { GEOARROW_THROW_NOT_OK(&error_, v_.feat_end(&v_)); }
-
-  void Finish(struct ArrowArray* out) {
-    GEOARROW_THROW_NOT_OK(&error_,
-                          GeoArrowWKBWriterFinish(&writer_, out, &error_));
-  }
-
- private:
-  GeoArrowWKBWriter writer_{};
-  GeoArrowVisitor v_{};
-  GeoArrowError error_{};
-  enum GeoArrowDimensions dim_ { GEOARROW_DIMENSIONS_XY };
-  struct GeoArrowCoordView coords_{};
-  std::array<double, 64> coord_buf_{};
-  static constexpr int64_t kCoordsCapcity = 64 / 4;
-  double coord_src_[5];
-  double coord_dst_[5];
 };
 
 /// \brief Generic view of Arrow input

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -225,6 +225,13 @@ class GeoArrowOutputBuilder {
     GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKBWriterAppendNull(&writer_));
   }
 
+  void AppendEmpty(enum GeoArrowGeometryType geometry_type) {
+    FeatureStart();
+    GeomStart(geometry_type);
+    GeomEnd();
+    FeatureEnd();
+  }
+
   void AppendGeometry(struct GeoArrowGeometryView geom) {
     GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKBWriterAppend(&writer_, geom));
   }
@@ -299,7 +306,7 @@ class GeoArrowOutputBuilder {
 
   void GeomEnd() {
     FlushCoords();
-    GEOARROW_THROW_NOT_OK(&error_, v_.feat_end(&v_));
+    GEOARROW_THROW_NOT_OK(&error_, v_.geom_end(&v_));
   }
 
   void FeatureEnd() { GEOARROW_THROW_NOT_OK(&error_, v_.feat_end(&v_)); }
@@ -313,7 +320,7 @@ class GeoArrowOutputBuilder {
   GeoArrowWKBWriter writer_{};
   GeoArrowVisitor v_{};
   GeoArrowError error_{};
-  enum GeoArrowDimensions dim_ {};
+  enum GeoArrowDimensions dim_ {GEOARROW_DIMENSIONS_XY};
   struct GeoArrowCoordView coords_{};
   std::array<double, 64> coord_buf_{};
   static constexpr int64_t kCoordsCapcity = 64 / 4;

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -265,7 +265,7 @@ class GeoArrowOutputBuilder {
   }
 
   void WriteCoord(const internal::GeoArrowVertex& v,
-                  enum GeoArrowDimensions dim_src = GEOARROW_DIMENSIONS_XY) {
+                  uint8_t dim_src = GEOARROW_DIMENSIONS_XYZM) {
     if (coords_.n_coords == kCoordsCapcity) {
       FlushCoords();
     }
@@ -278,7 +278,8 @@ class GeoArrowOutputBuilder {
     }
 
     int map[5];
-    GeoArrowMapDimensions(dim_src, dim_, map);
+    GeoArrowMapDimensions(static_cast<enum GeoArrowDimensions>(dim_src), dim_,
+                          map);
     std::memcpy(coord_src_ + 1, &v, sizeof(v));
     for (int i = 0; i < 4; i++) {
       coord_dst_[i] = coord_src_[map[i] + 1];

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -3,8 +3,8 @@
 #include <algorithm>
 #include <array>
 #include <cerrno>
+#include <cstring>
 #include <limits>
-#include <memory>
 
 #include "geoarrow/geoarrow.hpp"
 #include "nanoarrow/nanoarrow.hpp"

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -207,6 +207,20 @@ class GeoArrowOutputBuilder {
     // however, it does support multiple cylces of Append/Finish.
   }
 
+  void SetDimensionsCommon(uint8_t dim0, uint8_t dim1) {
+    if (dim0 == GEOARROW_DIMENSIONS_XY || dim1 == GEOARROW_DIMENSIONS_XY) {
+      SetDimensions(GEOARROW_DIMENSIONS_XY);
+    } else if (dim0 == GEOARROW_DIMENSIONS_XYZ &&
+               dim1 == GEOARROW_DIMENSIONS_XYM) {
+      SetDimensions(GEOARROW_DIMENSIONS_XY);
+    } else if (dim0 == GEOARROW_DIMENSIONS_XYM &&
+               dim1 == GEOARROW_DIMENSIONS_XYZ) {
+      SetDimensions(GEOARROW_DIMENSIONS_XY);
+    } else {
+      SetDimensions(std::min(dim0, dim1));
+    }
+  }
+
   void SetDimensions(uint8_t dim) {
     switch (dim) {
       case GEOARROW_DIMENSIONS_XY:

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cerrno>
+#include <limits>
+#include <memory>
 
 #include "geoarrow/geoarrow.hpp"
 #include "nanoarrow/nanoarrow.hpp"
@@ -220,7 +223,7 @@ class GeoArrowOutputBuilder {
 
   void Reserve(int64_t additional_size) {
     // The current geoarrow writer doesn't provide any support for this;
-    // however, it does support multiple cylces of Append/Finish.
+    // however, it does support multiple cycles of Append/Finish.
   }
 
   /// \brief Set the dimensions of this writer to the common dimensions of dim0
@@ -282,7 +285,7 @@ class GeoArrowOutputBuilder {
     GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKBWriterAppend(&writer_, geom));
   }
 
-  /// \brief Start a feature (must be paired with FeatEnd())
+  /// \brief Start a feature (must be paired with FeatureEnd())
   void FeatureStart() { GEOARROW_THROW_NOT_OK(&error_, v_.feat_start(&v_)); }
 
   /// \brief Start a geometry (must be paired with GeomEnd())
@@ -309,7 +312,7 @@ class GeoArrowOutputBuilder {
   /// around the coordinate dimension separately.
   void WriteCoord(const internal::GeoArrowVertex& v,
                   uint8_t dim_src = GEOARROW_DIMENSIONS_XYZM) {
-    if (coords_.n_coords == kCoordsCapcity) {
+    if (coords_.n_coords == kCoordsCapacity) {
       FlushCoords();
     }
 
@@ -364,12 +367,12 @@ class GeoArrowOutputBuilder {
   enum GeoArrowDimensions dim_ { GEOARROW_DIMENSIONS_XY };
   struct GeoArrowCoordView coords_{};
   std::array<double, 64> coord_buf_{};
-  static constexpr int64_t kCoordsCapcity = 64 / 4;
+  static constexpr int64_t kCoordsCapacity = 64 / 4;
   double coord_src_[5];
   double coord_dst_[5];
 
   void WriteCoord(double x, double y) {
-    if (coords_.n_coords == kCoordsCapcity) {
+    if (coords_.n_coords == kCoordsCapacity) {
       FlushCoords();
     }
 

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -320,7 +320,7 @@ class GeoArrowOutputBuilder {
   GeoArrowWKBWriter writer_{};
   GeoArrowVisitor v_{};
   GeoArrowError error_{};
-  enum GeoArrowDimensions dim_ {GEOARROW_DIMENSIONS_XY};
+  enum GeoArrowDimensions dim_ { GEOARROW_DIMENSIONS_XY };
   struct GeoArrowCoordView coords_{};
   std::array<double, 64> coord_buf_{};
   static constexpr int64_t kCoordsCapcity = 64 / 4;

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cerrno>
 
 #include "geoarrow/geoarrow.hpp"
@@ -165,6 +166,159 @@ class WkbGeographyOutputBuilder {
 
  private:
   geoarrow::Writer writer_;
+};
+
+class GeoArrowOutputBuilder {
+ public:
+  GeoArrowOutputBuilder() {
+    GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKBWriterInit(&writer_));
+    GeoArrowWKBWriterInitVisitor(&writer_, &v_);
+    v_.error = &error_;
+
+    coords_.coords_stride = 1;
+    coords_.n_values = 2;
+    coords_.n_coords = 0;
+    coords_.values[0] = coord_buf_.data();
+    coords_.values[1] = coord_buf_.data() + coord_buf_.size() / 4;
+    coords_.values[2] = coord_buf_.data() + 2 * coord_buf_.size() / 4;
+    coords_.values[3] = coord_buf_.data() + 3 * coord_buf_.size() / 4;
+
+    coord_src_[0] = std::numeric_limits<double>::quiet_NaN();
+  }
+
+  GeoArrowOutputBuilder(const GeoArrowOutputBuilder&) = delete;
+  GeoArrowOutputBuilder& operator=(const GeoArrowOutputBuilder&) = delete;
+
+  void InitOutputType(struct ArrowSchema* out) {
+    ::geoarrow::Wkb()
+        .WithEdgeType(GEOARROW_EDGE_TYPE_SPHERICAL)
+        .InitSchema(out);
+  }
+
+  void InitOutputTypeWithCrs(struct ArrowSchema* out, const std::string& crs) {
+    ::geoarrow::Wkb()
+        .WithEdgeType(GEOARROW_EDGE_TYPE_SPHERICAL)
+        .WithCrs(crs)
+        .InitSchema(out);
+  }
+
+  void Reserve(int64_t additional_size) {
+    // The current geoarrow writer doesn't provide any support for this;
+    // however, it does support multiple cylces of Append/Finish.
+  }
+
+  void SetDimensions(uint8_t dim) {
+    switch (dim) {
+      case GEOARROW_DIMENSIONS_XY:
+      case GEOARROW_DIMENSIONS_XYZ:
+      case GEOARROW_DIMENSIONS_XYM:
+      case GEOARROW_DIMENSIONS_XYZM:
+        coords_.n_values = _GeoArrowkNumDimensions[dim];
+        dim_ = static_cast<enum GeoArrowDimensions>(dim);
+        break;
+      default:
+        throw Exception("Unknown dimensions constant");
+    }
+  }
+
+  void AppendNull() {
+    GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKBWriterAppendNull(&writer_));
+  }
+
+  void AppendGeometry(struct GeoArrowGeometryView geom) {
+    GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKBWriterAppend(&writer_, geom));
+  }
+
+  void FeatureStart() { GEOARROW_THROW_NOT_OK(&error_, v_.feat_start(&v_)); }
+
+  void GeomStart(enum GeoArrowGeometryType geometry_type) {
+    GEOARROW_THROW_NOT_OK(&error_, v_.geom_start(&v_, geometry_type, dim_));
+  }
+
+  void RingStart() { GEOARROW_THROW_NOT_OK(&error_, v_.ring_start(&v_)); }
+
+  void WriteCoord(const S2Point& v) { WriteCoord(S2LatLng(v)); }
+
+  void WriteCoord(const S2LatLng& v) {
+    WriteCoord(v.lng().degrees(), v.lat().degrees());
+  }
+
+  void WriteCoord(const internal::GeoArrowVertex& v,
+                  enum GeoArrowDimensions dim_src = GEOARROW_DIMENSIONS_XY) {
+    if (coords_.n_coords == kCoordsCapcity) {
+      FlushCoords();
+    }
+
+    if (dim_ == GEOARROW_DIMENSIONS_XY) {
+      const_cast<double*>(coords_.values[0])[coords_.n_coords] = v.lng;
+      const_cast<double*>(coords_.values[1])[coords_.n_coords] = v.lat;
+      ++coords_.n_coords;
+      return;
+    }
+
+    int map[5];
+    GeoArrowMapDimensions(dim_src, dim_, map);
+    std::memcpy(coord_src_ + 1, &v, sizeof(v));
+    for (int i = 0; i < 4; i++) {
+      coord_dst_[i] = coord_src_[map[i] + 1];
+    }
+
+    for (int i = 0; i < coords_.n_values; ++i) {
+      const_cast<double*>(coords_.values[i])[coords_.n_coords] = coord_dst_[i];
+    }
+    ++coords_.n_coords;
+  }
+
+  void WriteCoord(double x, double y) {
+    if (coords_.n_coords == kCoordsCapcity) {
+      FlushCoords();
+    }
+
+    const_cast<double*>(coords_.values[0])[coords_.n_coords] = x;
+    const_cast<double*>(coords_.values[1])[coords_.n_coords] = y;
+    for (int i = 2; i < coords_.n_values; ++i) {
+      const_cast<double*>(coords_.values[i])[coords_.n_coords] = coord_src_[0];
+    }
+
+    ++coords_.n_coords;
+  }
+
+  void FlushCoords() {
+    if (coords_.n_coords == 0) {
+      return;
+    }
+
+    GEOARROW_THROW_NOT_OK(&error_, v_.coords(&v_, &coords_));
+    coords_.n_coords = 0;
+  }
+
+  void RingEnd() {
+    FlushCoords();
+    GEOARROW_THROW_NOT_OK(&error_, v_.ring_end(&v_));
+  }
+
+  void GeomEnd() {
+    FlushCoords();
+    GEOARROW_THROW_NOT_OK(&error_, v_.feat_end(&v_));
+  }
+
+  void FeatureEnd() { GEOARROW_THROW_NOT_OK(&error_, v_.feat_end(&v_)); }
+
+  void Finish(struct ArrowArray* out) {
+    GEOARROW_THROW_NOT_OK(&error_,
+                          GeoArrowWKBWriterFinish(&writer_, out, &error_));
+  }
+
+ private:
+  GeoArrowWKBWriter writer_{};
+  GeoArrowVisitor v_{};
+  GeoArrowError error_{};
+  enum GeoArrowDimensions dim_ {};
+  struct GeoArrowCoordView coords_{};
+  std::array<double, 64> coord_buf_{};
+  static constexpr int64_t kCoordsCapcity = 64 / 4;
+  double coord_src_[5];
+  double coord_dst_[5];
 };
 
 /// \brief Generic view of Arrow input

--- a/src/s2geography/sedona_udf/sedona_udf_test_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_test_internal.h
@@ -2,6 +2,10 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 #include "geoarrow/geoarrow.hpp"
@@ -95,11 +99,14 @@ class TestGeometry {
     return result;
   }
 
-  static TestGeometry FromWKB(const std::vector<uint8_t>& wkb) {
+  static TestGeometry FromWKB(std::vector<uint8_t> wkb) {
     TestGeometry result;
+    result.data_ = std::move(wkb);
+
     struct GeoArrowWKBReader reader;
     GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKBReaderInit(&reader));
-    struct GeoArrowBufferView src{wkb.data(), static_cast<int64_t>(wkb.size())};
+    struct GeoArrowBufferView src{result.data_.data(),
+                                  static_cast<int64_t>(result.data_.size())};
     struct GeoArrowGeometryView view;
     GeoArrowErrorCode code =
         GeoArrowWKBReaderRead(&reader, src, &view, nullptr);
@@ -108,7 +115,9 @@ class TestGeometry {
       throw std::runtime_error("Invalid WKB");
     }
 
-    // Copy the parsed geometry into our owned GeoArrowGeometry
+    // Copy the parsed geometry into our owned GeoArrowGeometry. Because data_
+    // is attached to this object, the pointed to buffers from the nodes will
+    // stay valid
     code = GeoArrowGeometryShallowCopy(view, &result.geom_);
     GeoArrowWKBReaderReset(&reader);
     if (code != GEOARROW_OK) {
@@ -132,6 +141,7 @@ class TestGeometry {
   struct GeoArrowGeometry geom_;
   std::string label_;
   bool oriented_;
+  std::vector<uint8_t> data_;
 };
 
 // We use a simple model for testing functions: types are either geoarrow.wkb

--- a/src/s2geography/sedona_udf/sedona_udf_test_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_test_internal.h
@@ -2,11 +2,124 @@
 
 #include <gtest/gtest.h>
 
+#include <vector>
+
 #include "geoarrow/geoarrow.hpp"
 #include "nanoarrow/nanoarrow.hpp"
 #include "s2geography.h"
-#include "s2geography/s2geography_gtest_util.h"
 #include "s2geography/sedona_udf/sedona_extension.h"
+
+/// \brief An owning wrapper around a GeoArrowGeometry with utilities to
+/// construct from WKT or WKB
+class TestGeometry {
+ public:
+  TestGeometry() : oriented_(false) {
+    GEOARROW_THROW_NOT_OK(nullptr, GeoArrowGeometryInit(&geom_));
+  }
+
+  ~TestGeometry() { GeoArrowGeometryReset(&geom_); }
+
+  TestGeometry(const TestGeometry&) = delete;
+  TestGeometry& operator=(const TestGeometry&) = delete;
+
+  TestGeometry(TestGeometry&& other) noexcept
+      : geom_(other.geom_),
+        label_(std::move(other.label_)),
+        oriented_(other.oriented_) {
+    GeoArrowGeometryInit(&other.geom_);
+  }
+
+  TestGeometry& operator=(TestGeometry&& other) noexcept {
+    if (this != &other) {
+      GeoArrowGeometryReset(&geom_);
+      geom_ = other.geom_;
+      GeoArrowGeometryInit(&other.geom_);
+      label_ = std::move(other.label_);
+      oriented_ = other.oriented_;
+    }
+    return *this;
+  }
+
+  std::string ToWKT(int precision = 16) const {
+    struct GeoArrowWKTWriter writer;
+    GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKTWriterInit(&writer));
+    writer.precision = precision;
+
+    struct GeoArrowVisitor v;
+    GeoArrowVisitorInitVoid(&v);
+    GeoArrowWKTWriterInitVisitor(&writer, &v);
+
+    GEOARROW_THROW_NOT_OK(nullptr, GeoArrowGeometryViewVisit(geom(), &v));
+
+    nanoarrow::UniqueArray out;
+    GEOARROW_THROW_NOT_OK(nullptr, S2GeographyGeoArrowWKTWriterFinish(
+                                       &writer, out.get(), nullptr));
+    GeoArrowWKTWriterReset(&writer);
+
+    auto* offsets = reinterpret_cast<const int32_t*>(out->buffers[1]);
+    auto* data = reinterpret_cast<const char*>(out->buffers[2]);
+    return std::string(data, offsets[1]);
+  }
+
+  static TestGeometry FromWKT(std::string_view wkt) {
+    TestGeometry result;
+    result.label_ = wkt;
+
+    struct GeoArrowStringView wkt_view{wkt.data(),
+                                       static_cast<int64_t>(wkt.size())};
+
+    struct GeoArrowVisitor v{};
+    GeoArrowGeometryInitVisitor(&result.geom_, &v);
+
+    struct GeoArrowWKTReader reader;
+    GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKTReaderInit(&reader));
+    GeoArrowErrorCode code = GeoArrowWKTReaderVisit(&reader, wkt_view, &v);
+    GeoArrowWKTReaderReset(&reader);
+    if (code != GEOARROW_OK) {
+      throw std::runtime_error("Invalid WKT");
+    }
+
+    return result;
+  }
+
+  static TestGeometry FromWKB(const std::vector<uint8_t>& wkb) {
+    TestGeometry result;
+    struct GeoArrowWKBReader reader;
+    GEOARROW_THROW_NOT_OK(nullptr, GeoArrowWKBReaderInit(&reader));
+    struct GeoArrowBufferView src{wkb.data(), static_cast<int64_t>(wkb.size())};
+    struct GeoArrowGeometryView view;
+    GeoArrowErrorCode code =
+        GeoArrowWKBReaderRead(&reader, src, &view, nullptr);
+    if (code != GEOARROW_OK) {
+      GeoArrowWKBReaderReset(&reader);
+      throw std::runtime_error("Invalid WKB");
+    }
+
+    // Copy the parsed geometry into our owned GeoArrowGeometry
+    code = GeoArrowGeometryShallowCopy(view, &result.geom_);
+    GeoArrowWKBReaderReset(&reader);
+    if (code != GEOARROW_OK) {
+      throw std::runtime_error("Failed to copy WKB geometry");
+    }
+
+    return result;
+  }
+
+  struct GeoArrowGeometryView geom() const {
+    return GeoArrowGeometryAsView(&geom_);
+  }
+
+  bool oriented() const { return oriented_; }
+
+  void set_oriented(bool oriented) { oriented_ = oriented; }
+
+  std::string_view label() const { return label_; }
+
+ private:
+  struct GeoArrowGeometry geom_;
+  std::string label_;
+  bool oriented_;
+};
 
 // We use a simple model for testing functions: types are either geoarrow.wkb
 // or an Arrow type (the only ones used here are bool, int32, and double).
@@ -230,27 +343,35 @@ inline void TestResultArrow(struct ArrowArray* result,
 // Check a geography result. This rounds the WKT output to 6 decimal places
 // to avoid floating point differences between platforms.
 inline void TestResultGeography(
-    struct ArrowArray* result,
-    std::vector<std::optional<std::string>> expected) {
+    struct ArrowArray* result, std::vector<std::optional<std::string>> expected,
+    int precision = 6) {
   ASSERT_EQ(result->length, expected.size());
 
-  s2geography::geoarrow::Reader reader;
-  s2geography::geoarrow::ImportOptions options;
-  options.set_check(false);
-  reader.Init(s2geography::geoarrow::Reader::InputType::kWKB, options);
-  std::vector<std::unique_ptr<s2geography::Geography>> geogs;
-  reader.ReadGeography(result, 0, result->length, &geogs);
+  nanoarrow::UniqueArrayView result_view;
+  ArrowArrayViewInitFromType(result_view.get(), NANOARROW_TYPE_BINARY);
+  NANOARROW_THROW_NOT_OK(
+      ArrowArrayViewSetArray(result_view.get(), result, nullptr));
 
   for (int64_t i = 0; i < result->length; i++) {
     SCOPED_TRACE("expected[" + std::to_string(i) + "]");
-    if (geogs[i].get() == nullptr) {
+    if (ArrowArrayViewIsNull(result_view.get(), i)) {
       ASSERT_FALSE(expected[i].has_value())
           << "Expected " << ::testing::PrintToString(*expected[i])
           << " but got NULL";
     } else {
+      auto actual_binary = ArrowArrayViewGetBytesUnsafe(result_view.get(), i);
+      std::vector<uint8_t> actual_binary_vec(
+          actual_binary.data.as_uint8,
+          actual_binary.data.as_uint8 + actual_binary.size_bytes);
+      auto actual_geometry = TestGeometry::FromWKB(actual_binary_vec);
+
       ASSERT_TRUE(expected[i].has_value())
-          << "Expected NULL but got " << ::testing::PrintToString(*geogs[i]);
-      ASSERT_THAT(*geogs[i], s2geography::WktEquals6(*expected[i]));
+          << "Expected NULL but got "
+          << ::testing::PrintToString(actual_geometry.ToWKT(precision));
+
+      auto expected_geometry = TestGeometry::FromWKT(*expected[i]);
+      ASSERT_EQ(actual_geometry.ToWKT(precision),
+                expected_geometry.ToWKT(precision));
     }
   }
 }

--- a/src/s2geography/sedona_udf/sedona_udf_test_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_test_internal.h
@@ -58,7 +58,20 @@ class TestGeometry {
 
     auto* offsets = reinterpret_cast<const int32_t*>(out->buffers[1]);
     auto* data = reinterpret_cast<const char*>(out->buffers[2]);
-    return std::string(data, offsets[1]);
+    std::string string_out(data, offsets[1]);
+
+    // Work around a bug in the WKT writer for empty points
+    if (string_out == "POINT (nan nan)") {
+      return "POINT EMPTY";
+    } else if (string_out == "POINT Z (nan nan nan)") {
+      return "POINT Z EMPTY";
+    } else if (string_out == "POINT M (nan nan nan)") {
+      return "POINT M EMPTY";
+    } else if (string_out == "POINT ZM (nan nan nan nan)") {
+      return "POINT ZM EMPTY";
+    }
+
+    return string_out;
   }
 
   static TestGeometry FromWKT(std::string_view wkt) {

--- a/src/s2geography/sedona_udf/sedona_udf_test_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_test_internal.h
@@ -29,7 +29,8 @@ class TestGeometry {
   TestGeometry(TestGeometry&& other) noexcept
       : geom_(other.geom_),
         label_(std::move(other.label_)),
-        oriented_(other.oriented_) {
+        oriented_(other.oriented_),
+        data_(std::move(other.data_)) {
     GeoArrowGeometryInit(&other.geom_);
   }
 
@@ -40,6 +41,7 @@ class TestGeometry {
       GeoArrowGeometryInit(&other.geom_);
       label_ = std::move(other.label_);
       oriented_ = other.oriented_;
+      data_ = std::move(other.data_);
     }
     return *this;
   }


### PR DESCRIPTION
Not only is this a cool feature (we don't drop ZM values when computing closest points and we propagate source vertex lon/lat values instead of roundtripping through S2Point), it also is (slightly) faster because it more directly writes values to WKB output (i.e., no creating a polygon or polyline just to dump it to WKB).

The end goal of this PR was to add ZM support to two functions, but this required adding the testing and IO infrastructure (most of the changes). Future functions should be much easier to add ZM support to.

```
s2geography-st_closestpoint-ArrayArray(geog(Point), geog(Point))
                        time:   [11.320 ms 11.397 ms 11.460 ms]
                        change: [−13.854% −11.639% −9.7267%] (p = 0.00 < 0.05)

s2geography-st_closestpoint-ArrayScalar(geog(Point), geog(LineString(10)))
                        time:   [57.350 ms 57.441 ms 57.529 ms]
                        change: [−8.3884% −7.8134% −7.3003%] (p = 0.00 < 0.05)

s2geography-st_closestpoint-ArrayScalar(geog(LineString(10)), geog(LineString(10)))
                        time:   [532.26 ms 533.72 ms 535.08 ms]
                        change: [+1.2990% +1.7182% +2.1552%] (p = 0.00 < 0.05)
```