### PR TITLE
feat: Add ReducePrecision and Simplify with ZM support

### DIFF
--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -625,7 +625,7 @@ class GeoArrowPolygonLayer : public S2Builder::Layer {
   GraphOptions graph_options() const override {
     return GraphOptions(S2Builder::EdgeType::DIRECTED,
                         GraphOptions::DegenerateEdges::DISCARD,
-                        GraphOptions::DuplicateEdges::KEEP,
+                        GraphOptions::DuplicateEdges::MERGE,
                         GraphOptions::SiblingPairs::DISCARD);
   }
 
@@ -819,8 +819,15 @@ struct RebuildExec {
     bool has_polygons = !polygon_lengths_.empty();
     int num_types = has_points + has_lines + has_polygons;
 
+    // If there are no outputs, write an empty attempting to preserve the input
+    // geometry type.
+    if (num_types == 0) {
+      out->AppendEmpty(value0.geometry_type());
+      return;
+    }
+
     // If there is only one type of output, write it directly
-    if (num_types <= 1) {
+    if (num_types == 1) {
       out->FeatureStart();
       if (has_points) WritePointOutput(out);
       if (has_lines) WriteLinesOuput(out);
@@ -919,7 +926,7 @@ struct RebuildExec {
   std::vector<internal::GeoArrowVertex> polygon_vertices_;
 };
 
-struct SnapToGridExec {
+struct ReducePrecisionExec {
   using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = DoubleInputView;
   using out_t = GeoArrowOutputBuilder;
@@ -989,8 +996,8 @@ void UnionKernel(struct SedonaCScalarKernel* out) {
       out, "st_union");
 }
 
-void SnapToGridKernel(struct SedonaCScalarKernel* out) {
-  InitBinaryKernel<SnapToGridExec>(out, "st_snaptogrid");
+void ReducePrecisionKernel(struct SedonaCScalarKernel* out) {
+  InitBinaryKernel<ReducePrecisionExec>(out, "st_reduceprecision");
 }
 
 }  // namespace sedona_udf

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -513,7 +513,7 @@ struct EdgeTracker {
 /// output. To mediate this, we use the OutputGeometry to buffer one output
 /// feature at a time.
 ///
-/// This strucutre also takes care of reordering polygon rings to align with
+/// This structure also takes care of reordering polygon rings to align with
 /// shell/hole expectations of simple features output (i.e., oriented rings are
 /// written to this object and reordering only occurs on output).
 ///

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -757,6 +757,18 @@ struct OutputGeometry {
       return;
     }
 
+    // Another common case: there are no holes, so each ring becomes
+    // its own polygon
+    if (holes.empty()) {
+      ring_order_.clear();
+      ring_order_.reserve(num_rings);
+      for (int s : shells) {
+        polygon_lengths_.push_back(1);
+        ring_order_.push_back(s);
+      }
+      return;
+    }
+
     // Multiple shells: build S2Loops for containment checks, which are
     // more efficient than brute force when checking multiple holes.
     std::vector<std::unique_ptr<S2Loop>> s2loops(shells.size());

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -485,20 +485,6 @@ struct EdgeTracker {
   std::vector<const S2Shape*> shapes_;
 };
 
-/// \brief A reference to a source edge, used as a label payload
-struct SourceEdgeRef {
-  int shape_id;
-  int edge_id;
-};
-
-/// \brief An S2Builder layer that collects degenerate edges (points) and
-/// resolves them back to native GeoArrow vertices via labels.
-///
-/// Like s2builderutil::S2PointVectorLayer, this layer expects all edges to be
-/// degenerate. It uses Graph::LabelFetcher to retrieve source (shape_id,
-/// edge_id) references that were attached as labels when the edges were added
-/// to the builder, then resolves those references against the source
-/// GeoArrowGeography to recover lossless lon/lat/z/m coordinates.
 class GeoArrowPointVectorLayer : public S2Builder::Layer {
  public:
   using GraphOptions = S2Builder::GraphOptions;
@@ -553,7 +539,69 @@ class GeoArrowPointVectorLayer : public S2Builder::Layer {
  private:
   EdgeTracker* edge_tracker_;
   std::vector<internal::GeoArrowVertex>* points_out_;
-  GraphOptions::DuplicateEdges duplicate_edges_;
+};
+
+class GeoArrowPolylinesLayer : public S2Builder::Layer {
+ public:
+  using GraphOptions = S2Builder::GraphOptions;
+  using Graph = S2Builder::Graph;
+  using EdgeId = Graph::EdgeId;
+  using InputEdgeId = Graph::InputEdgeId;
+
+  GeoArrowPolylinesLayer(EdgeTracker* edge_tracker,
+                         std::vector<internal::GeoArrowVertex>* points_out,
+                         std::vector<int>* lengths_out)
+      : edge_tracker_(edge_tracker),
+        points_out_(points_out),
+        lengths_out_(lengths_out) {}
+
+  GraphOptions graph_options() const override {
+    return GraphOptions(S2Builder::EdgeType::DIRECTED,
+                        GraphOptions::DegenerateEdges::DISCARD,
+                        GraphOptions::DuplicateEdges::MERGE,
+                        GraphOptions::SiblingPairs::DISCARD);
+  }
+
+  void Build(const Graph& g, S2Error* error) override {
+    std::vector<Graph::EdgePolyline> edge_polylines =
+        g.GetPolylines(Graph::PolylineType::WALK);
+
+    for (const auto& edge_polyline : edge_polylines) {
+      Start();
+
+      // Write the first vertex of the polyline
+      EdgeId first_edge_id = edge_polyline[0];
+      S2Point first_pt = g.vertex(g.edge(first_edge_id).first);
+      for (InputEdgeId input_edge_id : g.input_edge_ids(first_edge_id)) {
+        Write(edge_tracker_->ResolveEdge(input_edge_id).Interpolate(first_pt));
+        break;
+      }
+
+      // Write the second vertex of each edge
+      for (EdgeId edge_id : edge_polyline) {
+        S2Point pt = g.vertex(g.edge(edge_id).second);
+        for (InputEdgeId input_edge_id : g.input_edge_ids(edge_id)) {
+          Write(edge_tracker_->ResolveEdge(input_edge_id).Interpolate(pt));
+          break;
+        }
+      }
+
+      lengths_out_->push_back(current_length_);
+    }
+  }
+
+  void Start() { current_length_ = 0; }
+
+  void Write(const internal::GeoArrowVertex& v) {
+    points_out_->push_back(v);
+    ++current_length_;
+  }
+
+ private:
+  EdgeTracker* edge_tracker_;
+  std::vector<int>* lengths_out_;
+  std::vector<internal::GeoArrowVertex>* points_out_;
+  int current_length_{0};
 };
 
 struct RebuildExec {
@@ -567,8 +615,11 @@ struct RebuildExec {
 
   void Exec(const GeoArrowGeography& value0, GeoArrowOutputBuilder* out) {
     builder_.Reset();
-    native_points_.clear();
     edge_tracker_.Clear();
+
+    native_points_.clear();
+    line_lengths_.clear();
+    line_vertices_.clear();
 
     // Start a layer that collects point vertices
     builder_.StartLayer(absl::make_unique<GeoArrowPointVectorLayer>(
@@ -580,8 +631,15 @@ struct RebuildExec {
       return true;
     });
 
-    // TODO: add GeoArrow-aware layers for lines and polygons
-    // builder_.AddShape(*value0.lines());
+    // Start a layer that collects polyline vertices
+    auto lines_layer = absl::make_unique<GeoArrowPolylinesLayer>(
+        &edge_tracker_, &line_vertices_, &line_lengths_);
+    builder_.StartLayer(std::move(lines_layer));
+
+    edge_tracker_.Add(value0.lines());
+    builder_.AddShape(*value0.lines());
+
+    // TODO: add GeoArrow-aware layer for polygons
     // builder_.AddShape(*value0.polygons());
 
     // build the output
@@ -597,21 +655,27 @@ struct RebuildExec {
     out->SetDimensions(value0.dimensions());
 
     // If there is only point output, write it
-    if (!native_points_.empty()) {
+    if (!native_points_.empty() && line_lengths_.empty()) {
       out->FeatureStart();
       WritePointOutput(out);
       out->FeatureEnd();
       return;
     }
 
-    // TODO: check for only polyline output
+    if (!line_lengths_.empty() && native_points_.empty()) {
+      out->FeatureStart();
+      WriteLinesOuput(out);
+      out->FeatureEnd();
+      return;
+    }
 
-    // TODO: check for only polgon output
+    // TODO: check for only polygon output
 
     // Otherwise, write a GEOMETRYCOLLECTION with any of the available output
     out->FeatureStart();
     out->GeomStart(GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION);
     WritePointOutput(out);
+    WriteLinesOuput(out);
     out->GeomEnd();
     out->FeatureEnd();
   }
@@ -632,10 +696,33 @@ struct RebuildExec {
     }
   }
 
+  void WriteLinesOuput(out_t* out) {
+    if (line_lengths_.size() == 1) {
+      out->GeomStart(GEOARROW_GEOMETRY_TYPE_LINESTRING);
+      for (int i = 0; i < line_lengths_[0]; ++i) {
+        out->WriteCoord(line_vertices_[i]);
+      }
+      out->GeomEnd();
+    } else if (native_points_.size() > 1) {
+      out->GeomStart(GEOARROW_GEOMETRY_TYPE_MULTILINESTRING);
+      int line_vertex_id = 0;
+      for (int line_length : line_lengths_) {
+        out->GeomStart(GEOARROW_GEOMETRY_TYPE_LINESTRING);
+        for (int i = 0; i < line_length; ++i) {
+          out->WriteCoord(line_vertices_[line_vertex_id++]);
+        }
+        out->GeomEnd();
+      }
+      out->GeomEnd();
+    }
+  }
+
   S2Builder builder_;
   S2Builder::Options builder_options_;
   EdgeTracker edge_tracker_;
   std::vector<internal::GeoArrowVertex> native_points_;
+  std::vector<int> line_lengths_;
+  std::vector<internal::GeoArrowVertex> line_vertices_;
 };
 
 struct UnaryUnionGridSizeExec {

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -436,48 +436,66 @@ std::unique_ptr<Geography> S2UnionAggregator::Finalize() {
 
 namespace sedona_udf {
 
+/// \brief Tracker to help obtain source edges from S2Builder::Graph edges
 struct EdgeTracker {
+  /// \brief Create an edge tracker with empty state
   EdgeTracker() { Clear(); }
 
+  /// \brief Clear this tracker of any existing state
   void Clear() {
     num_edges_.clear();
     num_edges_.push_back(0);
     edge_count_ = 0;
   }
 
+  /// \brief Add a tracked shape
+  ///
+  /// The number of edges of this shape is used when mapping the global
+  /// (S2Builder) edge ID back to the source. This should be called paired with
+  /// each addition of a shape to the builder.
+  ///
+  /// In general, whenever the S2Builder has to be invoked, performance is not
+  /// driven by the reading and writing of coordinates, so the the overhead of
+  /// resolving source edges for potentially better writes is minimal.
   void Add(const S2Shape* shape) {
     shapes_.push_back(shape);
     edge_count_ += shape->num_edges();
     num_edges_.push_back(edge_count_);
   }
 
-  std::pair<const S2Shape*, int> ResolveSource(int edge_id) {
+  /// \brief Resolve the input source shape and local edge ID
+  std::pair<const S2Shape*, int> ResolveSource(int edge_id) const {
     auto it = std::upper_bound(num_edges_.begin(), num_edges_.end(), edge_id);
     int shape_idx = static_cast<int>(std::distance(num_edges_.begin(), it)) - 1;
     return {shapes_[shape_idx], edge_id - num_edges_[shape_idx]};
   }
 
-  internal::GeoArrowEdge ResolveEdge(int edge_id) {
+  /// \brief Resolve the source edge associated with the input
+  ///
+  /// This edge has its vertices normalized to XYZM order such that the output
+  /// handling need not consider the input dimensions after the edge has been
+  /// resolved.
+  internal::GeoArrowEdge ResolveEdge(int edge_id) const {
     auto src = ResolveSource(edge_id);
-    switch (src.first->dimension()) {
-      case 0: {
+    switch (src.first->type_tag()) {
+      case GeoArrowPointShape::kTypeTag: {
         const auto* points =
             reinterpret_cast<const GeoArrowPointShape*>(src.first);
         return points->native_edge(src.second).Normalize(points->dimensions());
       }
-      case 1: {
+      case GeoArrowLaxPolylineShape::kTypeTag: {
         const auto* lines =
             reinterpret_cast<const GeoArrowLaxPolylineShape*>(src.first);
         return lines->native_edge(src.second).Normalize(lines->dimensions());
       }
-      case 2: {
+      case GeoArrowLaxPolygonShape::kTypeTag: {
         const auto* polygons =
             reinterpret_cast<const GeoArrowLaxPolygonShape*>(src.first);
         return polygons->native_edge(src.second)
             .Normalize(polygons->dimensions());
       }
       default:
-        throw Exception("Unexpected value of dimension()");
+        throw Exception("Unexpected value of type_tag()");
     }
   }
 
@@ -486,7 +504,24 @@ struct EdgeTracker {
   std::vector<const S2Shape*> shapes_;
 };
 
+/// \brief Output geometry collector
+///
+/// When using the S2Builder or S2Builder::Layer via the S2BooleanOperation, it
+/// is not generally possible to predict the exact output type in advance such
+/// that output could be written directly whilst walking the graph to obtain the
+/// output. To mediate this, we use the OutputGeometry to buffer one output
+/// feature at a time.
+///
+/// This strucutre also takes care of reordering polygon rings to align with
+/// shell/hole expectations of simple features output (i.e., oriented rings are
+/// written to this object and reordering only occurs on output).
+///
+/// This object makes an attempt to reuse scratch space between iterations to
+/// mitigate the fact that it has to buffer a whole geometry at a time; however,
+/// this might lead to increased memory usage if a lot of threads are building
+/// large output at once.
 struct OutputGeometry {
+  /// \brief Clear this object
   void Clear() {
     points_.clear();
     line_lengths_.clear();
@@ -498,34 +533,75 @@ struct OutputGeometry {
     current_line_length_ = 0;
   }
 
+  /// \brief Add a point to the output
+  ///
+  /// This vertex must have been normalized before this call to correctly write
+  /// ZM information to the output.
   void AddPoint(const internal::GeoArrowVertex& v) { points_.push_back(v); }
 
+  /// \brief Add a vertex to the current line output
+  ///
+  /// This vertex must have been normalized before this call to correctly write
+  /// ZM information to the output.
   void AddLineVertex(const internal::GeoArrowVertex& v) {
     line_vertices_.push_back(v);
     ++current_line_length_;
   }
 
+  /// \brief Finish the current line output
   void FinishLine() {
     line_lengths_.push_back(current_line_length_);
     current_line_length_ = 0;
   }
 
+  /// \brief Add a vertex to the current ring
+  ///
+  /// This vertex must have been normalized before this call to correctly write
+  /// ZM information to the output.
   void AddRingVertex(const internal::GeoArrowVertex& v) {
     polygon_vertices_.push_back(v);
   }
 
+  /// \brief Finish the current ring output
   void FinishRing() {
     ring_offsets_.push_back(static_cast<int>(polygon_vertices_.size()));
   }
 
+  /// \brief Return true if any points were added to the output
   bool has_points() const { return !points_.empty(); }
+
+  /// \brief Return true if any lines were added to the output
   bool has_lines() const { return !line_lengths_.empty(); }
+
+  /// \brief Return true of any rings were added to the output
   bool has_polygons() const { return ring_offsets_.size() > 1; }
+
+  /// \brief Return the number of output geometry dimensions
   int num_types() const { return has_points() + has_lines() + has_polygons(); }
 
-  void WriteTo(GeoArrowOutputBuilder* out, uint8_t geometry_type) {
+  /// \brief Write this output to a builder
+  ///
+  /// This method uses the following heuristic to determine what to write:
+  ///
+  /// - empty output is written as empty according to geometry_type_if_empty
+  /// (typically
+  ///   the input geometry type is propagated)
+  /// - Single points are written as POINT; multiple points are written as
+  /// MULTIPOINT
+  /// - Single linestrings are written as LINESTRING; multiple linestrings are
+  /// written as
+  ///   MULTILINESTRING
+  /// - Single polygons are written as POLYGON; multiple polygons are written as
+  /// MULTIPOLYGON
+  /// - More than one of the above is written as a GEOMETRYCOLLECTION
+  ///
+  /// This is the point at which the nesting of any output polygon rings are
+  /// calculated.
+  void WriteTo(GeoArrowOutputBuilder* out,
+               uint8_t geometry_type_if_empty =
+                   GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION) {
     if (num_types() == 0) {
-      out->AppendEmpty(geometry_type);
+      out->AppendEmpty(geometry_type_if_empty);
       return;
     }
 
@@ -650,7 +726,7 @@ struct OutputGeometry {
       return;
     }
 
-    // Build ring nodes so we can use GeoArrowLoop for area/containment
+    // Build ring nodes so we can use GeoArrowLoop for utilities
     BuildRingNodes();
 
     // Classify shells vs holes using signed area.
@@ -745,6 +821,62 @@ struct OutputGeometry {
   std::vector<S2Point> scratch_;
 };
 
+// Common utilities for building output from the edge tracker and the
+// S2Builder::Graph
+void PopulateVertex(const S2Builder::Graph& g, const EdgeTracker& tracker,
+                    int edge_id, const S2Point& v,
+                    internal::GeoArrowVertex* vt) {
+  // For now, always pick the first piece of edge information to propagate
+  // from the source. This could also be averaged or otherwise aggregated
+  // (e.g., min, max, median). GEOS seems to propagate the first piece of
+  // information for points but averages ZM information of edge crossings.
+  for (int input_edge_id : g.input_edge_ids(edge_id)) {
+    *vt = tracker.ResolveEdge(input_edge_id).Interpolate(v);
+    break;
+  }
+
+  // If this vertex was snapped to a new location, use the snapped output.
+  // Otherwise, use the original input to avoid rounding errors from the
+  // roundtrip to S2Point.
+  if (vt->ToPoint() != v) {
+    vt->SetPoint(v);
+  }
+}
+
+template <typename Visit>
+void VisitTrackedVertices(const S2Builder::Graph& g, const EdgeTracker& tracker,
+                          const std::vector<int>& edge_loop, Visit&& visit) {
+  internal::GeoArrowVertex vt;
+
+  S2Point first_pt = g.vertex(g.edge(edge_loop[0]).first);
+  PopulateVertex(g, tracker, edge_loop[0], first_pt, &vt);
+  visit(vt);
+
+  for (int edge_id : edge_loop) {
+    S2Point pt = g.vertex(g.edge(edge_id).second);
+    PopulateVertex(g, tracker, edge_loop[0], pt, &vt);
+    visit(vt);
+  }
+}
+
+template <typename Visit>
+void VisitVertices(const S2Builder::Graph& g, const std::vector<int>& edge_loop,
+                   Visit&& visit) {
+  internal::GeoArrowVertex vt;
+
+  S2Point first_pt = g.vertex(g.edge(edge_loop[0]).first);
+  vt.SetPoint(first_pt);
+  visit(vt);
+
+  for (int edge_id : edge_loop) {
+    S2Point pt = g.vertex(g.edge(edge_id).second);
+    vt.SetPoint(pt);
+    visit(vt);
+  }
+}
+
+/// \brief Output layer that collects degenerate edges in the graph as point
+/// output
 class GeoArrowPointVectorLayer : public S2Builder::Layer {
  public:
   using GraphOptions = S2Builder::GraphOptions;
@@ -752,7 +884,8 @@ class GeoArrowPointVectorLayer : public S2Builder::Layer {
   using EdgeId = Graph::EdgeId;
   using InputEdgeId = Graph::InputEdgeId;
 
-  GeoArrowPointVectorLayer(EdgeTracker* edge_tracker, OutputGeometry* output)
+  GeoArrowPointVectorLayer(OutputGeometry* output,
+                           EdgeTracker* edge_tracker = nullptr)
       : edge_tracker_(edge_tracker), output_(output) {}
 
   GraphOptions graph_options() const override {
@@ -762,6 +895,8 @@ class GeoArrowPointVectorLayer : public S2Builder::Layer {
   }
 
   void Build(const Graph& g, S2Error* error) override {
+    internal::GeoArrowVertex vt;
+
     for (EdgeId edge_id = 0; static_cast<size_t>(edge_id) < g.edges().size();
          ++edge_id) {
       // Resolve the edge
@@ -774,18 +909,13 @@ class GeoArrowPointVectorLayer : public S2Builder::Layer {
 
       // Resolve the vertex as an S2Point
       S2Point pt = g.vertex(edge.first);
-      internal::GeoArrowVertex vt;
 
-      // GEOS seems to always return the first Z or M it encounters for point
-      // output. We could also merge by averaging or some other strategy.
-      for (InputEdgeId input_edge_id : g.input_edge_ids(edge_id)) {
-        auto e = edge_tracker_->ResolveEdge(input_edge_id);
-        vt = e.v0;
-        break;
-      }
-
-      // If this vertex was snapped to a new location, set its vertex
-      if (pt != vt.ToPoint()) {
+      // If we have the ability to propagate input edge information to the
+      // output, use the EdgeTracker to resolve input edges. Otherwise, just
+      // write 2D points based on the builder-derived vertex.
+      if (edge_tracker_) {
+        PopulateVertex(g, *edge_tracker_, edge.first, pt, &vt);
+      } else {
         vt.SetPoint(pt);
       }
 
@@ -806,7 +936,8 @@ class GeoArrowPolylinesLayer : public S2Builder::Layer {
   using EdgeId = Graph::EdgeId;
   using InputEdgeId = Graph::InputEdgeId;
 
-  GeoArrowPolylinesLayer(EdgeTracker* edge_tracker, OutputGeometry* output)
+  GeoArrowPolylinesLayer(OutputGeometry* output,
+                         EdgeTracker* edge_tracker = nullptr)
       : edge_tracker_(edge_tracker), output_(output) {}
 
   GraphOptions graph_options() const override {
@@ -820,27 +951,24 @@ class GeoArrowPolylinesLayer : public S2Builder::Layer {
     std::vector<Graph::EdgePolyline> edge_polylines =
         g.GetPolylines(Graph::PolylineType::WALK);
 
-    for (const auto& edge_polyline : edge_polylines) {
-      // Write the first vertex of the polyline
-      EdgeId first_edge_id = edge_polyline[0];
-      S2Point first_pt = g.vertex(g.edge(first_edge_id).first);
-      for (InputEdgeId input_edge_id : g.input_edge_ids(first_edge_id)) {
-        output_->AddLineVertex(
-            edge_tracker_->ResolveEdge(input_edge_id).Interpolate(first_pt));
-        break;
+    // If we can track input edge information, do so now (or else
+    // use to a simpler output path)
+    if (edge_tracker_) {
+      for (const auto& edge_polyline : edge_polylines) {
+        VisitTrackedVertices(g, *edge_tracker_, edge_polyline,
+                             [&](const internal::GeoArrowVertex& vt) {
+                               output_->AddLineVertex(vt);
+                             });
+        output_->FinishLine();
       }
-
-      // Write the second vertex of each edge
-      for (EdgeId edge_id : edge_polyline) {
-        S2Point pt = g.vertex(g.edge(edge_id).second);
-        for (InputEdgeId input_edge_id : g.input_edge_ids(edge_id)) {
-          output_->AddLineVertex(
-              edge_tracker_->ResolveEdge(input_edge_id).Interpolate(pt));
-          break;
-        }
+    } else {
+      for (const auto& edge_polyline : edge_polylines) {
+        VisitVertices(g, edge_polyline,
+                      [&](const internal::GeoArrowVertex& vt) {
+                        output_->AddLineVertex(vt);
+                      });
+        output_->FinishLine();
       }
-
-      output_->FinishLine();
     }
   }
 
@@ -856,7 +984,7 @@ class GeoArrowPolygonLayer : public S2Builder::Layer {
   using EdgeId = Graph::EdgeId;
   using InputEdgeId = Graph::InputEdgeId;
 
-  GeoArrowPolygonLayer(EdgeTracker* edge_tracker, OutputGeometry* output)
+  GeoArrowPolygonLayer(OutputGeometry* output, EdgeTracker* edge_tracker)
       : edge_tracker_(edge_tracker), output_(output) {}
 
   GraphOptions graph_options() const override {
@@ -872,34 +1000,22 @@ class GeoArrowPolygonLayer : public S2Builder::Layer {
       return;
     }
 
-    // Write all loops as rings; polygon grouping is deferred to OutputGeometry
-    for (int i = 0; i < static_cast<int>(edge_loops_.size()); ++i) {
-      WriteLoop(g, i);
-    }
-  }
-
-  void WriteLoop(const Graph& g, int loop_index) {
-    const auto& edge_loop = edge_loops_[loop_index];
-
-    for (EdgeId edge_id : edge_loop) {
-      S2Point pt = g.vertex(g.edge(edge_id).first);
-      for (InputEdgeId input_edge_id : g.input_edge_ids(edge_id)) {
-        output_->AddRingVertex(
-            edge_tracker_->ResolveEdge(input_edge_id).Interpolate(pt));
-        break;
+    if (edge_tracker_) {
+      for (const auto& edge_loop : edge_loops_) {
+        VisitTrackedVertices(g, *edge_tracker_, edge_loop,
+                             [&](const internal::GeoArrowVertex& vt) {
+                               output_->AddRingVertex(vt);
+                             });
+        output_->FinishRing();
+      }
+    } else {
+      for (const auto& edge_loop : edge_loops_) {
+        VisitVertices(g, edge_loop, [&](const internal::GeoArrowVertex& vt) {
+          output_->AddRingVertex(vt);
+        });
+        output_->FinishRing();
       }
     }
-
-    // Close the ring by repeating the first vertex
-    EdgeId first_edge_id = edge_loop[0];
-    S2Point first_pt = g.vertex(g.edge(first_edge_id).first);
-    for (InputEdgeId input_edge_id : g.input_edge_ids(first_edge_id)) {
-      output_->AddRingVertex(
-          edge_tracker_->ResolveEdge(input_edge_id).Interpolate(first_pt));
-      break;
-    }
-
-    output_->FinishRing();
   }
 
  private:
@@ -921,7 +1037,7 @@ struct RebuildExec {
 
     // Start a layer that collects point vertices
     builder_.StartLayer(
-        absl::make_unique<GeoArrowPointVectorLayer>(&edge_tracker_, &output_));
+        absl::make_unique<GeoArrowPointVectorLayer>(&output_, &edge_tracker_));
 
     edge_tracker_.Add(value0.points());
     value0.points()->geom().VisitVertices([&](const S2Point& v) {
@@ -931,14 +1047,14 @@ struct RebuildExec {
 
     // Start a layer that collects polyline vertices
     builder_.StartLayer(
-        absl::make_unique<GeoArrowPolylinesLayer>(&edge_tracker_, &output_));
+        absl::make_unique<GeoArrowPolylinesLayer>(&output_, &edge_tracker_));
 
     edge_tracker_.Add(value0.lines());
     builder_.AddShape(*value0.lines());
 
     // Start a layer that collects polygon vertices
     builder_.StartLayer(
-        absl::make_unique<GeoArrowPolygonLayer>(&edge_tracker_, &output_));
+        absl::make_unique<GeoArrowPolygonLayer>(&output_, &edge_tracker_));
 
     edge_tracker_.Add(value0.polygons());
     builder_.AddShape(*value0.polygons());

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -496,7 +496,6 @@ struct OutputGeometry {
     polygon_vertices_.clear();
     current_line_length_ = 0;
     current_ring_length_ = 0;
-    current_polygon_ring_count_ = 0;
   }
 
   void AddPoint(const internal::GeoArrowVertex& v) { points_.push_back(v); }
@@ -519,17 +518,11 @@ struct OutputGeometry {
   void FinishRing() {
     ring_lengths_.push_back(current_ring_length_);
     current_ring_length_ = 0;
-    ++current_polygon_ring_count_;
-  }
-
-  void FinishPolygon() {
-    polygon_lengths_.push_back(current_polygon_ring_count_);
-    current_polygon_ring_count_ = 0;
   }
 
   bool has_points() const { return !points_.empty(); }
   bool has_lines() const { return !line_lengths_.empty(); }
-  bool has_polygons() const { return !polygon_lengths_.empty(); }
+  bool has_polygons() const { return !ring_lengths_.empty(); }
   int num_types() const { return has_points() + has_lines() + has_polygons(); }
 
   void WriteTo(GeoArrowOutputBuilder* out, uint8_t geometry_type) {
@@ -595,6 +588,8 @@ struct OutputGeometry {
   }
 
   void WritePolygonOutput(GeoArrowOutputBuilder* out) {
+    GroupRings();
+
     int ring_id = 0;
     int vertex_id = 0;
     if (polygon_lengths_.size() == 1) {
@@ -626,6 +621,174 @@ struct OutputGeometry {
     }
   }
 
+  void BuildRingNodes() {
+    ring_nodes_.resize(ring_lengths_.size());
+    const uint8_t* base =
+        reinterpret_cast<const uint8_t*>(polygon_vertices_.data());
+    int vertex_offset = 0;
+    for (size_t i = 0; i < ring_lengths_.size(); ++i) {
+      struct GeoArrowBufferView coords;
+      coords.data = base + vertex_offset * sizeof(internal::GeoArrowVertex);
+      coords.size_bytes =
+          ring_lengths_[i] * sizeof(internal::GeoArrowVertex);
+      GeoArrowGeometryNodeSetInterleaved(&ring_nodes_[i],
+                                         GEOARROW_GEOMETRY_TYPE_LINESTRING,
+                                         GEOARROW_DIMENSIONS_XYZM, coords);
+      vertex_offset += ring_lengths_[i];
+    }
+  }
+
+  void GroupRings() {
+    polygon_lengths_.clear();
+    int num_rings = static_cast<int>(ring_lengths_.size());
+
+    if (num_rings == 0) {
+      return;
+    }
+
+    // Fast path: single ring -> single polygon
+    if (num_rings == 1) {
+      polygon_lengths_.push_back(1);
+      return;
+    }
+
+    // Build ring nodes so we can use GeoArrowLoop for area/containment
+    BuildRingNodes();
+
+    // Classify shells vs holes using signed area.
+    // S2Builder outputs directed edges with interior to the left, so
+    // shells are CCW (positive signed area) and holes are CW (negative).
+    ring_signed_areas_.resize(num_rings);
+    std::vector<int> shells;
+    std::vector<int> holes;
+
+    for (int i = 0; i < num_rings; ++i) {
+      GeoArrowLoop loop(&ring_nodes_[i], &scratch_);
+      ring_signed_areas_[i] = loop.GetSignedArea();
+      if (ring_signed_areas_[i] >= 0) {
+        shells.push_back(i);
+      } else {
+        holes.push_back(i);
+      }
+    }
+
+    // Common case: exactly one shell with zero or more holes
+    if (shells.size() == 1) {
+      polygon_lengths_.push_back(num_rings);
+      // Reorder rings: shell first, then holes (already in order if shell
+      // was the first ring written, but may not be in general)
+      if (shells[0] != 0) {
+        ReorderRings(shells, holes);
+      }
+      return;
+    }
+
+    // Multiple shells: build S2Loops for containment checks, which are
+    // more efficient than brute force when checking multiple holes.
+    std::vector<std::unique_ptr<S2Loop>> s2loops(shells.size());
+    for (size_t s = 0; s < shells.size(); ++s) {
+      GeoArrowLoop loop(&ring_nodes_[shells[s]], &scratch_);
+      std::vector<S2Point> vertices;
+      vertices.reserve(loop.size() - 1);
+      loop.VisitVertices(0, loop.size() - 1, [&](const S2Point& pt) {
+        vertices.push_back(pt);
+        return true;
+      });
+      s2loops[s] = absl::make_unique<S2Loop>(vertices);
+      // Normalize so that Contains() works correctly
+      s2loops[s]->Normalize();
+    }
+
+    // Match each hole to its containing shell.
+    // Among all containing shells, pick the smallest (by area).
+    std::vector<int> hole_parent(holes.size(), -1);
+    for (size_t j = 0; j < holes.size(); ++j) {
+      GeoArrowLoop hole_loop(&ring_nodes_[holes[j]], &scratch_);
+      S2Point test_point = hole_loop.vertex(0);
+      int best_shell = -1;
+      double best_area = std::numeric_limits<double>::max();
+      for (size_t s = 0; s < shells.size(); ++s) {
+        if (s2loops[s]->Contains(test_point)) {
+          double area = s2loops[s]->GetArea();
+          if (area < best_area) {
+            best_area = area;
+            best_shell = static_cast<int>(s);
+          }
+        }
+      }
+      hole_parent[j] = best_shell;
+    }
+
+    // Build polygon_lengths_ and reorder rings: each shell followed by its
+    // holes
+    ReorderGroupedRings(shells, holes, hole_parent);
+  }
+
+  void ReorderRings(const std::vector<int>& shells,
+                    const std::vector<int>& holes) {
+    std::vector<internal::GeoArrowVertex> reordered_vertices;
+    std::vector<int> reordered_lengths;
+    reordered_vertices.reserve(polygon_vertices_.size());
+    reordered_lengths.reserve(ring_lengths_.size());
+
+    auto appendRing = [&](int ring_idx) {
+      int offset = 0;
+      for (int r = 0; r < ring_idx; ++r) offset += ring_lengths_[r];
+      reordered_vertices.insert(reordered_vertices.end(),
+                                polygon_vertices_.begin() + offset,
+                                polygon_vertices_.begin() + offset +
+                                    ring_lengths_[ring_idx]);
+      reordered_lengths.push_back(ring_lengths_[ring_idx]);
+    };
+
+    for (int s : shells) appendRing(s);
+    for (int h : holes) appendRing(h);
+
+    polygon_vertices_ = std::move(reordered_vertices);
+    ring_lengths_ = std::move(reordered_lengths);
+  }
+
+  void ReorderGroupedRings(const std::vector<int>& shells,
+                           const std::vector<int>& holes,
+                           const std::vector<int>& hole_parent) {
+    std::vector<internal::GeoArrowVertex> reordered_vertices;
+    std::vector<int> reordered_lengths;
+    reordered_vertices.reserve(polygon_vertices_.size());
+    reordered_lengths.reserve(ring_lengths_.size());
+
+    // Precompute ring start offsets
+    std::vector<int> ring_offsets(ring_lengths_.size());
+    int offset = 0;
+    for (size_t i = 0; i < ring_lengths_.size(); ++i) {
+      ring_offsets[i] = offset;
+      offset += ring_lengths_[i];
+    }
+
+    auto appendRing = [&](int ring_idx) {
+      int off = ring_offsets[ring_idx];
+      reordered_vertices.insert(reordered_vertices.end(),
+                                polygon_vertices_.begin() + off,
+                                polygon_vertices_.begin() + off +
+                                    ring_lengths_[ring_idx]);
+      reordered_lengths.push_back(ring_lengths_[ring_idx]);
+    };
+
+    for (size_t s = 0; s < shells.size(); ++s) {
+      int ring_count = 1;
+      appendRing(shells[s]);
+      for (size_t j = 0; j < holes.size(); ++j) {
+        if (hole_parent[j] == static_cast<int>(s)) {
+          appendRing(holes[j]);
+          ++ring_count;
+        }
+      }
+      polygon_lengths_.push_back(ring_count);
+    }
+
+    polygon_vertices_ = std::move(reordered_vertices);
+    ring_lengths_ = std::move(reordered_lengths);
+  }
+
   std::vector<internal::GeoArrowVertex> points_;
   std::vector<int> line_lengths_;
   std::vector<internal::GeoArrowVertex> line_vertices_;
@@ -634,7 +797,9 @@ struct OutputGeometry {
   std::vector<internal::GeoArrowVertex> polygon_vertices_;
   int current_line_length_{0};
   int current_ring_length_{0};
-  int current_polygon_ring_count_{0};
+  std::vector<struct GeoArrowGeometryNode> ring_nodes_;
+  std::vector<double> ring_signed_areas_;
+  std::vector<S2Point> scratch_;
 };
 
 class GeoArrowPointVectorLayer : public S2Builder::Layer {
@@ -764,87 +929,9 @@ class GeoArrowPolygonLayer : public S2Builder::Layer {
       return;
     }
 
-    if (edge_loops_.empty()) {
-      return;
-    }
-
-    int num_loops = static_cast<int>(edge_loops_.size());
-
-    // Fast path: single loop -> single polygon with one ring
-    if (num_loops == 1) {
-      WriteLoop(g, 0);
-      output_->FinishPolygon();
-      return;
-    }
-
-    // Build temporary S2Loops from graph vertices. Since the edges coming
-    // from the builder are directed with interior to the left, loops are
-    // already properly oriented: shells are CCW (normalized) and holes are
-    // CW (not normalized). We do NOT call Normalize() so that we can
-    // determine shell vs hole from the orientation.
-    std::vector<std::unique_ptr<S2Loop>> s2loops(num_loops);
-    std::vector<bool> is_shell(num_loops);
-    std::vector<int> shells;
-    std::vector<int> holes;
-
-    for (int i = 0; i < num_loops; ++i) {
-      std::vector<S2Point> vertices;
-      vertices.reserve(edge_loops_[i].size());
-      for (EdgeId edge_id : edge_loops_[i]) {
-        vertices.push_back(g.vertex(g.edge(edge_id).first));
-      }
-      s2loops[i] = absl::make_unique<S2Loop>(vertices);
-      is_shell[i] = s2loops[i]->IsNormalized();
-      if (is_shell[i]) {
-        shells.push_back(i);
-      } else {
-        // Normalize so that containment checks work correctly
-        s2loops[i]->Normalize();
-        holes.push_back(i);
-      }
-    }
-
-    // Common case: exactly one shell with zero or more holes
-    if (shells.size() == 1) {
-      WriteLoop(g, shells[0]);
-      for (int hole_idx : holes) {
-        WriteLoop(g, hole_idx);
-      }
-      output_->FinishPolygon();
-      return;
-    }
-
-    // Multiple shells: match each hole to its containing shell.
-    // hole_parent[j] = index into shells[] for the shell containing hole j,
-    // or -1 if unmatched.
-    std::vector<int> hole_parent(holes.size(), -1);
-    for (size_t j = 0; j < holes.size(); ++j) {
-      // Use a vertex of the hole to find which shell contains it.
-      // Among all containing shells, pick the smallest (most nested).
-      S2Point test_point = s2loops[holes[j]]->vertex(0);
-      int best_shell = -1;
-      double best_area = std::numeric_limits<double>::max();
-      for (size_t s = 0; s < shells.size(); ++s) {
-        if (s2loops[shells[s]]->Contains(test_point)) {
-          double area = s2loops[shells[s]]->GetArea();
-          if (area < best_area) {
-            best_area = area;
-            best_shell = static_cast<int>(s);
-          }
-        }
-      }
-      hole_parent[j] = best_shell;
-    }
-
-    // Write each shell followed by its holes as a separate polygon
-    for (size_t s = 0; s < shells.size(); ++s) {
-      WriteLoop(g, shells[s]);
-      for (size_t j = 0; j < holes.size(); ++j) {
-        if (hole_parent[j] == static_cast<int>(s)) {
-          WriteLoop(g, holes[j]);
-        }
-      }
-      output_->FinishPolygon();
+    // Write all loops as rings; polygon grouping is deferred to OutputGeometry
+    for (int i = 0; i < static_cast<int>(edge_loops_.size()); ++i) {
+      WriteLoop(g, i);
     }
   }
 

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -486,6 +486,157 @@ struct EdgeTracker {
   std::vector<const S2Shape*> shapes_;
 };
 
+struct OutputGeometry {
+  void Clear() {
+    points_.clear();
+    line_lengths_.clear();
+    line_vertices_.clear();
+    ring_lengths_.clear();
+    polygon_lengths_.clear();
+    polygon_vertices_.clear();
+    current_line_length_ = 0;
+    current_ring_length_ = 0;
+    current_polygon_ring_count_ = 0;
+  }
+
+  void AddPoint(const internal::GeoArrowVertex& v) { points_.push_back(v); }
+
+  void AddLineVertex(const internal::GeoArrowVertex& v) {
+    line_vertices_.push_back(v);
+    ++current_line_length_;
+  }
+
+  void FinishLine() {
+    line_lengths_.push_back(current_line_length_);
+    current_line_length_ = 0;
+  }
+
+  void AddRingVertex(const internal::GeoArrowVertex& v) {
+    polygon_vertices_.push_back(v);
+    ++current_ring_length_;
+  }
+
+  void FinishRing() {
+    ring_lengths_.push_back(current_ring_length_);
+    current_ring_length_ = 0;
+    ++current_polygon_ring_count_;
+  }
+
+  void FinishPolygon() {
+    polygon_lengths_.push_back(current_polygon_ring_count_);
+    current_polygon_ring_count_ = 0;
+  }
+
+  bool has_points() const { return !points_.empty(); }
+  bool has_lines() const { return !line_lengths_.empty(); }
+  bool has_polygons() const { return !polygon_lengths_.empty(); }
+  int num_types() const { return has_points() + has_lines() + has_polygons(); }
+
+  void WriteTo(GeoArrowOutputBuilder* out, uint8_t geometry_type) {
+    if (num_types() == 0) {
+      out->AppendEmpty(geometry_type);
+      return;
+    }
+
+    if (num_types() == 1) {
+      out->FeatureStart();
+      if (has_points()) WritePointOutput(out);
+      if (has_lines()) WriteLinesOutput(out);
+      if (has_polygons()) WritePolygonOutput(out);
+      out->FeatureEnd();
+      return;
+    }
+
+    out->FeatureStart();
+    out->GeomStart(GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION);
+    if (has_points()) WritePointOutput(out);
+    if (has_lines()) WriteLinesOutput(out);
+    if (has_polygons()) WritePolygonOutput(out);
+    out->GeomEnd();
+    out->FeatureEnd();
+  }
+
+ private:
+  void WritePointOutput(GeoArrowOutputBuilder* out) {
+    if (points_.size() == 1) {
+      out->GeomStart(GEOARROW_GEOMETRY_TYPE_POINT);
+      out->WriteCoord(points_[0]);
+      out->GeomEnd();
+    } else if (points_.size() > 1) {
+      out->GeomStart(GEOARROW_GEOMETRY_TYPE_MULTIPOINT);
+      for (const auto& pt : points_) {
+        out->GeomStart(GEOARROW_GEOMETRY_TYPE_POINT);
+        out->WriteCoord(pt);
+        out->GeomEnd();
+      }
+      out->GeomEnd();
+    }
+  }
+
+  void WriteLinesOutput(GeoArrowOutputBuilder* out) {
+    if (line_lengths_.size() == 1) {
+      out->GeomStart(GEOARROW_GEOMETRY_TYPE_LINESTRING);
+      for (int i = 0; i < line_lengths_[0]; ++i) {
+        out->WriteCoord(line_vertices_[i]);
+      }
+      out->GeomEnd();
+    } else if (line_lengths_.size() > 1) {
+      out->GeomStart(GEOARROW_GEOMETRY_TYPE_MULTILINESTRING);
+      int line_vertex_id = 0;
+      for (int line_length : line_lengths_) {
+        out->GeomStart(GEOARROW_GEOMETRY_TYPE_LINESTRING);
+        for (int i = 0; i < line_length; ++i) {
+          out->WriteCoord(line_vertices_[line_vertex_id++]);
+        }
+        out->GeomEnd();
+      }
+      out->GeomEnd();
+    }
+  }
+
+  void WritePolygonOutput(GeoArrowOutputBuilder* out) {
+    int ring_id = 0;
+    int vertex_id = 0;
+    if (polygon_lengths_.size() == 1) {
+      out->GeomStart(GEOARROW_GEOMETRY_TYPE_POLYGON);
+      for (int r = 0; r < polygon_lengths_[0]; ++r) {
+        out->RingStart();
+        for (int i = 0; i < ring_lengths_[ring_id]; ++i) {
+          out->WriteCoord(polygon_vertices_[vertex_id++]);
+        }
+        out->RingEnd();
+        ++ring_id;
+      }
+      out->GeomEnd();
+    } else if (polygon_lengths_.size() > 1) {
+      out->GeomStart(GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON);
+      for (int polygon_length : polygon_lengths_) {
+        out->GeomStart(GEOARROW_GEOMETRY_TYPE_POLYGON);
+        for (int r = 0; r < polygon_length; ++r) {
+          out->RingStart();
+          for (int i = 0; i < ring_lengths_[ring_id]; ++i) {
+            out->WriteCoord(polygon_vertices_[vertex_id++]);
+          }
+          out->RingEnd();
+          ++ring_id;
+        }
+        out->GeomEnd();
+      }
+      out->GeomEnd();
+    }
+  }
+
+  std::vector<internal::GeoArrowVertex> points_;
+  std::vector<int> line_lengths_;
+  std::vector<internal::GeoArrowVertex> line_vertices_;
+  std::vector<int> ring_lengths_;
+  std::vector<int> polygon_lengths_;
+  std::vector<internal::GeoArrowVertex> polygon_vertices_;
+  int current_line_length_{0};
+  int current_ring_length_{0};
+  int current_polygon_ring_count_{0};
+};
+
 class GeoArrowPointVectorLayer : public S2Builder::Layer {
  public:
   using GraphOptions = S2Builder::GraphOptions;
@@ -493,9 +644,8 @@ class GeoArrowPointVectorLayer : public S2Builder::Layer {
   using EdgeId = Graph::EdgeId;
   using InputEdgeId = Graph::InputEdgeId;
 
-  GeoArrowPointVectorLayer(EdgeTracker* edge_tracker,
-                           std::vector<internal::GeoArrowVertex>* points_out)
-      : edge_tracker_(edge_tracker), points_out_(points_out) {}
+  GeoArrowPointVectorLayer(EdgeTracker* edge_tracker, OutputGeometry* output)
+      : edge_tracker_(edge_tracker), output_(output) {}
 
   GraphOptions graph_options() const override {
     return GraphOptions(
@@ -519,7 +669,7 @@ class GeoArrowPointVectorLayer : public S2Builder::Layer {
       internal::GeoArrowVertex vt;
 
       // GEOS seems to always return the first Z or M it encounters for point
-      // output
+      // output. We could also merge by averaging or some other strategy.
       for (InputEdgeId input_edge_id : g.input_edge_ids(edge_id)) {
         auto e = edge_tracker_->ResolveEdge(input_edge_id);
         vt = e.v0;
@@ -532,15 +682,13 @@ class GeoArrowPointVectorLayer : public S2Builder::Layer {
       }
 
       // Write to the output
-      Write(vt);
+      output_->AddPoint(vt);
     }
   }
 
-  void Write(const internal::GeoArrowVertex& v) { points_out_->push_back(v); }
-
  private:
   EdgeTracker* edge_tracker_;
-  std::vector<internal::GeoArrowVertex>* points_out_;
+  OutputGeometry* output_;
 };
 
 class GeoArrowPolylinesLayer : public S2Builder::Layer {
@@ -550,12 +698,8 @@ class GeoArrowPolylinesLayer : public S2Builder::Layer {
   using EdgeId = Graph::EdgeId;
   using InputEdgeId = Graph::InputEdgeId;
 
-  GeoArrowPolylinesLayer(EdgeTracker* edge_tracker,
-                         std::vector<internal::GeoArrowVertex>* points_out,
-                         std::vector<int>* lengths_out)
-      : edge_tracker_(edge_tracker),
-        points_out_(points_out),
-        lengths_out_(lengths_out) {}
+  GeoArrowPolylinesLayer(EdgeTracker* edge_tracker, OutputGeometry* output)
+      : edge_tracker_(edge_tracker), output_(output) {}
 
   GraphOptions graph_options() const override {
     return GraphOptions(S2Builder::EdgeType::DIRECTED,
@@ -569,13 +713,12 @@ class GeoArrowPolylinesLayer : public S2Builder::Layer {
         g.GetPolylines(Graph::PolylineType::WALK);
 
     for (const auto& edge_polyline : edge_polylines) {
-      Start();
-
       // Write the first vertex of the polyline
       EdgeId first_edge_id = edge_polyline[0];
       S2Point first_pt = g.vertex(g.edge(first_edge_id).first);
       for (InputEdgeId input_edge_id : g.input_edge_ids(first_edge_id)) {
-        Write(edge_tracker_->ResolveEdge(input_edge_id).Interpolate(first_pt));
+        output_->AddLineVertex(
+            edge_tracker_->ResolveEdge(input_edge_id).Interpolate(first_pt));
         break;
       }
 
@@ -583,27 +726,19 @@ class GeoArrowPolylinesLayer : public S2Builder::Layer {
       for (EdgeId edge_id : edge_polyline) {
         S2Point pt = g.vertex(g.edge(edge_id).second);
         for (InputEdgeId input_edge_id : g.input_edge_ids(edge_id)) {
-          Write(edge_tracker_->ResolveEdge(input_edge_id).Interpolate(pt));
+          output_->AddLineVertex(
+              edge_tracker_->ResolveEdge(input_edge_id).Interpolate(pt));
           break;
         }
       }
 
-      lengths_out_->push_back(current_length_);
+      output_->FinishLine();
     }
-  }
-
-  void Start() { current_length_ = 0; }
-
-  void Write(const internal::GeoArrowVertex& v) {
-    points_out_->push_back(v);
-    ++current_length_;
   }
 
  private:
   EdgeTracker* edge_tracker_;
-  std::vector<int>* lengths_out_;
-  std::vector<internal::GeoArrowVertex>* points_out_;
-  int current_length_{0};
+  OutputGeometry* output_;
 };
 
 class GeoArrowPolygonLayer : public S2Builder::Layer {
@@ -613,14 +748,8 @@ class GeoArrowPolygonLayer : public S2Builder::Layer {
   using EdgeId = Graph::EdgeId;
   using InputEdgeId = Graph::InputEdgeId;
 
-  GeoArrowPolygonLayer(EdgeTracker* edge_tracker,
-                       std::vector<internal::GeoArrowVertex>* points_out,
-                       std::vector<int>* ring_lengths_out,
-                       std::vector<int>* polygon_lengths_out)
-      : edge_tracker_(edge_tracker),
-        points_out_(points_out),
-        ring_lengths_out_(ring_lengths_out),
-        polygon_lengths_out_(polygon_lengths_out) {}
+  GeoArrowPolygonLayer(EdgeTracker* edge_tracker, OutputGeometry* output)
+      : edge_tracker_(edge_tracker), output_(output) {}
 
   GraphOptions graph_options() const override {
     return GraphOptions(S2Builder::EdgeType::DIRECTED,
@@ -644,7 +773,7 @@ class GeoArrowPolygonLayer : public S2Builder::Layer {
     // Fast path: single loop -> single polygon with one ring
     if (num_loops == 1) {
       WriteLoop(g, 0);
-      polygon_lengths_out_->push_back(1);
+      output_->FinishPolygon();
       return;
     }
 
@@ -681,7 +810,7 @@ class GeoArrowPolygonLayer : public S2Builder::Layer {
       for (int hole_idx : holes) {
         WriteLoop(g, hole_idx);
       }
-      polygon_lengths_out_->push_back(1 + static_cast<int>(holes.size()));
+      output_->FinishPolygon();
       return;
     }
 
@@ -709,57 +838,47 @@ class GeoArrowPolygonLayer : public S2Builder::Layer {
 
     // Write each shell followed by its holes as a separate polygon
     for (size_t s = 0; s < shells.size(); ++s) {
-      int ring_count = 1;
       WriteLoop(g, shells[s]);
       for (size_t j = 0; j < holes.size(); ++j) {
         if (hole_parent[j] == static_cast<int>(s)) {
           WriteLoop(g, holes[j]);
-          ++ring_count;
         }
       }
-      polygon_lengths_out_->push_back(ring_count);
+      output_->FinishPolygon();
     }
   }
 
   void WriteLoop(const Graph& g, int loop_index) {
     const auto& edge_loop = edge_loops_[loop_index];
-    int ring_length = 0;
 
     for (EdgeId edge_id : edge_loop) {
       S2Point pt = g.vertex(g.edge(edge_id).first);
       for (InputEdgeId input_edge_id : g.input_edge_ids(edge_id)) {
-        points_out_->push_back(
+        output_->AddRingVertex(
             edge_tracker_->ResolveEdge(input_edge_id).Interpolate(pt));
         break;
       }
-      ++ring_length;
     }
 
     // Close the ring by repeating the first vertex
     EdgeId first_edge_id = edge_loop[0];
     S2Point first_pt = g.vertex(g.edge(first_edge_id).first);
     for (InputEdgeId input_edge_id : g.input_edge_ids(first_edge_id)) {
-      points_out_->push_back(
+      output_->AddRingVertex(
           edge_tracker_->ResolveEdge(input_edge_id).Interpolate(first_pt));
       break;
     }
-    ++ring_length;
 
-    ring_lengths_out_->push_back(ring_length);
+    output_->FinishRing();
   }
 
  private:
   EdgeTracker* edge_tracker_;
-  std::vector<internal::GeoArrowVertex>* points_out_;
-  std::vector<int>* ring_lengths_out_;
-  std::vector<int>* polygon_lengths_out_;
+  OutputGeometry* output_;
   std::vector<Graph::EdgeLoop> edge_loops_;
 };
 
 struct RebuildExec {
-  using arg0_t = GeoArrowGeographyInputView;
-  using out_t = GeoArrowOutputBuilder;
-
   RebuildExec(const S2Builder::Options& options = S2Builder::Options())
       : builder_options_(options) {
     builder_.Init(builder_options_);
@@ -768,17 +887,11 @@ struct RebuildExec {
   void Exec(const GeoArrowGeography& value0, GeoArrowOutputBuilder* out) {
     builder_.Reset();
     edge_tracker_.Clear();
-
-    native_points_.clear();
-    line_lengths_.clear();
-    line_vertices_.clear();
-    ring_lengths_.clear();
-    polygon_lengths_.clear();
-    polygon_vertices_.clear();
+    output_.Clear();
 
     // Start a layer that collects point vertices
-    builder_.StartLayer(absl::make_unique<GeoArrowPointVectorLayer>(
-        &edge_tracker_, &native_points_));
+    builder_.StartLayer(
+        absl::make_unique<GeoArrowPointVectorLayer>(&edge_tracker_, &output_));
 
     edge_tracker_.Add(value0.points());
     value0.points()->geom().VisitVertices([&](const S2Point& v) {
@@ -787,17 +900,15 @@ struct RebuildExec {
     });
 
     // Start a layer that collects polyline vertices
-    auto lines_layer = absl::make_unique<GeoArrowPolylinesLayer>(
-        &edge_tracker_, &line_vertices_, &line_lengths_);
-    builder_.StartLayer(std::move(lines_layer));
+    builder_.StartLayer(
+        absl::make_unique<GeoArrowPolylinesLayer>(&edge_tracker_, &output_));
 
     edge_tracker_.Add(value0.lines());
     builder_.AddShape(*value0.lines());
 
     // Start a layer that collects polygon vertices
-    auto polygon_layer = absl::make_unique<GeoArrowPolygonLayer>(
-        &edge_tracker_, &polygon_vertices_, &ring_lengths_, &polygon_lengths_);
-    builder_.StartLayer(std::move(polygon_layer));
+    builder_.StartLayer(
+        absl::make_unique<GeoArrowPolygonLayer>(&edge_tracker_, &output_));
 
     edge_tracker_.Add(value0.polygons());
     builder_.AddShape(*value0.polygons());
@@ -813,117 +924,13 @@ struct RebuildExec {
     // Write the output. For unary input we write the same output dimensions as
     // the input
     out->SetDimensions(value0.dimensions());
-
-    bool has_points = !native_points_.empty();
-    bool has_lines = !line_lengths_.empty();
-    bool has_polygons = !polygon_lengths_.empty();
-    int num_types = has_points + has_lines + has_polygons;
-
-    // If there are no outputs, write an empty attempting to preserve the input
-    // geometry type.
-    if (num_types == 0) {
-      out->AppendEmpty(value0.geometry_type());
-      return;
-    }
-
-    // If there is only one type of output, write it directly
-    if (num_types == 1) {
-      out->FeatureStart();
-      if (has_points) WritePointOutput(out);
-      if (has_lines) WriteLinesOuput(out);
-      if (has_polygons) WritePolygonOutput(out);
-      out->FeatureEnd();
-      return;
-    }
-
-    // Otherwise, write a GEOMETRYCOLLECTION with any of the available output
-    out->FeatureStart();
-    out->GeomStart(GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION);
-    if (has_points) WritePointOutput(out);
-    if (has_lines) WriteLinesOuput(out);
-    if (has_polygons) WritePolygonOutput(out);
-    out->GeomEnd();
-    out->FeatureEnd();
-  }
-
-  void WritePointOutput(out_t* out) {
-    if (native_points_.size() == 1) {
-      out->GeomStart(GEOARROW_GEOMETRY_TYPE_POINT);
-      out->WriteCoord(native_points_[0]);
-      out->GeomEnd();
-    } else if (native_points_.size() > 1) {
-      out->GeomStart(GEOARROW_GEOMETRY_TYPE_MULTIPOINT);
-      for (const auto& pt : native_points_) {
-        out->GeomStart(GEOARROW_GEOMETRY_TYPE_POINT);
-        out->WriteCoord(pt);
-        out->GeomEnd();
-      }
-      out->GeomEnd();
-    }
-  }
-
-  void WriteLinesOuput(out_t* out) {
-    if (line_lengths_.size() == 1) {
-      out->GeomStart(GEOARROW_GEOMETRY_TYPE_LINESTRING);
-      for (int i = 0; i < line_lengths_[0]; ++i) {
-        out->WriteCoord(line_vertices_[i]);
-      }
-      out->GeomEnd();
-    } else if (line_lengths_.size() > 1) {
-      out->GeomStart(GEOARROW_GEOMETRY_TYPE_MULTILINESTRING);
-      int line_vertex_id = 0;
-      for (int line_length : line_lengths_) {
-        out->GeomStart(GEOARROW_GEOMETRY_TYPE_LINESTRING);
-        for (int i = 0; i < line_length; ++i) {
-          out->WriteCoord(line_vertices_[line_vertex_id++]);
-        }
-        out->GeomEnd();
-      }
-      out->GeomEnd();
-    }
-  }
-
-  void WritePolygonOutput(out_t* out) {
-    int ring_id = 0;
-    int vertex_id = 0;
-    if (polygon_lengths_.size() == 1) {
-      out->GeomStart(GEOARROW_GEOMETRY_TYPE_POLYGON);
-      for (int r = 0; r < polygon_lengths_[0]; ++r) {
-        out->RingStart();
-        for (int i = 0; i < ring_lengths_[ring_id]; ++i) {
-          out->WriteCoord(polygon_vertices_[vertex_id++]);
-        }
-        out->RingEnd();
-        ++ring_id;
-      }
-      out->GeomEnd();
-    } else if (polygon_lengths_.size() > 1) {
-      out->GeomStart(GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON);
-      for (int polygon_length : polygon_lengths_) {
-        out->GeomStart(GEOARROW_GEOMETRY_TYPE_POLYGON);
-        for (int r = 0; r < polygon_length; ++r) {
-          out->RingStart();
-          for (int i = 0; i < ring_lengths_[ring_id]; ++i) {
-            out->WriteCoord(polygon_vertices_[vertex_id++]);
-          }
-          out->RingEnd();
-          ++ring_id;
-        }
-        out->GeomEnd();
-      }
-      out->GeomEnd();
-    }
+    output_.WriteTo(out, value0.geometry_type());
   }
 
   S2Builder builder_;
   S2Builder::Options builder_options_;
   EdgeTracker edge_tracker_;
-  std::vector<internal::GeoArrowVertex> native_points_;
-  std::vector<int> line_lengths_;
-  std::vector<internal::GeoArrowVertex> line_vertices_;
-  std::vector<int> ring_lengths_;
-  std::vector<int> polygon_lengths_;
-  std::vector<internal::GeoArrowVertex> polygon_vertices_;
+  OutputGeometry output_;
 };
 
 struct ReducePrecisionExec {

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -3,6 +3,7 @@
 
 #include <s2/s2boolean_operation.h>
 #include <s2/s2builder.h>
+#include <s2/s2loop.h>
 #include <s2/s2builderutil_closed_set_normalizer.h>
 #include <s2/s2builderutil_s2point_vector_layer.h>
 #include <s2/s2builderutil_s2polygon_layer.h>
@@ -604,6 +605,156 @@ class GeoArrowPolylinesLayer : public S2Builder::Layer {
   int current_length_{0};
 };
 
+class GeoArrowPolygonLayer : public S2Builder::Layer {
+ public:
+  using GraphOptions = S2Builder::GraphOptions;
+  using Graph = S2Builder::Graph;
+  using EdgeId = Graph::EdgeId;
+  using InputEdgeId = Graph::InputEdgeId;
+
+  GeoArrowPolygonLayer(EdgeTracker* edge_tracker,
+                       std::vector<internal::GeoArrowVertex>* points_out,
+                       std::vector<int>* ring_lengths_out,
+                       std::vector<int>* polygon_lengths_out)
+      : edge_tracker_(edge_tracker),
+        points_out_(points_out),
+        ring_lengths_out_(ring_lengths_out),
+        polygon_lengths_out_(polygon_lengths_out) {}
+
+  GraphOptions graph_options() const override {
+    return GraphOptions(S2Builder::EdgeType::DIRECTED,
+                        GraphOptions::DegenerateEdges::DISCARD,
+                        GraphOptions::DuplicateEdges::KEEP,
+                        GraphOptions::SiblingPairs::DISCARD);
+  }
+
+  void Build(const Graph& g, S2Error* error) override {
+    edge_loops_.clear();
+    if (!g.GetDirectedLoops(Graph::LoopType::SIMPLE, &edge_loops_, error)) {
+      return;
+    }
+
+    if (edge_loops_.empty()) {
+      return;
+    }
+
+    int num_loops = static_cast<int>(edge_loops_.size());
+
+    // Fast path: single loop -> single polygon with one ring
+    if (num_loops == 1) {
+      WriteLoop(g, 0);
+      polygon_lengths_out_->push_back(1);
+      return;
+    }
+
+    // Build temporary S2Loops from graph vertices. Since the edges coming
+    // from the builder are directed with interior to the left, loops are
+    // already properly oriented: shells are CCW (normalized) and holes are
+    // CW (not normalized). We do NOT call Normalize() so that we can
+    // determine shell vs hole from the orientation.
+    std::vector<std::unique_ptr<S2Loop>> s2loops(num_loops);
+    std::vector<bool> is_shell(num_loops);
+    std::vector<int> shells;
+    std::vector<int> holes;
+
+    for (int i = 0; i < num_loops; ++i) {
+      std::vector<S2Point> vertices;
+      vertices.reserve(edge_loops_[i].size());
+      for (EdgeId edge_id : edge_loops_[i]) {
+        vertices.push_back(g.vertex(g.edge(edge_id).first));
+      }
+      s2loops[i] = absl::make_unique<S2Loop>(vertices);
+      is_shell[i] = s2loops[i]->IsNormalized();
+      if (is_shell[i]) {
+        shells.push_back(i);
+      } else {
+        // Normalize so that containment checks work correctly
+        s2loops[i]->Normalize();
+        holes.push_back(i);
+      }
+    }
+
+    // Common case: exactly one shell with zero or more holes
+    if (shells.size() == 1) {
+      WriteLoop(g, shells[0]);
+      for (int hole_idx : holes) {
+        WriteLoop(g, hole_idx);
+      }
+      polygon_lengths_out_->push_back(1 + static_cast<int>(holes.size()));
+      return;
+    }
+
+    // Multiple shells: match each hole to its containing shell.
+    // hole_parent[j] = index into shells[] for the shell containing hole j,
+    // or -1 if unmatched.
+    std::vector<int> hole_parent(holes.size(), -1);
+    for (size_t j = 0; j < holes.size(); ++j) {
+      // Use a vertex of the hole to find which shell contains it.
+      // Among all containing shells, pick the smallest (most nested).
+      S2Point test_point = s2loops[holes[j]]->vertex(0);
+      int best_shell = -1;
+      double best_area = std::numeric_limits<double>::max();
+      for (size_t s = 0; s < shells.size(); ++s) {
+        if (s2loops[shells[s]]->Contains(test_point)) {
+          double area = s2loops[shells[s]]->GetArea();
+          if (area < best_area) {
+            best_area = area;
+            best_shell = static_cast<int>(s);
+          }
+        }
+      }
+      hole_parent[j] = best_shell;
+    }
+
+    // Write each shell followed by its holes as a separate polygon
+    for (size_t s = 0; s < shells.size(); ++s) {
+      int ring_count = 1;
+      WriteLoop(g, shells[s]);
+      for (size_t j = 0; j < holes.size(); ++j) {
+        if (hole_parent[j] == static_cast<int>(s)) {
+          WriteLoop(g, holes[j]);
+          ++ring_count;
+        }
+      }
+      polygon_lengths_out_->push_back(ring_count);
+    }
+  }
+
+  void WriteLoop(const Graph& g, int loop_index) {
+    const auto& edge_loop = edge_loops_[loop_index];
+    int ring_length = 0;
+
+    for (EdgeId edge_id : edge_loop) {
+      S2Point pt = g.vertex(g.edge(edge_id).first);
+      for (InputEdgeId input_edge_id : g.input_edge_ids(edge_id)) {
+        points_out_->push_back(
+            edge_tracker_->ResolveEdge(input_edge_id).Interpolate(pt));
+        break;
+      }
+      ++ring_length;
+    }
+
+    // Close the ring by repeating the first vertex
+    EdgeId first_edge_id = edge_loop[0];
+    S2Point first_pt = g.vertex(g.edge(first_edge_id).first);
+    for (InputEdgeId input_edge_id : g.input_edge_ids(first_edge_id)) {
+      points_out_->push_back(
+          edge_tracker_->ResolveEdge(input_edge_id).Interpolate(first_pt));
+      break;
+    }
+    ++ring_length;
+
+    ring_lengths_out_->push_back(ring_length);
+  }
+
+ private:
+  EdgeTracker* edge_tracker_;
+  std::vector<internal::GeoArrowVertex>* points_out_;
+  std::vector<int>* ring_lengths_out_;
+  std::vector<int>* polygon_lengths_out_;
+  std::vector<Graph::EdgeLoop> edge_loops_;
+};
+
 struct RebuildExec {
   using arg0_t = GeoArrowGeographyInputView;
   using out_t = GeoArrowOutputBuilder;
@@ -620,6 +771,9 @@ struct RebuildExec {
     native_points_.clear();
     line_lengths_.clear();
     line_vertices_.clear();
+    ring_lengths_.clear();
+    polygon_lengths_.clear();
+    polygon_vertices_.clear();
 
     // Start a layer that collects point vertices
     builder_.StartLayer(absl::make_unique<GeoArrowPointVectorLayer>(
@@ -639,8 +793,13 @@ struct RebuildExec {
     edge_tracker_.Add(value0.lines());
     builder_.AddShape(*value0.lines());
 
-    // TODO: add GeoArrow-aware layer for polygons
-    // builder_.AddShape(*value0.polygons());
+    // Start a layer that collects polygon vertices
+    auto polygon_layer = absl::make_unique<GeoArrowPolygonLayer>(
+        &edge_tracker_, &polygon_vertices_, &ring_lengths_, &polygon_lengths_);
+    builder_.StartLayer(std::move(polygon_layer));
+
+    edge_tracker_.Add(value0.polygons());
+    builder_.AddShape(*value0.polygons());
 
     // build the output
     S2Error error;
@@ -654,28 +813,27 @@ struct RebuildExec {
     // the input
     out->SetDimensions(value0.dimensions());
 
-    // If there is only point output, write it
-    if (!native_points_.empty() && line_lengths_.empty()) {
+    bool has_points = !native_points_.empty();
+    bool has_lines = !line_lengths_.empty();
+    bool has_polygons = !polygon_lengths_.empty();
+    int num_types = has_points + has_lines + has_polygons;
+
+    // If there is only one type of output, write it directly
+    if (num_types <= 1) {
       out->FeatureStart();
-      WritePointOutput(out);
+      if (has_points) WritePointOutput(out);
+      if (has_lines) WriteLinesOuput(out);
+      if (has_polygons) WritePolygonOutput(out);
       out->FeatureEnd();
       return;
     }
-
-    if (!line_lengths_.empty() && native_points_.empty()) {
-      out->FeatureStart();
-      WriteLinesOuput(out);
-      out->FeatureEnd();
-      return;
-    }
-
-    // TODO: check for only polygon output
 
     // Otherwise, write a GEOMETRYCOLLECTION with any of the available output
     out->FeatureStart();
     out->GeomStart(GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION);
-    WritePointOutput(out);
-    WriteLinesOuput(out);
+    if (has_points) WritePointOutput(out);
+    if (has_lines) WriteLinesOuput(out);
+    if (has_polygons) WritePolygonOutput(out);
     out->GeomEnd();
     out->FeatureEnd();
   }
@@ -703,7 +861,7 @@ struct RebuildExec {
         out->WriteCoord(line_vertices_[i]);
       }
       out->GeomEnd();
-    } else if (native_points_.size() > 1) {
+    } else if (line_lengths_.size() > 1) {
       out->GeomStart(GEOARROW_GEOMETRY_TYPE_MULTILINESTRING);
       int line_vertex_id = 0;
       for (int line_length : line_lengths_) {
@@ -717,12 +875,47 @@ struct RebuildExec {
     }
   }
 
+  void WritePolygonOutput(out_t* out) {
+    int ring_id = 0;
+    int vertex_id = 0;
+    if (polygon_lengths_.size() == 1) {
+      out->GeomStart(GEOARROW_GEOMETRY_TYPE_POLYGON);
+      for (int r = 0; r < polygon_lengths_[0]; ++r) {
+        out->RingStart();
+        for (int i = 0; i < ring_lengths_[ring_id]; ++i) {
+          out->WriteCoord(polygon_vertices_[vertex_id++]);
+        }
+        out->RingEnd();
+        ++ring_id;
+      }
+      out->GeomEnd();
+    } else if (polygon_lengths_.size() > 1) {
+      out->GeomStart(GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON);
+      for (int polygon_length : polygon_lengths_) {
+        out->GeomStart(GEOARROW_GEOMETRY_TYPE_POLYGON);
+        for (int r = 0; r < polygon_length; ++r) {
+          out->RingStart();
+          for (int i = 0; i < ring_lengths_[ring_id]; ++i) {
+            out->WriteCoord(polygon_vertices_[vertex_id++]);
+          }
+          out->RingEnd();
+          ++ring_id;
+        }
+        out->GeomEnd();
+      }
+      out->GeomEnd();
+    }
+  }
+
   S2Builder builder_;
   S2Builder::Options builder_options_;
   EdgeTracker edge_tracker_;
   std::vector<internal::GeoArrowVertex> native_points_;
   std::vector<int> line_lengths_;
   std::vector<internal::GeoArrowVertex> line_vertices_;
+  std::vector<int> ring_lengths_;
+  std::vector<int> polygon_lengths_;
+  std::vector<internal::GeoArrowVertex> polygon_vertices_;
 };
 
 struct UnaryUnionGridSizeExec {

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -11,6 +11,9 @@
 #include <s2/s2earth.h>
 #include <s2/s2loop.h>
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
 #include <sstream>
 
 #include "s2geography/accessors.h"
@@ -867,7 +870,7 @@ void VisitTrackedVertices(const S2Builder::Graph& g, const EdgeTracker& tracker,
 
   for (int edge_id : edge_loop) {
     S2Point pt = g.vertex(g.edge(edge_id).second);
-    PopulateVertex(g, tracker, edge_loop[0], pt, &vt);
+    PopulateVertex(g, tracker, edge_id, pt, &vt);
     visit(vt);
   }
 }
@@ -927,7 +930,7 @@ class GeoArrowPointVectorLayer : public S2Builder::Layer {
       // output, use the EdgeTracker to resolve input edges. Otherwise, just
       // write 2D points based on the builder-derived vertex.
       if (edge_tracker_) {
-        PopulateVertex(g, *edge_tracker_, edge.first, pt, &vt);
+        PopulateVertex(g, *edge_tracker_, edge_id, pt, &vt);
       } else {
         vt.SetPoint(pt);
       }
@@ -1145,8 +1148,8 @@ struct SimplifyExec {
     // the snap function and reinitialize the builder with the new options
     if (tolerance != last_tolerance_) {
       if (tolerance < 0) {
-        throw Exception(
-            "Can't set tolerance to a negative value in ST_Simplify()");
+        // PostGIS seems to do this
+        tolerance = -tolerance;
       }
 
       // Create the identity snap function

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -434,6 +434,108 @@ std::unique_ptr<Geography> S2UnionAggregator::Finalize() {
 
 namespace sedona_udf {
 
+class GeoArrowPointVectorLayer : public S2Builder::Layer {
+ public:
+  using GraphOptions = S2Builder::GraphOptions;
+  using Graph = S2Builder::Graph;
+  using EdgeId = Graph::EdgeId;
+
+  GeoArrowPointVectorLayer(const GeoArrowPointShape* source,
+                           std::vector<internal::GeoArrowVertex>* points_out,
+                           int32_t input_edge_id_offset = 0)
+      : source_(source),
+        points_out_(points_out),
+        input_edge_id_offset_(input_edge_id_offset) {}
+
+  GraphOptions graph_options() const override {
+    return GraphOptions(
+        S2Builder::EdgeType::DIRECTED,
+        GraphOptions::DegenerateEdges::KEEP,
+        GraphOptions::DuplicateEdges::MERGE,
+        GraphOptions::SiblingPairs::KEEP);
+  }
+
+  void Build(const Graph& g, S2Error* error) override {
+    for (EdgeId edge_id = 0;
+         static_cast<size_t>(edge_id) < g.edges().size();
+         ++edge_id) {
+      const auto& edge = g.edge(edge_id);
+
+      if (edge.first != edge.second) {
+        *error = S2Error::InvalidArgument("Found non-degenerate edges");
+        continue;
+      }
+
+      // Resolve the output edge back to an input edge, then to a native vertex
+      for (auto input_id : g.input_edge_ids(edge_id)) {
+        int source_edge = static_cast<int>(input_id - input_edge_id_offset_);
+        auto native = source_->native_vertex(source_edge);
+        // For degenerate (point) edges, v0 == v1
+        points_out_->push_back(native.Normalize(source_->dimensions()));
+      }
+    }
+  }
+
+ private:
+  const GeoArrowPointShape* source_;
+  std::vector<internal::GeoArrowVertex>* points_out_;
+  int32_t input_edge_id_offset_;
+};
+
+struct RebuildExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using out_t = GeoArrowOutputBuilder;
+
+  RebuildExec() {
+    builder_.Init(builder_options_);
+  }
+
+  void Exec(arg0_t::c_type value0, out_t* out) {
+    builder_.Reset();
+    native_points_.clear();
+
+    // Start a layer that collects native point vertices
+    builder_.StartLayer(absl::make_unique<GeoArrowPointVectorLayer>(
+        value0.points(), &native_points_));
+    builder_.AddShape(*value0.points());
+
+
+    // TODO: add GeoArrow-aware layers for lines and polygons
+    builder_.AddShape(*value0.lines());
+    builder_.AddShape(*value0.polygons());
+
+    // build the output
+    S2Error error;
+    if (!builder_.Build(&error)) {
+      std::stringstream ss;
+      ss << error;
+      throw Exception(ss.str());
+    }
+
+    // Write native point output to the GeoArrowOutputBuilder
+    // TODO: handle lines and polygons; write a complete geometry
+    if (native_points_.size() == 1) {
+      out->AppendPoint(native_points_[0]);
+    } else if (native_points_.size() > 1) {
+      out->FeatureStart();
+      out->GeomStart(GEOARROW_GEOMETRY_TYPE_MULTIPOINT);
+      for (const auto& pt : native_points_) {
+        out->GeomStart(GEOARROW_GEOMETRY_TYPE_POINT);
+        out->WriteCoord(pt);
+        out->GeomEnd();
+      }
+      out->GeomEnd();
+      out->FeatureEnd();
+    } else {
+      out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_POINT);
+    }
+  }
+
+  S2Builder builder_;
+  S2Builder::Options builder_options_;
+  std::vector<internal::GeoArrowVertex> native_points_;
+};
+
 template <S2BooleanOperation::OpType op_type>
 struct BooleanOperationExec {
   using arg0_t = GeoArrowGeographyInputView;

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -3,12 +3,12 @@
 
 #include <s2/s2boolean_operation.h>
 #include <s2/s2builder.h>
-#include <s2/s2loop.h>
 #include <s2/s2builderutil_closed_set_normalizer.h>
 #include <s2/s2builderutil_s2point_vector_layer.h>
 #include <s2/s2builderutil_s2polygon_layer.h>
 #include <s2/s2builderutil_s2polyline_vector_layer.h>
 #include <s2/s2builderutil_snap_functions.h>
+#include <s2/s2loop.h>
 
 #include <sstream>
 

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -8,6 +8,7 @@
 #include <s2/s2builderutil_s2polygon_layer.h>
 #include <s2/s2builderutil_s2polyline_vector_layer.h>
 #include <s2/s2builderutil_snap_functions.h>
+#include <s2/s2earth.h>
 #include <s2/s2loop.h>
 
 #include <sstream>
@@ -979,6 +980,11 @@ class GeoArrowPolylinesLayer : public S2Builder::Layer {
 };
 
 /// \brief Output layer that collects polygon edge collections in the graph
+///
+/// Note that this does not in any way consider input polygons that partially
+/// overlapped (i.e., this is not a unary union). If there were
+/// invalid polygons in the input, there may be invalid polygons created in
+/// the output.
 class GeoArrowPolygonLayer : public S2Builder::Layer {
  public:
   using GraphOptions = S2Builder::GraphOptions;
@@ -1027,6 +1033,8 @@ class GeoArrowPolygonLayer : public S2Builder::Layer {
   std::vector<Graph::EdgeLoop> edge_loops_;
 };
 
+/// \brief A helper Exec for ReducePrecision and Simplify, which both are a
+/// version of adding input to the builder and rebuilding the output.
 struct RebuildExec {
   RebuildExec(const S2Builder::Options& options = S2Builder::Options())
       : builder_options_(options) {
@@ -1115,6 +1123,39 @@ struct ReducePrecisionExec {
   double last_grid_size_{-100};
 };
 
+struct SimplifyExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = DoubleInputView;
+  using out_t = GeoArrowOutputBuilder;
+
+  void Exec(arg0_t::c_type value, double tolerance, out_t* out) {
+    // If the grid size changed since the last iteration, we need to recreate
+    // the snap function and reinitialize the builder with the new options
+    if (tolerance != last_tolerance_) {
+      if (tolerance < 0) {
+        throw Exception(
+            "Can't set tolerance to a negative value in ST_Simplify()");
+      }
+
+      // Create the identity snap function
+      S1Angle tolerance_angle =
+          S1Angle::Radians(tolerance / S2Earth::RadiusMeters());
+      s2builderutil::IdentitySnapFunction snap(tolerance_angle);
+      rebuild_.builder_options_.set_snap_function(snap);
+
+      rebuild_.builder_options_.set_simplify_edge_chains(true);
+
+      rebuild_.builder_.Init(rebuild_.builder_options_);
+      last_tolerance_ = tolerance;
+    }
+
+    rebuild_.Exec(value, out);
+  }
+
+  RebuildExec rebuild_;
+  double last_tolerance_{-100};
+};
+
 template <S2BooleanOperation::OpType op_type>
 struct BooleanOperationExec {
   using arg0_t = GeoArrowGeographyInputView;
@@ -1154,6 +1195,10 @@ void UnionKernel(struct SedonaCScalarKernel* out) {
 
 void ReducePrecisionKernel(struct SedonaCScalarKernel* out) {
   InitBinaryKernel<ReducePrecisionExec>(out, "st_reduceprecision");
+}
+
+void SimplifyKernel(struct SedonaCScalarKernel* out) {
+  InitBinaryKernel<SimplifyExec>(out, "st_simplify");
 }
 
 }  // namespace sedona_udf

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -508,8 +508,9 @@ class GeoArrowPointVectorLayer : public S2Builder::Layer {
          ++edge_id) {
       // Resolve the edge
       const auto& edge = g.edge(edge_id);
+
+      // We only collect degenerate edges to output as points
       if (edge.first != edge.second) {
-        *error = S2Error::InvalidArgument("Found non-degenerate edges");
         continue;
       }
 

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -929,6 +929,7 @@ class GeoArrowPointVectorLayer : public S2Builder::Layer {
   OutputGeometry* output_;
 };
 
+/// \brief Output layer that collects line edge collections in the graph
 class GeoArrowPolylinesLayer : public S2Builder::Layer {
  public:
   using GraphOptions = S2Builder::GraphOptions;
@@ -977,6 +978,7 @@ class GeoArrowPolylinesLayer : public S2Builder::Layer {
   OutputGeometry* output_;
 };
 
+/// \brief Output layer that collects polygon edge collections in the graph
 class GeoArrowPolygonLayer : public S2Builder::Layer {
  public:
   using GraphOptions = S2Builder::GraphOptions;
@@ -984,7 +986,8 @@ class GeoArrowPolygonLayer : public S2Builder::Layer {
   using EdgeId = Graph::EdgeId;
   using InputEdgeId = Graph::InputEdgeId;
 
-  GeoArrowPolygonLayer(OutputGeometry* output, EdgeTracker* edge_tracker)
+  GeoArrowPolygonLayer(OutputGeometry* output,
+                       EdgeTracker* edge_tracker = nullptr)
       : edge_tracker_(edge_tracker), output_(output) {}
 
   GraphOptions graph_options() const override {

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -918,7 +918,7 @@ struct RebuildExec {
   std::vector<internal::GeoArrowVertex> polygon_vertices_;
 };
 
-struct UnaryUnionGridSizeExec {
+struct SnapToGridExec {
   using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = DoubleInputView;
   using out_t = GeoArrowOutputBuilder;
@@ -988,8 +988,8 @@ void UnionKernel(struct SedonaCScalarKernel* out) {
       out, "st_union");
 }
 
-void UnaryUnionGridSizeKernel(struct SedonaCScalarKernel* out) {
-  InitBinaryKernel<UnaryUnionGridSizeExec>(out, "st_unaryunion");
+void SnapToGridKernel(struct SedonaCScalarKernel* out) {
+  InitBinaryKernel<SnapToGridExec>(out, "st_snaptogrid");
 }
 
 }  // namespace sedona_udf

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -7,6 +7,7 @@
 #include <s2/s2builderutil_s2point_vector_layer.h>
 #include <s2/s2builderutil_s2polygon_layer.h>
 #include <s2/s2builderutil_s2polyline_vector_layer.h>
+#include <s2/s2builderutil_snap_functions.h>
 
 #include <sstream>
 
@@ -434,75 +435,154 @@ std::unique_ptr<Geography> S2UnionAggregator::Finalize() {
 
 namespace sedona_udf {
 
+struct EdgeTracker {
+  EdgeTracker() { Clear(); }
+
+  void Clear() {
+    num_edges_.clear();
+    num_edges_.push_back(0);
+    edge_count_ = 0;
+  }
+
+  void Add(const S2Shape* shape) {
+    shapes_.push_back(shape);
+    edge_count_ += shape->num_edges();
+    num_edges_.push_back(edge_count_);
+  }
+
+  std::pair<const S2Shape*, int> ResolveSource(int edge_id) {
+    auto it = std::upper_bound(num_edges_.begin(), num_edges_.end(), edge_id);
+    int shape_idx = static_cast<int>(std::distance(num_edges_.begin(), it)) - 1;
+    return {shapes_[shape_idx], edge_id - num_edges_[shape_idx]};
+  }
+
+  internal::GeoArrowEdge ResolveEdge(int edge_id) {
+    auto src = ResolveSource(edge_id);
+    switch (src.first->dimension()) {
+      case 0: {
+        const auto* points =
+            reinterpret_cast<const GeoArrowPointShape*>(src.first);
+        return points->native_edge(src.second).Normalize(points->dimensions());
+      }
+      case 1: {
+        const auto* lines =
+            reinterpret_cast<const GeoArrowLaxPolylineShape*>(src.first);
+        return lines->native_edge(src.second).Normalize(lines->dimensions());
+      }
+      case 2: {
+        const auto* polygons =
+            reinterpret_cast<const GeoArrowLaxPolygonShape*>(src.first);
+        return polygons->native_edge(src.second)
+            .Normalize(polygons->dimensions());
+      }
+      default:
+        throw Exception("Unexpected value of dimension()");
+    }
+  }
+
+  std::vector<int> num_edges_;
+  int edge_count_;
+  std::vector<const S2Shape*> shapes_;
+};
+
+/// \brief A reference to a source edge, used as a label payload
+struct SourceEdgeRef {
+  int shape_id;
+  int edge_id;
+};
+
+/// \brief An S2Builder layer that collects degenerate edges (points) and
+/// resolves them back to native GeoArrow vertices via labels.
+///
+/// Like s2builderutil::S2PointVectorLayer, this layer expects all edges to be
+/// degenerate. It uses Graph::LabelFetcher to retrieve source (shape_id,
+/// edge_id) references that were attached as labels when the edges were added
+/// to the builder, then resolves those references against the source
+/// GeoArrowGeography to recover lossless lon/lat/z/m coordinates.
 class GeoArrowPointVectorLayer : public S2Builder::Layer {
  public:
   using GraphOptions = S2Builder::GraphOptions;
   using Graph = S2Builder::Graph;
   using EdgeId = Graph::EdgeId;
+  using InputEdgeId = Graph::InputEdgeId;
 
-  GeoArrowPointVectorLayer(const GeoArrowPointShape* source,
-                           std::vector<internal::GeoArrowVertex>* points_out,
-                           int32_t input_edge_id_offset = 0)
-      : source_(source),
-        points_out_(points_out),
-        input_edge_id_offset_(input_edge_id_offset) {}
+  GeoArrowPointVectorLayer(EdgeTracker* edge_tracker,
+                           std::vector<internal::GeoArrowVertex>* points_out)
+      : edge_tracker_(edge_tracker), points_out_(points_out) {}
 
   GraphOptions graph_options() const override {
     return GraphOptions(
-        S2Builder::EdgeType::DIRECTED,
-        GraphOptions::DegenerateEdges::KEEP,
-        GraphOptions::DuplicateEdges::MERGE,
-        GraphOptions::SiblingPairs::KEEP);
+        S2Builder::EdgeType::DIRECTED, GraphOptions::DegenerateEdges::KEEP,
+        GraphOptions::DuplicateEdges::MERGE, GraphOptions::SiblingPairs::KEEP);
   }
 
   void Build(const Graph& g, S2Error* error) override {
-    for (EdgeId edge_id = 0;
-         static_cast<size_t>(edge_id) < g.edges().size();
+    for (EdgeId edge_id = 0; static_cast<size_t>(edge_id) < g.edges().size();
          ++edge_id) {
+      // Resolve the edge
       const auto& edge = g.edge(edge_id);
-
       if (edge.first != edge.second) {
         *error = S2Error::InvalidArgument("Found non-degenerate edges");
         continue;
       }
 
-      // Resolve the output edge back to an input edge, then to a native vertex
-      for (auto input_id : g.input_edge_ids(edge_id)) {
-        int source_edge = static_cast<int>(input_id - input_edge_id_offset_);
-        auto native = source_->native_vertex(source_edge);
-        // For degenerate (point) edges, v0 == v1
-        points_out_->push_back(native.Normalize(source_->dimensions()));
+      // Resolve the vertex as an S2Point
+      S2Point pt = g.vertex(edge.first);
+      internal::GeoArrowVertex vt;
+
+      // GEOS seems to always return the first Z or M it encounters for point
+      // output
+      for (InputEdgeId input_edge_id : g.input_edge_ids(edge_id)) {
+        auto e = edge_tracker_->ResolveEdge(input_edge_id);
+        vt = e.v0;
+        break;
       }
+
+      // If this vertex was snapped to a new location, set its vertex
+      if (pt != vt.ToPoint()) {
+        vt.SetPoint(pt);
+      }
+
+      // Write to the output
+      Write(vt);
     }
   }
 
+  void Write(const internal::GeoArrowVertex& v) { points_out_->push_back(v); }
+
  private:
-  const GeoArrowPointShape* source_;
+  EdgeTracker* edge_tracker_;
   std::vector<internal::GeoArrowVertex>* points_out_;
-  int32_t input_edge_id_offset_;
+  GraphOptions::DuplicateEdges duplicate_edges_;
 };
 
 struct RebuildExec {
   using arg0_t = GeoArrowGeographyInputView;
   using out_t = GeoArrowOutputBuilder;
 
-  RebuildExec() {
+  RebuildExec(const S2Builder::Options& options = S2Builder::Options())
+      : builder_options_(options) {
     builder_.Init(builder_options_);
   }
 
-  void Exec(arg0_t::c_type value0, out_t* out) {
+  void Exec(const GeoArrowGeography& value0, GeoArrowOutputBuilder* out) {
     builder_.Reset();
     native_points_.clear();
+    edge_tracker_.Clear();
 
-    // Start a layer that collects native point vertices
+    // Start a layer that collects point vertices
     builder_.StartLayer(absl::make_unique<GeoArrowPointVectorLayer>(
-        value0.points(), &native_points_));
-    builder_.AddShape(*value0.points());
+        &edge_tracker_, &native_points_));
 
+    edge_tracker_.Add(value0.points());
+    value0.points()->geom().VisitVertices([&](const S2Point& v) {
+      builder_.AddPoint(v);
+      return true;
+    });
 
     // TODO: add GeoArrow-aware layers for lines and polygons
-    builder_.AddShape(*value0.lines());
-    builder_.AddShape(*value0.polygons());
+    // builder_.AddShape(*value0.lines());
+    // builder_.AddShape(*value0.polygons());
 
     // build the output
     S2Error error;
@@ -512,10 +592,33 @@ struct RebuildExec {
       throw Exception(ss.str());
     }
 
-    // Write native point output to the GeoArrowOutputBuilder
-    // TODO: handle lines and polygons; write a complete geometry
+    // Write the output
+
+    // If there is only point output, write it
+    if (!native_points_.empty()) {
+      out->FeatureStart();
+      WritePointOutput(out);
+      out->FeatureEnd();
+      return;
+    }
+
+    // TODO: check for only polyline output
+
+    // TODO: check for only polgon output
+
+    // Otherwise, write a GEOMETRYCOLLECTION with any of the available output
+    out->FeatureStart();
+    out->GeomStart(GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION);
+    WritePointOutput(out);
+    out->GeomEnd();
+    out->FeatureEnd();
+  }
+
+  void WritePointOutput(out_t* out) {
     if (native_points_.size() == 1) {
-      out->AppendPoint(native_points_[0]);
+      out->GeomStart(GEOARROW_GEOMETRY_TYPE_POINT);
+      out->WriteCoord(native_points_[0]);
+      out->GeomEnd();
     } else if (native_points_.size() > 1) {
       out->FeatureStart();
       out->GeomStart(GEOARROW_GEOMETRY_TYPE_MULTIPOINT);
@@ -525,15 +628,40 @@ struct RebuildExec {
         out->GeomEnd();
       }
       out->GeomEnd();
-      out->FeatureEnd();
-    } else {
-      out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_POINT);
     }
   }
 
   S2Builder builder_;
   S2Builder::Options builder_options_;
+  EdgeTracker edge_tracker_;
   std::vector<internal::GeoArrowVertex> native_points_;
+};
+
+struct UnaryUnionGridSizeExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = DoubleInputView;
+  using out_t = GeoArrowOutputBuilder;
+
+  void Exec(arg0_t::c_type value, double grid_size, out_t* out) {
+    // If the grid size changed since the last iteration, we need to recreate
+    // the snap function and reinitialize the builder with the new options
+    if (grid_size != last_grid_size_) {
+      int exponent = static_cast<int>(std::round(-std::log10(grid_size)));
+      exponent =
+          std::max(s2builderutil::IntLatLngSnapFunction::kMinExponent,
+                   std::min(s2builderutil::IntLatLngSnapFunction::kMaxExponent,
+                            exponent));
+      s2builderutil::IntLatLngSnapFunction snap(exponent);
+      rebuild_.builder_options_.set_snap_function(snap);
+      rebuild_.builder_.Init(rebuild_.builder_options_);
+      last_grid_size_ = grid_size;
+    }
+
+    rebuild_.Exec(value, out);
+  }
+
+  RebuildExec rebuild_;
+  double last_grid_size_{-100};
 };
 
 template <S2BooleanOperation::OpType op_type>
@@ -571,6 +699,10 @@ void IntersectionKernel(struct SedonaCScalarKernel* out) {
 void UnionKernel(struct SedonaCScalarKernel* out) {
   InitBinaryKernel<BooleanOperationExec<S2BooleanOperation::OpType::UNION>>(
       out, "st_union");
+}
+
+void UnaryUnionGridSizeKernel(struct SedonaCScalarKernel* out) {
+  InitBinaryKernel<UnaryUnionGridSizeExec>(out, "st_unaryunion");
 }
 
 }  // namespace sedona_udf

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -450,6 +450,7 @@ struct EdgeTracker {
     num_edges_.clear();
     num_edges_.push_back(0);
     edge_count_ = 0;
+    shapes_.clear();
   }
 
   /// \brief Add a tracked shape
@@ -804,7 +805,12 @@ struct OutputGeometry {
           }
         }
       }
-      hole_parent[j] = best_shell;
+
+      if (best_shell == -1) {
+        throw Exception("Can't find shell for polygon hole");
+      } else {
+        hole_parent[j] = best_shell;
+      }
     }
 
     // Build polygon_lengths_ and ring_order_: each shell followed by its
@@ -1146,12 +1152,12 @@ struct SimplifyExec {
   void Exec(arg0_t::c_type value, double tolerance, out_t* out) {
     // If the grid size changed since the last iteration, we need to recreate
     // the snap function and reinitialize the builder with the new options
-    if (tolerance != last_tolerance_) {
-      if (tolerance < 0) {
-        // PostGIS seems to do this
-        tolerance = -tolerance;
-      }
+    if (tolerance < 0) {
+      // PostGIS seems to do this
+      tolerance = -tolerance;
+    }
 
+    if (tolerance != last_tolerance_) {
       // Create the identity snap function
       S1Angle tolerance_angle =
           S1Angle::Radians(tolerance / S2Earth::RadiusMeters());

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -592,7 +592,9 @@ struct RebuildExec {
       throw Exception(ss.str());
     }
 
-    // Write the output
+    // Write the output. For unary input we write the same output dimensions as
+    // the input
+    out->SetDimensions(value0.dimensions());
 
     // If there is only point output, write it
     if (!native_points_.empty()) {
@@ -620,7 +622,6 @@ struct RebuildExec {
       out->WriteCoord(native_points_[0]);
       out->GeomEnd();
     } else if (native_points_.size() > 1) {
-      out->FeatureStart();
       out->GeomStart(GEOARROW_GEOMETRY_TYPE_MULTIPOINT);
       for (const auto& pt : native_points_) {
         out->GeomStart(GEOARROW_GEOMETRY_TYPE_POINT);
@@ -646,13 +647,19 @@ struct UnaryUnionGridSizeExec {
     // If the grid size changed since the last iteration, we need to recreate
     // the snap function and reinitialize the builder with the new options
     if (grid_size != last_grid_size_) {
-      int exponent = static_cast<int>(std::round(-std::log10(grid_size)));
-      exponent =
-          std::max(s2builderutil::IntLatLngSnapFunction::kMinExponent,
-                   std::min(s2builderutil::IntLatLngSnapFunction::kMaxExponent,
-                            exponent));
-      s2builderutil::IntLatLngSnapFunction snap(exponent);
-      rebuild_.builder_options_.set_snap_function(snap);
+      if (grid_size > 0) {
+        int exponent = static_cast<int>(std::round(-std::log10(grid_size)));
+        exponent = std::max(
+            s2builderutil::IntLatLngSnapFunction::kMinExponent,
+            std::min(s2builderutil::IntLatLngSnapFunction::kMaxExponent,
+                     exponent));
+        s2builderutil::IntLatLngSnapFunction snap(exponent);
+        rebuild_.builder_options_.set_snap_function(snap);
+      } else {
+        s2builderutil::IdentitySnapFunction snap;
+        rebuild_.builder_options_.set_snap_function(snap);
+      }
+
       rebuild_.builder_.Init(rebuild_.builder_options_);
       last_grid_size_ = grid_size;
     }

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -491,11 +491,11 @@ struct OutputGeometry {
     points_.clear();
     line_lengths_.clear();
     line_vertices_.clear();
-    ring_lengths_.clear();
+    ring_offsets_.assign(1, 0);
+    ring_order_.clear();
     polygon_lengths_.clear();
     polygon_vertices_.clear();
     current_line_length_ = 0;
-    current_ring_length_ = 0;
   }
 
   void AddPoint(const internal::GeoArrowVertex& v) { points_.push_back(v); }
@@ -512,17 +512,15 @@ struct OutputGeometry {
 
   void AddRingVertex(const internal::GeoArrowVertex& v) {
     polygon_vertices_.push_back(v);
-    ++current_ring_length_;
   }
 
   void FinishRing() {
-    ring_lengths_.push_back(current_ring_length_);
-    current_ring_length_ = 0;
+    ring_offsets_.push_back(static_cast<int>(polygon_vertices_.size()));
   }
 
   bool has_points() const { return !points_.empty(); }
   bool has_lines() const { return !line_lengths_.empty(); }
-  bool has_polygons() const { return !ring_lengths_.empty(); }
+  bool has_polygons() const { return ring_offsets_.size() > 1; }
   int num_types() const { return has_points() + has_lines() + has_polygons(); }
 
   void WriteTo(GeoArrowOutputBuilder* out, uint8_t geometry_type) {
@@ -590,17 +588,16 @@ struct OutputGeometry {
   void WritePolygonOutput(GeoArrowOutputBuilder* out) {
     GroupRings();
 
-    int ring_id = 0;
-    int vertex_id = 0;
+    int order_id = 0;
     if (polygon_lengths_.size() == 1) {
       out->GeomStart(GEOARROW_GEOMETRY_TYPE_POLYGON);
       for (int r = 0; r < polygon_lengths_[0]; ++r) {
+        int ri = ring_order_[order_id++];
         out->RingStart();
-        for (int i = 0; i < ring_lengths_[ring_id]; ++i) {
-          out->WriteCoord(polygon_vertices_[vertex_id++]);
+        for (int i = ring_offsets_[ri]; i < ring_offsets_[ri + 1]; ++i) {
+          out->WriteCoord(polygon_vertices_[i]);
         }
         out->RingEnd();
-        ++ring_id;
       }
       out->GeomEnd();
     } else if (polygon_lengths_.size() > 1) {
@@ -608,12 +605,12 @@ struct OutputGeometry {
       for (int polygon_length : polygon_lengths_) {
         out->GeomStart(GEOARROW_GEOMETRY_TYPE_POLYGON);
         for (int r = 0; r < polygon_length; ++r) {
+          int ri = ring_order_[order_id++];
           out->RingStart();
-          for (int i = 0; i < ring_lengths_[ring_id]; ++i) {
-            out->WriteCoord(polygon_vertices_[vertex_id++]);
+          for (int i = ring_offsets_[ri]; i < ring_offsets_[ri + 1]; ++i) {
+            out->WriteCoord(polygon_vertices_[i]);
           }
           out->RingEnd();
-          ++ring_id;
         }
         out->GeomEnd();
       }
@@ -622,33 +619,34 @@ struct OutputGeometry {
   }
 
   void BuildRingNodes() {
-    ring_nodes_.resize(ring_lengths_.size());
+    int num_rings = static_cast<int>(ring_offsets_.size()) - 1;
+    ring_nodes_.resize(num_rings);
     const uint8_t* base =
         reinterpret_cast<const uint8_t*>(polygon_vertices_.data());
-    int vertex_offset = 0;
-    for (size_t i = 0; i < ring_lengths_.size(); ++i) {
+    for (int i = 0; i < num_rings; ++i) {
       struct GeoArrowBufferView coords;
-      coords.data = base + vertex_offset * sizeof(internal::GeoArrowVertex);
-      coords.size_bytes =
-          ring_lengths_[i] * sizeof(internal::GeoArrowVertex);
+      coords.data = base + ring_offsets_[i] * sizeof(internal::GeoArrowVertex);
+      coords.size_bytes = (ring_offsets_[i + 1] - ring_offsets_[i]) *
+                          sizeof(internal::GeoArrowVertex);
       GeoArrowGeometryNodeSetInterleaved(&ring_nodes_[i],
                                          GEOARROW_GEOMETRY_TYPE_LINESTRING,
                                          GEOARROW_DIMENSIONS_XYZM, coords);
-      vertex_offset += ring_lengths_[i];
     }
   }
 
   void GroupRings() {
     polygon_lengths_.clear();
-    int num_rings = static_cast<int>(ring_lengths_.size());
+    int num_rings = static_cast<int>(ring_offsets_.size()) - 1;
 
     if (num_rings == 0) {
+      ring_order_.clear();
       return;
     }
 
     // Fast path: single ring -> single polygon
     if (num_rings == 1) {
       polygon_lengths_.push_back(1);
+      ring_order_ = {0};
       return;
     }
 
@@ -675,11 +673,10 @@ struct OutputGeometry {
     // Common case: exactly one shell with zero or more holes
     if (shells.size() == 1) {
       polygon_lengths_.push_back(num_rings);
-      // Reorder rings: shell first, then holes (already in order if shell
-      // was the first ring written, but may not be in general)
-      if (shells[0] != 0) {
-        ReorderRings(shells, holes);
-      }
+      ring_order_.clear();
+      ring_order_.reserve(num_rings);
+      ring_order_.push_back(shells[0]);
+      for (int h : holes) ring_order_.push_back(h);
       return;
     }
 
@@ -687,16 +684,15 @@ struct OutputGeometry {
     // more efficient than brute force when checking multiple holes.
     std::vector<std::unique_ptr<S2Loop>> s2loops(shells.size());
     for (size_t s = 0; s < shells.size(); ++s) {
-      GeoArrowLoop loop(&ring_nodes_[shells[s]], &scratch_);
-      std::vector<S2Point> vertices;
-      vertices.reserve(loop.size() - 1);
+      GeoArrowChain loop(&ring_nodes_[shells[s]]);
+      scratch_.clear();
+      scratch_.reserve(loop.size() - 1);
       loop.VisitVertices(0, loop.size() - 1, [&](const S2Point& pt) {
-        vertices.push_back(pt);
+        scratch_.push_back(pt);
         return true;
       });
-      s2loops[s] = absl::make_unique<S2Loop>(vertices);
-      // Normalize so that Contains() works correctly
-      s2loops[s]->Normalize();
+      s2loops[s] = absl::make_unique<S2Loop>(scratch_, S2Debug::DISABLE);
+      S2GEOGRAPHY_DCHECK(s2loops[s]->IsValid());
     }
 
     // Match each hole to its containing shell.
@@ -709,7 +705,7 @@ struct OutputGeometry {
       double best_area = std::numeric_limits<double>::max();
       for (size_t s = 0; s < shells.size(); ++s) {
         if (s2loops[s]->Contains(test_point)) {
-          double area = s2loops[s]->GetArea();
+          double area = ring_signed_areas_[shells[s]];
           if (area < best_area) {
             best_area = area;
             best_shell = static_cast<int>(s);
@@ -719,84 +715,31 @@ struct OutputGeometry {
       hole_parent[j] = best_shell;
     }
 
-    // Build polygon_lengths_ and reorder rings: each shell followed by its
+    // Build polygon_lengths_ and ring_order_: each shell followed by its
     // holes
-    ReorderGroupedRings(shells, holes, hole_parent);
-  }
-
-  void ReorderRings(const std::vector<int>& shells,
-                    const std::vector<int>& holes) {
-    std::vector<internal::GeoArrowVertex> reordered_vertices;
-    std::vector<int> reordered_lengths;
-    reordered_vertices.reserve(polygon_vertices_.size());
-    reordered_lengths.reserve(ring_lengths_.size());
-
-    auto appendRing = [&](int ring_idx) {
-      int offset = 0;
-      for (int r = 0; r < ring_idx; ++r) offset += ring_lengths_[r];
-      reordered_vertices.insert(reordered_vertices.end(),
-                                polygon_vertices_.begin() + offset,
-                                polygon_vertices_.begin() + offset +
-                                    ring_lengths_[ring_idx]);
-      reordered_lengths.push_back(ring_lengths_[ring_idx]);
-    };
-
-    for (int s : shells) appendRing(s);
-    for (int h : holes) appendRing(h);
-
-    polygon_vertices_ = std::move(reordered_vertices);
-    ring_lengths_ = std::move(reordered_lengths);
-  }
-
-  void ReorderGroupedRings(const std::vector<int>& shells,
-                           const std::vector<int>& holes,
-                           const std::vector<int>& hole_parent) {
-    std::vector<internal::GeoArrowVertex> reordered_vertices;
-    std::vector<int> reordered_lengths;
-    reordered_vertices.reserve(polygon_vertices_.size());
-    reordered_lengths.reserve(ring_lengths_.size());
-
-    // Precompute ring start offsets
-    std::vector<int> ring_offsets(ring_lengths_.size());
-    int offset = 0;
-    for (size_t i = 0; i < ring_lengths_.size(); ++i) {
-      ring_offsets[i] = offset;
-      offset += ring_lengths_[i];
-    }
-
-    auto appendRing = [&](int ring_idx) {
-      int off = ring_offsets[ring_idx];
-      reordered_vertices.insert(reordered_vertices.end(),
-                                polygon_vertices_.begin() + off,
-                                polygon_vertices_.begin() + off +
-                                    ring_lengths_[ring_idx]);
-      reordered_lengths.push_back(ring_lengths_[ring_idx]);
-    };
-
+    ring_order_.clear();
+    ring_order_.reserve(num_rings);
     for (size_t s = 0; s < shells.size(); ++s) {
       int ring_count = 1;
-      appendRing(shells[s]);
+      ring_order_.push_back(shells[s]);
       for (size_t j = 0; j < holes.size(); ++j) {
         if (hole_parent[j] == static_cast<int>(s)) {
-          appendRing(holes[j]);
+          ring_order_.push_back(holes[j]);
           ++ring_count;
         }
       }
       polygon_lengths_.push_back(ring_count);
     }
-
-    polygon_vertices_ = std::move(reordered_vertices);
-    ring_lengths_ = std::move(reordered_lengths);
   }
 
   std::vector<internal::GeoArrowVertex> points_;
   std::vector<int> line_lengths_;
   std::vector<internal::GeoArrowVertex> line_vertices_;
-  std::vector<int> ring_lengths_;
+  std::vector<int> ring_offsets_;
+  std::vector<int> ring_order_;
   std::vector<int> polygon_lengths_;
   std::vector<internal::GeoArrowVertex> polygon_vertices_;
   int current_line_length_{0};
-  int current_ring_length_{0};
   std::vector<struct GeoArrowGeometryNode> ring_nodes_;
   std::vector<double> ring_signed_areas_;
   std::vector<S2Point> scratch_;

--- a/src/s2geography/build.h
+++ b/src/s2geography/build.h
@@ -109,6 +109,7 @@ void DifferenceKernel(struct SedonaCScalarKernel* out);
 void SymDifferenceKernel(struct SedonaCScalarKernel* out);
 void IntersectionKernel(struct SedonaCScalarKernel* out);
 void UnionKernel(struct SedonaCScalarKernel* out);
+void UnaryUnionGridSizeKernel(struct SedonaCScalarKernel* out);
 }  // namespace sedona_udf
 
 }  // namespace s2geography

--- a/src/s2geography/build.h
+++ b/src/s2geography/build.h
@@ -110,6 +110,8 @@ void SymDifferenceKernel(struct SedonaCScalarKernel* out);
 void IntersectionKernel(struct SedonaCScalarKernel* out);
 void UnionKernel(struct SedonaCScalarKernel* out);
 void ReducePrecisionKernel(struct SedonaCScalarKernel* out);
+void SimplifyKernel(struct SedonaCScalarKernel* out);
+
 }  // namespace sedona_udf
 
 }  // namespace s2geography

--- a/src/s2geography/build.h
+++ b/src/s2geography/build.h
@@ -109,7 +109,7 @@ void DifferenceKernel(struct SedonaCScalarKernel* out);
 void SymDifferenceKernel(struct SedonaCScalarKernel* out);
 void IntersectionKernel(struct SedonaCScalarKernel* out);
 void UnionKernel(struct SedonaCScalarKernel* out);
-void UnaryUnionGridSizeKernel(struct SedonaCScalarKernel* out);
+void SnapToGridKernel(struct SedonaCScalarKernel* out);
 }  // namespace sedona_udf
 
 }  // namespace s2geography

--- a/src/s2geography/build.h
+++ b/src/s2geography/build.h
@@ -109,7 +109,7 @@ void DifferenceKernel(struct SedonaCScalarKernel* out);
 void SymDifferenceKernel(struct SedonaCScalarKernel* out);
 void IntersectionKernel(struct SedonaCScalarKernel* out);
 void UnionKernel(struct SedonaCScalarKernel* out);
-void SnapToGridKernel(struct SedonaCScalarKernel* out);
+void ReducePrecisionKernel(struct SedonaCScalarKernel* out);
 }  // namespace sedona_udf
 
 }  // namespace s2geography

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -242,4 +242,126 @@ TEST(Build, SedonaUdfUnaryUnionGridSize) {
       out_array.get(), {"POINT (0 0)", "POINT (0 0)", std::nullopt}));
 }
 
+struct UnaryUnionGridSizeParam {
+  std::string name;
+  std::optional<std::string> input_wkt;
+  std::optional<double> grid_size;
+  std::optional<std::string> expected_wkt;
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const UnaryUnionGridSizeParam& p) {
+    os << (p.input_wkt ? *p.input_wkt : "null")
+       << " grid_size=" << (p.grid_size ? std::to_string(*p.grid_size) : "null")
+       << " -> " << (p.expected_wkt ? *p.expected_wkt : "null");
+    return os;
+  }
+};
+
+class UnaryUnionGridSizeTest
+    : public ::testing::TestWithParam<UnaryUnionGridSizeParam> {};
+
+TEST_P(UnaryUnionGridSizeTest, SedonaUdf) {
+  const auto& p = GetParam();
+
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::UnaryUnionGridSizeKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE},
+                        {{p.input_wkt}}, {{p.grid_size}}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(
+      TestResultGeography(out_array.get(), {p.expected_wkt}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Build, UnaryUnionGridSizeTest,
+    ::testing::Values(
+        // Null inputs
+        UnaryUnionGridSizeParam{"null_geom", std::nullopt, 1.0, std::nullopt},
+        UnaryUnionGridSizeParam{"null_grid_size", "POINT (0 0)", std::nullopt,
+                                std::nullopt},
+        UnaryUnionGridSizeParam{"null_both", std::nullopt, std::nullopt,
+                                std::nullopt},
+
+        // Point snapping to whole degrees (grid_size = 1.0)
+        UnaryUnionGridSizeParam{"point_on_grid", "POINT (0 0)", 1.0,
+                                "POINT (0 0)"},
+        UnaryUnionGridSizeParam{"point_not_on_grid", "POINT (0.001 0.001)", 1.0,
+                                "POINT (0 0)"},
+        UnaryUnionGridSizeParam{"point_no_snap", "POINT (0.001 0.001)", -1,
+                                "POINT (0.001 0.001)"},
+
+        // Point snapping to 0.1 degree grid (grid_size = 0.1)
+        UnaryUnionGridSizeParam{"point_tenth_degree_on_grid", "POINT (0.1 0.1)",
+                                0.1, "POINT (0.1 0.1)"},
+        UnaryUnionGridSizeParam{"point_tenth_degree_snap", "POINT (0.12 0.12)",
+                                0.1, "POINT (0.1 0.1)"},
+
+        // Multipoint: two nearby points snap to same location
+        UnaryUnionGridSizeParam{"multipoint_merge",
+                                "MULTIPOINT ((0.001 0.001), (0.002 0.002))",
+                                1.0, "POINT (0 0)"},
+        // Multipoint: points remain distinct after snapping
+        UnaryUnionGridSizeParam{"multipoint_distinct",
+                                "MULTIPOINT ((0 0), (10 10))", 1.0,
+                                "MULTIPOINT ((0 0), (10 10))"},
+
+        // Check ZM handling
+        UnaryUnionGridSizeParam{"point_on_grid_z", "POINT Z (0 1 10)", 1.0,
+                                "POINT Z (0 1 10)"},
+        UnaryUnionGridSizeParam{"point_no_snap_z", "POINT Z (0.01 1.01 10)",
+                                1.0, "POINT Z (0 1 10)"},
+        UnaryUnionGridSizeParam{"point_not_on_grid_z", "POINT Z (0.01 1.01 10)",
+                                1.0, "POINT Z (0 1 10)"},
+        UnaryUnionGridSizeParam{"multipoint_merge_z",
+                                "MULTIPOINT Z (0.01 1.01 10, 0.01 1.01 20)",
+                                1.0, "POINT Z (0 1 10)"},
+        UnaryUnionGridSizeParam{"multipoint_distinct_z",
+                                "MULTIPOINT Z (0.01 1.01 10, 2.01 3.01 20)",
+                                1.0, "MULTIPOINT Z (0 1 10, 2 3 20)"},
+
+        // Check M handling
+        UnaryUnionGridSizeParam{"point_on_grid_m", "POINT M (0 1 10)", 1.0,
+                                "POINT M (0 1 10)"},
+        UnaryUnionGridSizeParam{"point_no_snap_m", "POINT M (0.01 1.01 10)",
+                                1.0, "POINT M (0 1 10)"},
+        UnaryUnionGridSizeParam{"point_not_on_grid_m", "POINT M (0.01 1.01 10)",
+                                1.0, "POINT M (0 1 10)"},
+        UnaryUnionGridSizeParam{"multipoint_merge_m",
+                                "MULTIPOINT M (0.01 1.01 10, 0.01 1.01 20)",
+                                1.0, "POINT M (0 1 10)"},
+        UnaryUnionGridSizeParam{"multipoint_distinct_m",
+                                "MULTIPOINT M (0.01 1.01 10, 2.01 3.01 20)",
+                                1.0, "MULTIPOINT M (0 1 10, 2 3 20)"},
+
+        // Check ZM handling
+        UnaryUnionGridSizeParam{"point_on_grid_zm", "POINT ZM (0 1 10 100)",
+                                1.0, "POINT ZM (0 1 10 100)"},
+        UnaryUnionGridSizeParam{"point_no_snap_zm",
+                                "POINT ZM (0.01 1.01 10 100)", 1.0,
+                                "POINT ZM (0 1 10 100)"},
+        UnaryUnionGridSizeParam{"point_not_on_grid_zm",
+                                "POINT ZM (0.01 1.01 10 100)", 1.0,
+                                "POINT ZM (0 1 10 100)"},
+        UnaryUnionGridSizeParam{
+            "multipoint_merge_zm",
+            "MULTIPOINT ZM (0.01 1.01 10 100, 0.01 1.01 20 200)", 1.0,
+            "POINT ZM (0 1 10 100)"},
+        UnaryUnionGridSizeParam{
+            "multipoint_distinct_zm",
+            "MULTIPOINT ZM (0.01 1.01 10 100, 2.01 3.01 20 200)", 1.0,
+            "MULTIPOINT ZM (0 1 10 100, 2 3 20 200)"}
+
+        ),
+    [](const ::testing::TestParamInfo<UnaryUnionGridSizeParam>& info) {
+      return info.param.name;
+    });
+
 }  // namespace s2geography

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -438,4 +438,129 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.name;
     });
 
+TEST(Build, SedonaUdfSimplify) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::SimplifyKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
+      &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE},
+      {{"POINT (0 0)", "LINESTRING (0 0, 10 0)", std::nullopt}},
+      {{0.0, 0.0, std::nullopt}}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(TestResultGeography(
+      out_array.get(),
+      {"POINT (0 0)", "LINESTRING (0 0, 10 0)", std::nullopt}));
+}
+
+struct SimplifyParam {
+  std::string name;
+  std::optional<std::string> input_wkt;
+  std::optional<double> tolerance;
+  std::optional<std::string> expected_wkt;
+
+  friend std::ostream& operator<<(std::ostream& os, const SimplifyParam& p) {
+    os << (p.input_wkt ? *p.input_wkt : "null")
+       << " tolerance=" << (p.tolerance ? std::to_string(*p.tolerance) : "null")
+       << " -> " << (p.expected_wkt ? *p.expected_wkt : "null");
+    return os;
+  }
+};
+
+class SimplifyTest : public ::testing::TestWithParam<SimplifyParam> {};
+
+TEST_P(SimplifyTest, SedonaUdf) {
+  const auto& p = GetParam();
+
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::SimplifyKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE},
+                        {{p.input_wkt}}, {{p.tolerance}}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(
+      TestResultGeography(out_array.get(), {p.expected_wkt}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Build, SimplifyTest,
+    ::testing::Values(
+        // Null inputs
+        SimplifyParam{"null_geom", std::nullopt, 0.0, std::nullopt},
+        SimplifyParam{"null_tolerance", "POINT (0 0)", std::nullopt,
+                      std::nullopt},
+        SimplifyParam{"null_both", std::nullopt, std::nullopt, std::nullopt},
+
+        // Point: unaffected by simplification (no edges)
+        SimplifyParam{"point_zero_tolerance", "POINT (0 0)", 0.0,
+                      "POINT (0 0)"},
+        SimplifyParam{"point_large_tolerance", "POINT (0 0)", 1000000.0,
+                      "POINT (0 0)"},
+
+        // Multipoint: zero tolerance preserves all points
+        SimplifyParam{"multipoint_zero_tolerance",
+                      "MULTIPOINT ((0 0), (10 10))", 0.0,
+                      "MULTIPOINT ((0 0), (10 10))"},
+        // Multipoint: large tolerance merges nearby points
+        SimplifyParam{"multipoint_merge", "MULTIPOINT ((0 0), (0.001 0.001))",
+                      1000000.0, "POINT (0 0)"},
+
+        // Linestring: zero tolerance is identity
+        SimplifyParam{"linestring_zero_tolerance", "LINESTRING (0 0, 10 0)",
+                      0.0, "LINESTRING (0 0, 10 0)"},
+        // Linestring: zero tolerance preserves intermediate vertex
+        SimplifyParam{"linestring_zero_tolerance_3pt",
+                      "LINESTRING (0 0, 5 1, 10 0)", 0.0,
+                      "LINESTRING (0 0, 5 1, 10 0)"},
+        // Linestring: large tolerance removes intermediate vertex
+        SimplifyParam{"linestring_simplify", "LINESTRING (0 0, 5 1, 10 0)",
+                      200000.0, "LINESTRING (0 0, 10 0)"},
+        // Linestring: small tolerance keeps intermediate vertex
+        SimplifyParam{"linestring_keep_vertex", "LINESTRING (0 0, 5 1, 10 0)",
+                      50000.0, "LINESTRING (0 0, 5 1, 10 0)"},
+        // Linestring: collapse when endpoints merge
+        SimplifyParam{"linestring_collapse", "LINESTRING (0 0, 0.0001 0.0001)",
+                      1000000.0, "LINESTRING EMPTY"},
+
+        // Linestring with Z: zero tolerance preserves Z
+        SimplifyParam{"linestring_z_zero_tolerance",
+                      "LINESTRING Z (0 0 100, 10 0 200)", 0.0,
+                      "LINESTRING Z (0 0 100, 10 0 200)"},
+        // Linestring with M: zero tolerance preserves M
+        SimplifyParam{"linestring_m_zero_tolerance",
+                      "LINESTRING M (0 0 100, 10 0 200)", 0.0,
+                      "LINESTRING M (0 0 100, 10 0 200)"},
+        // Linestring with ZM: zero tolerance preserves ZM
+        SimplifyParam{"linestring_zm_zero_tolerance",
+                      "LINESTRING ZM (0 0 100 1000, 10 0 200 2000)", 0.0,
+                      "LINESTRING ZM (0 0 100 1000, 10 0 200 2000)"},
+
+        // Point with Z
+        SimplifyParam{"point_z", "POINT Z (0 1 10)", 0.0, "POINT Z (0 1 10)"},
+        // Point with M
+        SimplifyParam{"point_m", "POINT M (0 1 10)", 0.0, "POINT M (0 1 10)"},
+        // Point with ZM
+        SimplifyParam{"point_zm", "POINT ZM (0 1 10 100)", 0.0,
+                      "POINT ZM (0 1 10 100)"}
+
+        // Polygon tests not included here because they currently test the same
+        // code paths as the precision reducer.
+
+        ),
+    [](const ::testing::TestParamInfo<SimplifyParam>& info) {
+      return info.param.name;
+    });
+
 }  // namespace s2geography

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -350,10 +350,55 @@ INSTANTIATE_TEST_SUITE_P(
         ReducePrecisionParam{
             "linestring_zm", "LINESTRING ZM (0 0 100 1000, 10 10 200 2000)",
             1.0, "LINESTRING ZM (0 0 100 1000, 10 10 200 2000)"},
+
+        // Multilinestring: no snapping needed
+        ReducePrecisionParam{"multilinestring_on_grid",
+                             "MULTILINESTRING ((0 0, 10 10), (20 20, 30 30))",
+                             1.0,
+                             "MULTILINESTRING ((0 0, 10 10), (20 20, 30 30))"},
+        // Multilinestring: endpoints snap to grid
+        ReducePrecisionParam{"multilinestring_snap",
+                             "MULTILINESTRING ((0.001 0.001, 10.001 10.001), "
+                             "(20.001 20.001, 30.001 30.001))",
+                             1.0,
+                             "MULTILINESTRING ((0 0, 10 10), (20 20, 30 30))"},
+        // Multilinestring: midpoints snap together on a grid
+        ReducePrecisionParam{
+            "multilinestring_midpoint_snap",
+            "MULTILINESTRING ((0 0, 4.9 4.9, 5.1 5.1, 10 10), "
+            "(20 20, 24.9 24.9, 25.1 25.1, 30 30))",
+            1.0, "MULTILINESTRING ((0 0, 5 5, 10 10), (20 20, 25 25, 30 30))"},
+        // Multilinestring: one component collapses because endpoints snap
+        // together
+        ReducePrecisionParam{
+            "multilinestring_partial_collapse",
+            "MULTILINESTRING ((0 0, 10 10), (0.01 0.02, 0.03 0.04))", 1.0,
+            "LINESTRING (0 0, 10 10)"},
+        // Multilinestring with Z
+        ReducePrecisionParam{
+            "multilinestring_z",
+            "MULTILINESTRING Z ((0 0 100, 10 10 200), (20 20 300, 30 30 400))",
+            1.0,
+            "MULTILINESTRING Z ((0 0 100, 10 10 200), "
+            "(20 20 300, 30 30 400))"},
+        // Multilinestring with M
+        ReducePrecisionParam{
+            "multilinestring_m",
+            "MULTILINESTRING M ((0 0 100, 10 10 200), (20 20 300, 30 30 400))",
+            1.0,
+            "MULTILINESTRING M ((0 0 100, 10 10 200), "
+            "(20 20 300, 30 30 400))"},
+        // Multilinestring with ZM
+        ReducePrecisionParam{
+            "multilinestring_zm",
+            "MULTILINESTRING ZM ((0 0 100 1000, 10 10 200 2000), "
+            "(20 20 300 3000, 30 30 400 4000))",
+            1.0,
+            "MULTILINESTRING ZM ((0 0 100 1000, 10 10 200 2000), "
+            "(20 20 300 3000, 30 30 400 4000))"},
+
         // Check Z handling
         ReducePrecisionParam{"point_on_grid_z", "POINT Z (0 1 10)", 1.0,
-                             "POINT Z (0 1 10)"},
-        ReducePrecisionParam{"point_no_snap_z", "POINT Z (0.01 1.01 10)", 1.0,
                              "POINT Z (0 1 10)"},
         ReducePrecisionParam{"point_not_on_grid_z", "POINT Z (0.01 1.01 10)",
                              1.0, "POINT Z (0 1 10)"},
@@ -367,8 +412,6 @@ INSTANTIATE_TEST_SUITE_P(
         // Check M handling
         ReducePrecisionParam{"point_on_grid_m", "POINT M (0 1 10)", 1.0,
                              "POINT M (0 1 10)"},
-        ReducePrecisionParam{"point_no_snap_m", "POINT M (0.01 1.01 10)", 1.0,
-                             "POINT M (0 1 10)"},
         ReducePrecisionParam{"point_not_on_grid_m", "POINT M (0.01 1.01 10)",
                              1.0, "POINT M (0 1 10)"},
         ReducePrecisionParam{"multipoint_merge_m",
@@ -381,8 +424,6 @@ INSTANTIATE_TEST_SUITE_P(
         // Check POINT ZM handling
         ReducePrecisionParam{"point_on_grid_zm", "POINT ZM (0 1 10 100)", 1.0,
                              "POINT ZM (0 1 10 100)"},
-        ReducePrecisionParam{"point_no_snap_zm", "POINT ZM (0.01 1.01 10 100)",
-                             1.0, "POINT ZM (0 1 10 100)"},
         ReducePrecisionParam{"point_not_on_grid_zm",
                              "POINT ZM (0.01 1.01 10 100)", 1.0,
                              "POINT ZM (0 1 10 100)"},
@@ -516,6 +557,9 @@ INSTANTIATE_TEST_SUITE_P(
         // Multipoint: large tolerance merges nearby points
         SimplifyParam{"multipoint_merge", "MULTIPOINT ((0 0), (0.001 0.001))",
                       1000000.0, "POINT (0 0)"},
+        // Multipoint: large negative tolerance also merges nearby points
+        SimplifyParam{"negative_tolerance", "MULTIPOINT ((0 0), (0.001 0.001))",
+                      -1000000.0, "POINT (0 0)"},
 
         // Linestring: zero tolerance is identity
         SimplifyParam{"linestring_zero_tolerance", "LINESTRING (0 0, 10 0)",

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -223,9 +223,9 @@ TEST(Build, SedonaUdfSymDifference) {
       {"GEOMETRYCOLLECTION EMPTY", "MULTIPOINT ((0 0), (0 1))", std::nullopt}));
 }
 
-TEST(Build, SedonaUdfSnapToGrid) {
+TEST(Build, SedonaUdfReducePrecision) {
   struct SedonaCScalarKernel kernel;
-  s2geography::sedona_udf::SnapToGridKernel(&kernel);
+  s2geography::sedona_udf::ReducePrecisionKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
   ASSERT_NO_FATAL_FAILURE(TestInitKernel(
       &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
@@ -242,13 +242,14 @@ TEST(Build, SedonaUdfSnapToGrid) {
       out_array.get(), {"POINT (0 0)", "POINT (0 0)", std::nullopt}));
 }
 
-struct SnapToGridParam {
+struct ReducePrecisionParam {
   std::string name;
   std::optional<std::string> input_wkt;
   std::optional<double> grid_size;
   std::optional<std::string> expected_wkt;
 
-  friend std::ostream& operator<<(std::ostream& os, const SnapToGridParam& p) {
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const ReducePrecisionParam& p) {
     os << (p.input_wkt ? *p.input_wkt : "null")
        << " grid_size=" << (p.grid_size ? std::to_string(*p.grid_size) : "null")
        << " -> " << (p.expected_wkt ? *p.expected_wkt : "null");
@@ -256,13 +257,14 @@ struct SnapToGridParam {
   }
 };
 
-class SnapToGridTest : public ::testing::TestWithParam<SnapToGridParam> {};
+class ReducePrecisionTest
+    : public ::testing::TestWithParam<ReducePrecisionParam> {};
 
-TEST_P(SnapToGridTest, SedonaUdf) {
+TEST_P(ReducePrecisionTest, SedonaUdf) {
   const auto& p = GetParam();
 
   struct SedonaCScalarKernel kernel;
-  s2geography::sedona_udf::SnapToGridKernel(&kernel);
+  s2geography::sedona_udf::ReducePrecisionKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
   ASSERT_NO_FATAL_FAILURE(TestInitKernel(
       &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
@@ -279,137 +281,155 @@ TEST_P(SnapToGridTest, SedonaUdf) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    Build, SnapToGridTest,
+    Build, ReducePrecisionTest,
     ::testing::Values(
         // Null inputs
-        SnapToGridParam{"null_geom", std::nullopt, 1.0, std::nullopt},
-        SnapToGridParam{"null_grid_size", "POINT (0 0)", std::nullopt,
-                        std::nullopt},
-        SnapToGridParam{"null_both", std::nullopt, std::nullopt, std::nullopt},
+        ReducePrecisionParam{"null_geom", std::nullopt, 1.0, std::nullopt},
+        ReducePrecisionParam{"null_grid_size", "POINT (0 0)", std::nullopt,
+                             std::nullopt},
+        ReducePrecisionParam{"null_both", std::nullopt, std::nullopt,
+                             std::nullopt},
 
         // Point snapping to whole degrees (grid_size = 1.0)
-        SnapToGridParam{"point_on_grid", "POINT (0 0)", 1.0, "POINT (0 0)"},
-        SnapToGridParam{"point_not_on_grid", "POINT (0.001 0.001)", 1.0,
-                        "POINT (0 0)"},
-        SnapToGridParam{"point_no_snap", "POINT (0.001 0.001)", -1,
-                        "POINT (0.001 0.001)"},
+        ReducePrecisionParam{"point_on_grid", "POINT (0 0)", 1.0,
+                             "POINT (0 0)"},
+        ReducePrecisionParam{"point_not_on_grid", "POINT (0.001 0.001)", 1.0,
+                             "POINT (0 0)"},
+        ReducePrecisionParam{"point_no_snap", "POINT (0.001 0.001)", -1,
+                             "POINT (0.001 0.001)"},
 
         // Point snapping to 0.1 degree grid (grid_size = 0.1)
-        SnapToGridParam{"point_tenth_degree_on_grid", "POINT (0.1 0.1)", 0.1,
-                        "POINT (0.1 0.1)"},
-        SnapToGridParam{"point_tenth_degree_snap", "POINT (0.12 0.12)", 0.1,
-                        "POINT (0.1 0.1)"},
+        ReducePrecisionParam{"point_tenth_degree_on_grid", "POINT (0.1 0.1)",
+                             0.1, "POINT (0.1 0.1)"},
+        ReducePrecisionParam{"point_tenth_degree_snap", "POINT (0.12 0.12)",
+                             0.1, "POINT (0.1 0.1)"},
 
         // Multipoint: two nearby points snap to same location
-        SnapToGridParam{"multipoint_merge",
-                        "MULTIPOINT ((0.001 0.001), (0.002 0.002))", 1.0,
-                        "POINT (0 0)"},
+        ReducePrecisionParam{"multipoint_merge",
+                             "MULTIPOINT ((0.001 0.001), (0.002 0.002))", 1.0,
+                             "POINT (0 0)"},
         // Multipoint: points remain distinct after snapping
-        SnapToGridParam{"multipoint_distinct", "MULTIPOINT ((0 0), (10 10))",
-                        1.0, "MULTIPOINT ((0 0), (10 10))"},
+        ReducePrecisionParam{"multipoint_distinct",
+                             "MULTIPOINT ((0 0), (10 10))", 1.0,
+                             "MULTIPOINT ((0 0), (10 10))"},
 
         // Linestring: no snapping needed
-        SnapToGridParam{"linestring_on_grid", "LINESTRING (0 0, 10 10)", 1.0,
-                        "LINESTRING (0 0, 10 10)"},
+        ReducePrecisionParam{"linestring_on_grid", "LINESTRING (0 0, 10 10)",
+                             1.0, "LINESTRING (0 0, 10 10)"},
         // Linestring: endpoints snap to grid
-        SnapToGridParam{"linestring_snap",
-                        "LINESTRING (0.001 0.001, 10.001 10.001)", 1.0,
-                        "LINESTRING (0 0, 10 10)"},
+        ReducePrecisionParam{"linestring_snap",
+                             "LINESTRING (0.001 0.001, 10.001 10.001)", 1.0,
+                             "LINESTRING (0 0, 10 10)"},
+        // Linestring: midpoints snap together on a grid
+        ReducePrecisionParam{"linestring_midpoint_snap",
+                             "LINESTRING (0 0, 4.9 4.9, 5.1 5.1, 10 10)", 1.0,
+                             "LINESTRING (0 0, 5 5, 10 10)"},
+        // Linestring: component collapses because the endpoints snap together
+        ReducePrecisionParam{"linestring_collapse",
+                             "LINESTRING (0.01 0.02, 0.03 0.04)", 1.0,
+                             "LINESTRING EMPTY"},
         // Linestring: no snapping with negative grid size
-        SnapToGridParam{"linestring_no_snap",
-                        "LINESTRING (0.001 0.001, 10.001 10.001)", -1,
-                        "LINESTRING (0.001 0.001, 10.001 10.001)"},
+        ReducePrecisionParam{"linestring_no_snap",
+                             "LINESTRING (0.001 0.001, 10.001 10.001)", -1,
+                             "LINESTRING (0.001 0.001, 10.001 10.001)"},
         // Linestring with Z
-        SnapToGridParam{"linestring_z", "LINESTRING Z (0 0 100, 10 10 200)",
-                        1.0, "LINESTRING Z (0 0 100, 10 10 200)"},
+        ReducePrecisionParam{"linestring_z",
+                             "LINESTRING Z (0 0 100, 10 10 200)", 1.0,
+                             "LINESTRING Z (0 0 100, 10 10 200)"},
         // Linestring with Z and snapping (Z values are interpolated when
         // endpoints are snapped, so they won't be exact)
-        SnapToGridParam{"linestring_snap_z",
-                        "LINESTRING Z (0.001 0.001 100, 10.001 10.001 200)",
-                        1.0, "LINESTRING Z (0 0 100.010024, 10 10 199.99005)"},
+        ReducePrecisionParam{
+            "linestring_snap_z",
+            "LINESTRING Z (0.001 0.001 100, 10.001 10.001 200)", 1.0,
+            "LINESTRING Z (0 0 100.010024, 10 10 199.99005)"},
         // Linestring with M
-        SnapToGridParam{"linestring_m", "LINESTRING M (0 0 100, 10 10 200)",
-                        1.0, "LINESTRING M (0 0 100, 10 10 200)"},
+        ReducePrecisionParam{"linestring_m",
+                             "LINESTRING M (0 0 100, 10 10 200)", 1.0,
+                             "LINESTRING M (0 0 100, 10 10 200)"},
         // Linestring with ZM
-        SnapToGridParam{"linestring_zm",
-                        "LINESTRING ZM (0 0 100 1000, 10 10 200 2000)", 1.0,
-                        "LINESTRING ZM (0 0 100 1000, 10 10 200 2000)"},
+        ReducePrecisionParam{
+            "linestring_zm", "LINESTRING ZM (0 0 100 1000, 10 10 200 2000)",
+            1.0, "LINESTRING ZM (0 0 100 1000, 10 10 200 2000)"},
         // Check Z handling
-        SnapToGridParam{"point_on_grid_z", "POINT Z (0 1 10)", 1.0,
-                        "POINT Z (0 1 10)"},
-        SnapToGridParam{"point_no_snap_z", "POINT Z (0.01 1.01 10)", 1.0,
-                        "POINT Z (0 1 10)"},
-        SnapToGridParam{"point_not_on_grid_z", "POINT Z (0.01 1.01 10)", 1.0,
-                        "POINT Z (0 1 10)"},
-        SnapToGridParam{"multipoint_merge_z",
-                        "MULTIPOINT Z (0.01 1.01 10, 0.01 1.01 20)", 1.0,
-                        "POINT Z (0 1 10)"},
-        SnapToGridParam{"multipoint_distinct_z",
-                        "MULTIPOINT Z (0.01 1.01 10, 2.01 3.01 20)", 1.0,
-                        "MULTIPOINT Z (0 1 10, 2 3 20)"},
+        ReducePrecisionParam{"point_on_grid_z", "POINT Z (0 1 10)", 1.0,
+                             "POINT Z (0 1 10)"},
+        ReducePrecisionParam{"point_no_snap_z", "POINT Z (0.01 1.01 10)", 1.0,
+                             "POINT Z (0 1 10)"},
+        ReducePrecisionParam{"point_not_on_grid_z", "POINT Z (0.01 1.01 10)",
+                             1.0, "POINT Z (0 1 10)"},
+        ReducePrecisionParam{"multipoint_merge_z",
+                             "MULTIPOINT Z (0.01 1.01 10, 0.01 1.01 20)", 1.0,
+                             "POINT Z (0 1 10)"},
+        ReducePrecisionParam{"multipoint_distinct_z",
+                             "MULTIPOINT Z (0.01 1.01 10, 2.01 3.01 20)", 1.0,
+                             "MULTIPOINT Z (0 1 10, 2 3 20)"},
 
         // Check M handling
-        SnapToGridParam{"point_on_grid_m", "POINT M (0 1 10)", 1.0,
-                        "POINT M (0 1 10)"},
-        SnapToGridParam{"point_no_snap_m", "POINT M (0.01 1.01 10)", 1.0,
-                        "POINT M (0 1 10)"},
-        SnapToGridParam{"point_not_on_grid_m", "POINT M (0.01 1.01 10)", 1.0,
-                        "POINT M (0 1 10)"},
-        SnapToGridParam{"multipoint_merge_m",
-                        "MULTIPOINT M (0.01 1.01 10, 0.01 1.01 20)", 1.0,
-                        "POINT M (0 1 10)"},
-        SnapToGridParam{"multipoint_distinct_m",
-                        "MULTIPOINT M (0.01 1.01 10, 2.01 3.01 20)", 1.0,
-                        "MULTIPOINT M (0 1 10, 2 3 20)"},
+        ReducePrecisionParam{"point_on_grid_m", "POINT M (0 1 10)", 1.0,
+                             "POINT M (0 1 10)"},
+        ReducePrecisionParam{"point_no_snap_m", "POINT M (0.01 1.01 10)", 1.0,
+                             "POINT M (0 1 10)"},
+        ReducePrecisionParam{"point_not_on_grid_m", "POINT M (0.01 1.01 10)",
+                             1.0, "POINT M (0 1 10)"},
+        ReducePrecisionParam{"multipoint_merge_m",
+                             "MULTIPOINT M (0.01 1.01 10, 0.01 1.01 20)", 1.0,
+                             "POINT M (0 1 10)"},
+        ReducePrecisionParam{"multipoint_distinct_m",
+                             "MULTIPOINT M (0.01 1.01 10, 2.01 3.01 20)", 1.0,
+                             "MULTIPOINT M (0 1 10, 2 3 20)"},
 
         // Check POINT ZM handling
-        SnapToGridParam{"point_on_grid_zm", "POINT ZM (0 1 10 100)", 1.0,
-                        "POINT ZM (0 1 10 100)"},
-        SnapToGridParam{"point_no_snap_zm", "POINT ZM (0.01 1.01 10 100)", 1.0,
-                        "POINT ZM (0 1 10 100)"},
-        SnapToGridParam{"point_not_on_grid_zm", "POINT ZM (0.01 1.01 10 100)",
-                        1.0, "POINT ZM (0 1 10 100)"},
-        SnapToGridParam{"multipoint_merge_zm",
-                        "MULTIPOINT ZM (0.01 1.01 10 100, 0.01 1.01 20 200)",
-                        1.0, "POINT ZM (0 1 10 100)"},
-        SnapToGridParam{"multipoint_distinct_zm",
-                        "MULTIPOINT ZM (0.01 1.01 10 100, 2.01 3.01 20 200)",
-                        1.0, "MULTIPOINT ZM (0 1 10 100, 2 3 20 200)"},
+        ReducePrecisionParam{"point_on_grid_zm", "POINT ZM (0 1 10 100)", 1.0,
+                             "POINT ZM (0 1 10 100)"},
+        ReducePrecisionParam{"point_no_snap_zm", "POINT ZM (0.01 1.01 10 100)",
+                             1.0, "POINT ZM (0 1 10 100)"},
+        ReducePrecisionParam{"point_not_on_grid_zm",
+                             "POINT ZM (0.01 1.01 10 100)", 1.0,
+                             "POINT ZM (0 1 10 100)"},
+        ReducePrecisionParam{
+            "multipoint_merge_zm",
+            "MULTIPOINT ZM (0.01 1.01 10 100, 0.01 1.01 20 200)", 1.0,
+            "POINT ZM (0 1 10 100)"},
+        ReducePrecisionParam{
+            "multipoint_distinct_zm",
+            "MULTIPOINT ZM (0.01 1.01 10 100, 2.01 3.01 20 200)", 1.0,
+            "MULTIPOINT ZM (0 1 10 100, 2 3 20 200)"},
 
         // Polygon: single ring, no snapping (single loop fast path)
-        SnapToGridParam{"polygon_simple",
-                        "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))", -1,
-                        "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"},
+        ReducePrecisionParam{"polygon_simple",
+                             "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))", -1,
+                             "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"},
         // Polygon: single ring with snapping
-        SnapToGridParam{"polygon_snap",
-                        "POLYGON ((0.001 0.001, 10.001 0.001, 10.001 10.001, "
-                        "0.001 10.001, 0.001 0.001))",
-                        1.0, "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"},
+        ReducePrecisionParam{
+            "polygon_snap",
+            "POLYGON ((0.001 0.001, 10.001 0.001, 10.001 10.001, "
+            "0.001 10.001, 0.001 0.001))",
+            1.0, "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"},
         // Polygon: shell with one hole (one shell + holes branch)
-        SnapToGridParam{"polygon_with_hole",
-                        "POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0), "
-                        "(5 5, 5 15, 15 15, 15 5, 5 5))",
-                        -1,
-                        "POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0), "
-                        "(5 5, 5 15, 15 15, 15 5, 5 5))"},
+        ReducePrecisionParam{"polygon_with_hole",
+                             "POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0), "
+                             "(5 5, 5 15, 15 15, 15 5, 5 5))",
+                             -1,
+                             "POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0), "
+                             "(5 5, 5 15, 15 15, 15 5, 5 5))"},
         // Multipolygon: two disjoint shells (multiple shells, no holes)
-        SnapToGridParam{"multipolygon_disjoint",
-                        "MULTIPOLYGON (((0 0, 5 0, 5 5, 0 5, 0 0)), "
-                        "((10 10, 15 10, 15 15, 10 15, 10 10)))",
-                        -1,
-                        "MULTIPOLYGON (((0 0, 5 0, 5 5, 0 5, 0 0)), "
-                        "((10 10, 15 10, 15 15, 10 15, 10 10)))"},
+        ReducePrecisionParam{"multipolygon_disjoint",
+                             "MULTIPOLYGON (((0 0, 5 0, 5 5, 0 5, 0 0)), "
+                             "((10 10, 15 10, 15 15, 10 15, 10 10)))",
+                             -1,
+                             "MULTIPOLYGON (((0 0, 5 0, 5 5, 0 5, 0 0)), "
+                             "((10 10, 15 10, 15 15, 10 15, 10 10)))"},
         // Multipolygon: two shells, one with a hole (multiple shells +
         // holes)
-        SnapToGridParam{"multipolygon_with_hole",
-                        "MULTIPOLYGON (((0 0, 20 0, 20 20, 0 20, 0 0), "
-                        "(5 5, 5 15, 15 15, 15 5, 5 5)), "
-                        "((30 30, 40 30, 40 40, 30 40, 30 30)))",
-                        -1,
-                        "MULTIPOLYGON (((0 0, 20 0, 20 20, 0 20, 0 0), "
-                        "(5 5, 5 15, 15 15, 15 5, 5 5)), "
-                        "((30 30, 40 30, 40 40, 30 40, 30 30)))"}),
-    [](const ::testing::TestParamInfo<SnapToGridParam>& info) {
+        ReducePrecisionParam{"multipolygon_with_hole",
+                             "MULTIPOLYGON (((0 0, 20 0, 20 20, 0 20, 0 0), "
+                             "(5 5, 5 15, 15 15, 15 5, 5 5)), "
+                             "((30 30, 40 30, 40 40, 30 40, 30 30)))",
+                             -1,
+                             "MULTIPOLYGON (((0 0, 20 0, 20 20, 0 20, 0 0), "
+                             "(5 5, 5 15, 15 15, 15 5, 5 5)), "
+                             "((30 30, 40 30, 40 40, 30 40, 30 30)))"}),
+    [](const ::testing::TestParamInfo<ReducePrecisionParam>& info) {
       return info.param.name;
     });
 

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -313,7 +313,36 @@ INSTANTIATE_TEST_SUITE_P(
                                 "MULTIPOINT ((0 0), (10 10))", 1.0,
                                 "MULTIPOINT ((0 0), (10 10))"},
 
-        // Check ZM handling
+        // Linestring: no snapping needed
+        UnaryUnionGridSizeParam{"linestring_on_grid", "LINESTRING (0 0, 10 10)",
+                                1.0, "LINESTRING (0 0, 10 10)"},
+        // Linestring: endpoints snap to grid
+        UnaryUnionGridSizeParam{"linestring_snap",
+                                "LINESTRING (0.001 0.001, 10.001 10.001)", 1.0,
+                                "LINESTRING (0 0, 10 10)"},
+        // Linestring: no snapping with negative grid size
+        UnaryUnionGridSizeParam{"linestring_no_snap",
+                                "LINESTRING (0.001 0.001, 10.001 10.001)", -1,
+                                "LINESTRING (0.001 0.001, 10.001 10.001)"},
+        // Linestring with Z
+        UnaryUnionGridSizeParam{"linestring_z",
+                                "LINESTRING Z (0 0 100, 10 10 200)", 1.0,
+                                "LINESTRING Z (0 0 100, 10 10 200)"},
+        // Linestring with Z and snapping (Z values are interpolated when
+        // endpoints are snapped, so they won't be exact)
+        UnaryUnionGridSizeParam{
+            "linestring_snap_z",
+            "LINESTRING Z (0.001 0.001 100, 10.001 10.001 200)", 1.0,
+            "LINESTRING Z (0 0 100.010024, 10 10 199.99005)"},
+        // Linestring with M
+        UnaryUnionGridSizeParam{"linestring_m",
+                                "LINESTRING M (0 0 100, 10 10 200)", 1.0,
+                                "LINESTRING M (0 0 100, 10 10 200)"},
+        // Linestring with ZM
+        UnaryUnionGridSizeParam{
+            "linestring_zm", "LINESTRING ZM (0 0 100 1000, 10 10 200 2000)",
+            1.0, "LINESTRING ZM (0 0 100 1000, 10 10 200 2000)"},
+        // Check Z handling
         UnaryUnionGridSizeParam{"point_on_grid_z", "POINT Z (0 1 10)", 1.0,
                                 "POINT Z (0 1 10)"},
         UnaryUnionGridSizeParam{"point_no_snap_z", "POINT Z (0.01 1.01 10)",
@@ -341,7 +370,7 @@ INSTANTIATE_TEST_SUITE_P(
                                 "MULTIPOINT M (0.01 1.01 10, 2.01 3.01 20)",
                                 1.0, "MULTIPOINT M (0 1 10, 2 3 20)"},
 
-        // Check ZM handling
+        // Check POINT ZM handling
         UnaryUnionGridSizeParam{"point_on_grid_zm", "POINT ZM (0 1 10 100)",
                                 1.0, "POINT ZM (0 1 10 100)"},
         UnaryUnionGridSizeParam{"point_no_snap_zm",

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -223,9 +223,9 @@ TEST(Build, SedonaUdfSymDifference) {
       {"GEOMETRYCOLLECTION EMPTY", "MULTIPOINT ((0 0), (0 1))", std::nullopt}));
 }
 
-TEST(Build, SedonaUdfUnaryUnionGridSize) {
+TEST(Build, SedonaUdfSnapToGrid) {
   struct SedonaCScalarKernel kernel;
-  s2geography::sedona_udf::UnaryUnionGridSizeKernel(&kernel);
+  s2geography::sedona_udf::SnapToGridKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
   ASSERT_NO_FATAL_FAILURE(TestInitKernel(
       &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
@@ -242,14 +242,13 @@ TEST(Build, SedonaUdfUnaryUnionGridSize) {
       out_array.get(), {"POINT (0 0)", "POINT (0 0)", std::nullopt}));
 }
 
-struct UnaryUnionGridSizeParam {
+struct SnapToGridParam {
   std::string name;
   std::optional<std::string> input_wkt;
   std::optional<double> grid_size;
   std::optional<std::string> expected_wkt;
 
-  friend std::ostream& operator<<(std::ostream& os,
-                                  const UnaryUnionGridSizeParam& p) {
+  friend std::ostream& operator<<(std::ostream& os, const SnapToGridParam& p) {
     os << (p.input_wkt ? *p.input_wkt : "null")
        << " grid_size=" << (p.grid_size ? std::to_string(*p.grid_size) : "null")
        << " -> " << (p.expected_wkt ? *p.expected_wkt : "null");
@@ -257,14 +256,13 @@ struct UnaryUnionGridSizeParam {
   }
 };
 
-class UnaryUnionGridSizeTest
-    : public ::testing::TestWithParam<UnaryUnionGridSizeParam> {};
+class SnapToGridTest : public ::testing::TestWithParam<SnapToGridParam> {};
 
-TEST_P(UnaryUnionGridSizeTest, SedonaUdf) {
+TEST_P(SnapToGridTest, SedonaUdf) {
   const auto& p = GetParam();
 
   struct SedonaCScalarKernel kernel;
-  s2geography::sedona_udf::UnaryUnionGridSizeKernel(&kernel);
+  s2geography::sedona_udf::SnapToGridKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
   ASSERT_NO_FATAL_FAILURE(TestInitKernel(
       &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
@@ -281,158 +279,137 @@ TEST_P(UnaryUnionGridSizeTest, SedonaUdf) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    Build, UnaryUnionGridSizeTest,
+    Build, SnapToGridTest,
     ::testing::Values(
         // Null inputs
-        UnaryUnionGridSizeParam{"null_geom", std::nullopt, 1.0, std::nullopt},
-        UnaryUnionGridSizeParam{"null_grid_size", "POINT (0 0)", std::nullopt,
-                                std::nullopt},
-        UnaryUnionGridSizeParam{"null_both", std::nullopt, std::nullopt,
-                                std::nullopt},
+        SnapToGridParam{"null_geom", std::nullopt, 1.0, std::nullopt},
+        SnapToGridParam{"null_grid_size", "POINT (0 0)", std::nullopt,
+                        std::nullopt},
+        SnapToGridParam{"null_both", std::nullopt, std::nullopt, std::nullopt},
 
         // Point snapping to whole degrees (grid_size = 1.0)
-        UnaryUnionGridSizeParam{"point_on_grid", "POINT (0 0)", 1.0,
-                                "POINT (0 0)"},
-        UnaryUnionGridSizeParam{"point_not_on_grid", "POINT (0.001 0.001)", 1.0,
-                                "POINT (0 0)"},
-        UnaryUnionGridSizeParam{"point_no_snap", "POINT (0.001 0.001)", -1,
-                                "POINT (0.001 0.001)"},
+        SnapToGridParam{"point_on_grid", "POINT (0 0)", 1.0, "POINT (0 0)"},
+        SnapToGridParam{"point_not_on_grid", "POINT (0.001 0.001)", 1.0,
+                        "POINT (0 0)"},
+        SnapToGridParam{"point_no_snap", "POINT (0.001 0.001)", -1,
+                        "POINT (0.001 0.001)"},
 
         // Point snapping to 0.1 degree grid (grid_size = 0.1)
-        UnaryUnionGridSizeParam{"point_tenth_degree_on_grid", "POINT (0.1 0.1)",
-                                0.1, "POINT (0.1 0.1)"},
-        UnaryUnionGridSizeParam{"point_tenth_degree_snap", "POINT (0.12 0.12)",
-                                0.1, "POINT (0.1 0.1)"},
+        SnapToGridParam{"point_tenth_degree_on_grid", "POINT (0.1 0.1)", 0.1,
+                        "POINT (0.1 0.1)"},
+        SnapToGridParam{"point_tenth_degree_snap", "POINT (0.12 0.12)", 0.1,
+                        "POINT (0.1 0.1)"},
 
         // Multipoint: two nearby points snap to same location
-        UnaryUnionGridSizeParam{"multipoint_merge",
-                                "MULTIPOINT ((0.001 0.001), (0.002 0.002))",
-                                1.0, "POINT (0 0)"},
+        SnapToGridParam{"multipoint_merge",
+                        "MULTIPOINT ((0.001 0.001), (0.002 0.002))", 1.0,
+                        "POINT (0 0)"},
         // Multipoint: points remain distinct after snapping
-        UnaryUnionGridSizeParam{"multipoint_distinct",
-                                "MULTIPOINT ((0 0), (10 10))", 1.0,
-                                "MULTIPOINT ((0 0), (10 10))"},
+        SnapToGridParam{"multipoint_distinct", "MULTIPOINT ((0 0), (10 10))",
+                        1.0, "MULTIPOINT ((0 0), (10 10))"},
 
         // Linestring: no snapping needed
-        UnaryUnionGridSizeParam{"linestring_on_grid", "LINESTRING (0 0, 10 10)",
-                                1.0, "LINESTRING (0 0, 10 10)"},
+        SnapToGridParam{"linestring_on_grid", "LINESTRING (0 0, 10 10)", 1.0,
+                        "LINESTRING (0 0, 10 10)"},
         // Linestring: endpoints snap to grid
-        UnaryUnionGridSizeParam{"linestring_snap",
-                                "LINESTRING (0.001 0.001, 10.001 10.001)", 1.0,
-                                "LINESTRING (0 0, 10 10)"},
+        SnapToGridParam{"linestring_snap",
+                        "LINESTRING (0.001 0.001, 10.001 10.001)", 1.0,
+                        "LINESTRING (0 0, 10 10)"},
         // Linestring: no snapping with negative grid size
-        UnaryUnionGridSizeParam{"linestring_no_snap",
-                                "LINESTRING (0.001 0.001, 10.001 10.001)", -1,
-                                "LINESTRING (0.001 0.001, 10.001 10.001)"},
+        SnapToGridParam{"linestring_no_snap",
+                        "LINESTRING (0.001 0.001, 10.001 10.001)", -1,
+                        "LINESTRING (0.001 0.001, 10.001 10.001)"},
         // Linestring with Z
-        UnaryUnionGridSizeParam{"linestring_z",
-                                "LINESTRING Z (0 0 100, 10 10 200)", 1.0,
-                                "LINESTRING Z (0 0 100, 10 10 200)"},
+        SnapToGridParam{"linestring_z", "LINESTRING Z (0 0 100, 10 10 200)",
+                        1.0, "LINESTRING Z (0 0 100, 10 10 200)"},
         // Linestring with Z and snapping (Z values are interpolated when
         // endpoints are snapped, so they won't be exact)
-        UnaryUnionGridSizeParam{
-            "linestring_snap_z",
-            "LINESTRING Z (0.001 0.001 100, 10.001 10.001 200)", 1.0,
-            "LINESTRING Z (0 0 100.010024, 10 10 199.99005)"},
+        SnapToGridParam{"linestring_snap_z",
+                        "LINESTRING Z (0.001 0.001 100, 10.001 10.001 200)",
+                        1.0, "LINESTRING Z (0 0 100.010024, 10 10 199.99005)"},
         // Linestring with M
-        UnaryUnionGridSizeParam{"linestring_m",
-                                "LINESTRING M (0 0 100, 10 10 200)", 1.0,
-                                "LINESTRING M (0 0 100, 10 10 200)"},
+        SnapToGridParam{"linestring_m", "LINESTRING M (0 0 100, 10 10 200)",
+                        1.0, "LINESTRING M (0 0 100, 10 10 200)"},
         // Linestring with ZM
-        UnaryUnionGridSizeParam{
-            "linestring_zm", "LINESTRING ZM (0 0 100 1000, 10 10 200 2000)",
-            1.0, "LINESTRING ZM (0 0 100 1000, 10 10 200 2000)"},
+        SnapToGridParam{"linestring_zm",
+                        "LINESTRING ZM (0 0 100 1000, 10 10 200 2000)", 1.0,
+                        "LINESTRING ZM (0 0 100 1000, 10 10 200 2000)"},
         // Check Z handling
-        UnaryUnionGridSizeParam{"point_on_grid_z", "POINT Z (0 1 10)", 1.0,
-                                "POINT Z (0 1 10)"},
-        UnaryUnionGridSizeParam{"point_no_snap_z", "POINT Z (0.01 1.01 10)",
-                                1.0, "POINT Z (0 1 10)"},
-        UnaryUnionGridSizeParam{"point_not_on_grid_z", "POINT Z (0.01 1.01 10)",
-                                1.0, "POINT Z (0 1 10)"},
-        UnaryUnionGridSizeParam{"multipoint_merge_z",
-                                "MULTIPOINT Z (0.01 1.01 10, 0.01 1.01 20)",
-                                1.0, "POINT Z (0 1 10)"},
-        UnaryUnionGridSizeParam{"multipoint_distinct_z",
-                                "MULTIPOINT Z (0.01 1.01 10, 2.01 3.01 20)",
-                                1.0, "MULTIPOINT Z (0 1 10, 2 3 20)"},
+        SnapToGridParam{"point_on_grid_z", "POINT Z (0 1 10)", 1.0,
+                        "POINT Z (0 1 10)"},
+        SnapToGridParam{"point_no_snap_z", "POINT Z (0.01 1.01 10)", 1.0,
+                        "POINT Z (0 1 10)"},
+        SnapToGridParam{"point_not_on_grid_z", "POINT Z (0.01 1.01 10)", 1.0,
+                        "POINT Z (0 1 10)"},
+        SnapToGridParam{"multipoint_merge_z",
+                        "MULTIPOINT Z (0.01 1.01 10, 0.01 1.01 20)", 1.0,
+                        "POINT Z (0 1 10)"},
+        SnapToGridParam{"multipoint_distinct_z",
+                        "MULTIPOINT Z (0.01 1.01 10, 2.01 3.01 20)", 1.0,
+                        "MULTIPOINT Z (0 1 10, 2 3 20)"},
 
         // Check M handling
-        UnaryUnionGridSizeParam{"point_on_grid_m", "POINT M (0 1 10)", 1.0,
-                                "POINT M (0 1 10)"},
-        UnaryUnionGridSizeParam{"point_no_snap_m", "POINT M (0.01 1.01 10)",
-                                1.0, "POINT M (0 1 10)"},
-        UnaryUnionGridSizeParam{"point_not_on_grid_m", "POINT M (0.01 1.01 10)",
-                                1.0, "POINT M (0 1 10)"},
-        UnaryUnionGridSizeParam{"multipoint_merge_m",
-                                "MULTIPOINT M (0.01 1.01 10, 0.01 1.01 20)",
-                                1.0, "POINT M (0 1 10)"},
-        UnaryUnionGridSizeParam{"multipoint_distinct_m",
-                                "MULTIPOINT M (0.01 1.01 10, 2.01 3.01 20)",
-                                1.0, "MULTIPOINT M (0 1 10, 2 3 20)"},
+        SnapToGridParam{"point_on_grid_m", "POINT M (0 1 10)", 1.0,
+                        "POINT M (0 1 10)"},
+        SnapToGridParam{"point_no_snap_m", "POINT M (0.01 1.01 10)", 1.0,
+                        "POINT M (0 1 10)"},
+        SnapToGridParam{"point_not_on_grid_m", "POINT M (0.01 1.01 10)", 1.0,
+                        "POINT M (0 1 10)"},
+        SnapToGridParam{"multipoint_merge_m",
+                        "MULTIPOINT M (0.01 1.01 10, 0.01 1.01 20)", 1.0,
+                        "POINT M (0 1 10)"},
+        SnapToGridParam{"multipoint_distinct_m",
+                        "MULTIPOINT M (0.01 1.01 10, 2.01 3.01 20)", 1.0,
+                        "MULTIPOINT M (0 1 10, 2 3 20)"},
 
         // Check POINT ZM handling
-        UnaryUnionGridSizeParam{"point_on_grid_zm", "POINT ZM (0 1 10 100)",
-                                1.0, "POINT ZM (0 1 10 100)"},
-        UnaryUnionGridSizeParam{"point_no_snap_zm",
-                                "POINT ZM (0.01 1.01 10 100)", 1.0,
-                                "POINT ZM (0 1 10 100)"},
-        UnaryUnionGridSizeParam{"point_not_on_grid_zm",
-                                "POINT ZM (0.01 1.01 10 100)", 1.0,
-                                "POINT ZM (0 1 10 100)"},
-        UnaryUnionGridSizeParam{
-            "multipoint_merge_zm",
-            "MULTIPOINT ZM (0.01 1.01 10 100, 0.01 1.01 20 200)", 1.0,
-            "POINT ZM (0 1 10 100)"},
-        UnaryUnionGridSizeParam{
-            "multipoint_distinct_zm",
-            "MULTIPOINT ZM (0.01 1.01 10 100, 2.01 3.01 20 200)", 1.0,
-            "MULTIPOINT ZM (0 1 10 100, 2 3 20 200)"},
+        SnapToGridParam{"point_on_grid_zm", "POINT ZM (0 1 10 100)", 1.0,
+                        "POINT ZM (0 1 10 100)"},
+        SnapToGridParam{"point_no_snap_zm", "POINT ZM (0.01 1.01 10 100)", 1.0,
+                        "POINT ZM (0 1 10 100)"},
+        SnapToGridParam{"point_not_on_grid_zm", "POINT ZM (0.01 1.01 10 100)",
+                        1.0, "POINT ZM (0 1 10 100)"},
+        SnapToGridParam{"multipoint_merge_zm",
+                        "MULTIPOINT ZM (0.01 1.01 10 100, 0.01 1.01 20 200)",
+                        1.0, "POINT ZM (0 1 10 100)"},
+        SnapToGridParam{"multipoint_distinct_zm",
+                        "MULTIPOINT ZM (0.01 1.01 10 100, 2.01 3.01 20 200)",
+                        1.0, "MULTIPOINT ZM (0 1 10 100, 2 3 20 200)"},
 
         // Polygon: single ring, no snapping (single loop fast path)
-        UnaryUnionGridSizeParam{"polygon_simple",
-                                "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))", -1,
-                                "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"},
+        SnapToGridParam{"polygon_simple",
+                        "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))", -1,
+                        "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"},
         // Polygon: single ring with snapping
-        UnaryUnionGridSizeParam{
-            "polygon_snap",
-            "POLYGON ((0.001 0.001, 10.001 0.001, 10.001 10.001, "
-            "0.001 10.001, 0.001 0.001))",
-            1.0, "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"},
+        SnapToGridParam{"polygon_snap",
+                        "POLYGON ((0.001 0.001, 10.001 0.001, 10.001 10.001, "
+                        "0.001 10.001, 0.001 0.001))",
+                        1.0, "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"},
         // Polygon: shell with one hole (one shell + holes branch)
-        UnaryUnionGridSizeParam{"polygon_with_hole",
-                                "POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0), "
-                                "(5 5, 5 15, 15 15, 15 5, 5 5))",
-                                -1,
-                                "POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0), "
-                                "(5 5, 5 15, 15 15, 15 5, 5 5))"},
+        SnapToGridParam{"polygon_with_hole",
+                        "POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0), "
+                        "(5 5, 5 15, 15 15, 15 5, 5 5))",
+                        -1,
+                        "POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0), "
+                        "(5 5, 5 15, 15 15, 15 5, 5 5))"},
         // Multipolygon: two disjoint shells (multiple shells, no holes)
-        UnaryUnionGridSizeParam{"multipolygon_disjoint",
-                                "MULTIPOLYGON (((0 0, 5 0, 5 5, 0 5, 0 0)), "
-                                "((10 10, 15 10, 15 15, 10 15, 10 10)))",
-                                -1,
-                                "MULTIPOLYGON (((0 0, 5 0, 5 5, 0 5, 0 0)), "
-                                "((10 10, 15 10, 15 15, 10 15, 10 10)))"},
+        SnapToGridParam{"multipolygon_disjoint",
+                        "MULTIPOLYGON (((0 0, 5 0, 5 5, 0 5, 0 0)), "
+                        "((10 10, 15 10, 15 15, 10 15, 10 10)))",
+                        -1,
+                        "MULTIPOLYGON (((0 0, 5 0, 5 5, 0 5, 0 0)), "
+                        "((10 10, 15 10, 15 15, 10 15, 10 10)))"},
         // Multipolygon: two shells, one with a hole (multiple shells +
         // holes)
-        UnaryUnionGridSizeParam{"multipolygon_with_hole",
-                                "MULTIPOLYGON (((0 0, 20 0, 20 20, 0 20, 0 0), "
-                                "(5 5, 5 15, 15 15, 15 5, 5 5)), "
-                                "((30 30, 40 30, 40 40, 30 40, 30 30)))",
-                                -1,
-                                "MULTIPOLYGON (((0 0, 20 0, 20 20, 0 20, 0 0), "
-                                "(5 5, 5 15, 15 15, 15 5, 5 5)), "
-                                "((30 30, 40 30, 40 40, 30 40, 30 30)))"}
-        // Multipolygon: overlapping shells not yet merged into a single polygon
-        // UnaryUnionGridSizeParam{
-        //     "multipolygon_overlapping",
-        //     "MULTIPOLYGON (((0 0, 3 0, 3 3, 0 3, 0 0)), "
-        //     "((1 1, 4 1, 4 4, 1 4, 1 1)))",
-        //     -1,
-        //     "MULTIPOLYGON (((0 0, 3 0, 3 3, 0 3, 0 0)), "
-        //     "((1 1, 4 1, 4 4, 1 4, 1 1)))"}
-
-        ),
-    [](const ::testing::TestParamInfo<UnaryUnionGridSizeParam>& info) {
+        SnapToGridParam{"multipolygon_with_hole",
+                        "MULTIPOLYGON (((0 0, 20 0, 20 20, 0 20, 0 0), "
+                        "(5 5, 5 15, 15 15, 15 5, 5 5)), "
+                        "((30 30, 40 30, 40 40, 30 40, 30 30)))",
+                        -1,
+                        "MULTIPOLYGON (((0 0, 20 0, 20 20, 0 20, 0 0), "
+                        "(5 5, 5 15, 15 15, 15 5, 5 5)), "
+                        "((30 30, 40 30, 40 40, 30 40, 30 30)))"}),
+    [](const ::testing::TestParamInfo<SnapToGridParam>& info) {
       return info.param.name;
     });
 

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -386,7 +386,50 @@ INSTANTIATE_TEST_SUITE_P(
         UnaryUnionGridSizeParam{
             "multipoint_distinct_zm",
             "MULTIPOINT ZM (0.01 1.01 10 100, 2.01 3.01 20 200)", 1.0,
-            "MULTIPOINT ZM (0 1 10 100, 2 3 20 200)"}
+            "MULTIPOINT ZM (0 1 10 100, 2 3 20 200)"},
+
+        // Polygon: single ring, no snapping (single loop fast path)
+        UnaryUnionGridSizeParam{"polygon_simple",
+                                "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))", -1,
+                                "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"},
+        // Polygon: single ring with snapping
+        UnaryUnionGridSizeParam{
+            "polygon_snap",
+            "POLYGON ((0.001 0.001, 10.001 0.001, 10.001 10.001, "
+            "0.001 10.001, 0.001 0.001))",
+            1.0, "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"},
+        // Polygon: shell with one hole (one shell + holes branch)
+        UnaryUnionGridSizeParam{"polygon_with_hole",
+                                "POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0), "
+                                "(5 5, 5 15, 15 15, 15 5, 5 5))",
+                                -1,
+                                "POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0), "
+                                "(5 5, 5 15, 15 15, 15 5, 5 5))"},
+        // Multipolygon: two disjoint shells (multiple shells, no holes)
+        UnaryUnionGridSizeParam{"multipolygon_disjoint",
+                                "MULTIPOLYGON (((0 0, 5 0, 5 5, 0 5, 0 0)), "
+                                "((10 10, 15 10, 15 15, 10 15, 10 10)))",
+                                -1,
+                                "MULTIPOLYGON (((0 0, 5 0, 5 5, 0 5, 0 0)), "
+                                "((10 10, 15 10, 15 15, 10 15, 10 10)))"},
+        // Multipolygon: two shells, one with a hole (multiple shells +
+        // holes)
+        UnaryUnionGridSizeParam{"multipolygon_with_hole",
+                                "MULTIPOLYGON (((0 0, 20 0, 20 20, 0 20, 0 0), "
+                                "(5 5, 5 15, 15 15, 15 5, 5 5)), "
+                                "((30 30, 40 30, 40 40, 30 40, 30 30)))",
+                                -1,
+                                "MULTIPOLYGON (((0 0, 20 0, 20 20, 0 20, 0 0), "
+                                "(5 5, 5 15, 15 15, 15 5, 5 5)), "
+                                "((30 30, 40 30, 40 40, 30 40, 30 30)))"}
+        // Multipolygon: overlapping shells not yet merged into a single polygon
+        // UnaryUnionGridSizeParam{
+        //     "multipolygon_overlapping",
+        //     "MULTIPOLYGON (((0 0, 3 0, 3 3, 0 3, 0 0)), "
+        //     "((1 1, 4 1, 4 4, 1 4, 1 1)))",
+        //     -1,
+        //     "MULTIPOLYGON (((0 0, 3 0, 3 3, 0 3, 0 0)), "
+        //     "((1 1, 4 1, 4 4, 1 4, 1 1)))"}
 
         ),
     [](const ::testing::TestParamInfo<UnaryUnionGridSizeParam>& info) {

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -406,6 +406,11 @@ INSTANTIATE_TEST_SUITE_P(
             "0.001 10.001, 0.001 0.001))",
             1.0, "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"},
         // Polygon: shell with one hole (one shell + holes branch)
+        ReducePrecisionParam{"polygon_with_collapsed_hole",
+                             "POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0), "
+                             "(5 5, 5 5.1, 5.1 5.1, 5.1 5, 5 5))",
+                             1, "POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0))"},
+        // Polygon: shell with a hole that collapses
         ReducePrecisionParam{"polygon_with_hole",
                              "POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0), "
                              "(5 5, 5 15, 15 15, 15 5, 5 5))",

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -223,4 +223,23 @@ TEST(Build, SedonaUdfSymDifference) {
       {"GEOMETRYCOLLECTION EMPTY", "MULTIPOINT ((0 0), (0 1))", std::nullopt}));
 }
 
+TEST(Build, SedonaUdfUnaryUnionGridSize) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::UnaryUnionGridSizeKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE},
+                        {{"POINT (0 0)", "POINT (0.001 0.001)", std::nullopt}},
+                        {{1.0, 1.0, std::nullopt}}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(TestResultGeography(
+      out_array.get(), {"POINT (0 0)", "POINT (0 0)", std::nullopt}));
+}
+
 }  // namespace s2geography

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -119,6 +119,10 @@ S2Point GeoArrowPointShape::vertex(int v) const {
   return GeoArrowChain(geom_.root() + v).vertex(0);
 }
 
+internal::GeoArrowVertex GeoArrowPointShape::native_vertex(int v) const {
+  return GeoArrowChain(geom_.root() + v).native_vertex(0);
+}
+
 int GeoArrowPointShape::num_edges() const { return num_vertices(); }
 
 S2Shape::Edge GeoArrowPointShape::edge(int e) const {

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -579,6 +579,14 @@ std::optional<S2Point> GeoArrowGeography::Point() const {
   }
 }
 
+uint8_t GeoArrowGeography::geometry_type() const {
+  if (geom_.size_nodes == 0) {
+    return GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION;
+  } else {
+    return geom_.root->geometry_type;
+  }
+}
+
 uint8_t GeoArrowGeography::dimensions() const {
   if (geom_.size_nodes == 0) {
     return GEOARROW_DIMENSIONS_XY;

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -65,6 +65,7 @@ class GeoArrowPointShape : public S2Shape {
 
   int num_vertices() const;
   S2Point vertex(int v) const;
+  internal::GeoArrowVertex native_vertex(int v) const;
 
   int num_edges() const override;
   Edge edge(int e) const override;
@@ -380,6 +381,8 @@ class GeoArrowGeography {
   /// This may be accessed even if the underlying geometry is non-polygon
   /// (will represent a polygon with zero chains).
   const GeoArrowLaxPolygonShape* polygons() const;
+
+  const GeoArrowGeometryView geom() const { return geom_; }
 
   /// \brief Visit all vertices in this geography
   template <typename Visit>

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -341,6 +341,12 @@ class GeoArrowGeography {
   /// \brief Returns true if this geography has no edges
   bool is_empty() const;
 
+  /// \brief Returns the input geometry type
+  ///
+  /// This may be used to more accurately propagate the input geometry type to
+  /// the output for operations that require it.
+  uint8_t geometry_type() const;
+
   /// \brief Returns the coordinate dimensions (e.g., XY, XYZ, XYM, XYZM)
   ///
   /// For geometries with mixed dimension components (e.g., GEOMETRYCOLLECTION

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -112,15 +112,21 @@ bool VisitLngLat(const struct GeoArrowGeometryNode* node, int64_t offset,
 /// Z and M values.
 struct GeoArrowVertex {
   /// \brief The longitude (X) value
-  double lng;
+  double lng{};
   /// \brief The latitude (Y) values
-  double lat;
+  double lat{};
   /// \brief The ZM portion of the coordinate
   ///
   /// Whether these values are missing, Z, M, or ZM depends on the
   /// dimensions of the sequence. These will be NaN in the event that
   /// there is no Z or M present in the source sequence.
-  double zm[2];
+  double zm[2] = {0.0, 0.0};
+
+  void SetPoint(const S2Point& pt) {
+    S2LatLng ll(pt);
+    lng = ll.lng().degrees();
+    lat = ll.lat().degrees();
+  }
 
   /// \brief Return the S2Point representation of this vertex
   S2Point ToPoint() const { return S2LatLng::FromDegrees(lat, lng).ToPoint(); }
@@ -156,9 +162,9 @@ struct GeoArrowVertex {
 /// information.
 struct GeoArrowEdge {
   /// \brief The first vertex of the edge
-  GeoArrowVertex v0;
+  GeoArrowVertex v0{};
   /// \brief The second vertex of the edge
-  GeoArrowVertex v1;
+  GeoArrowVertex v1{};
 
   /// \brief Interpolate a value along this edge
   ///
@@ -174,6 +180,15 @@ struct GeoArrowEdge {
   ///   to minimize roundtrip rounding errors)
   /// - z and m values are interpolated linearly
   GeoArrowVertex Interpolate(const S2Point& point);
+
+  /// \brief Normalize the order of zm values such that this object
+  /// always represents, x, y, z, and m (in that order)
+  GeoArrowEdge Normalize(uint8_t dimensions) {
+    GeoArrowEdge e = *this;
+    e.v0 = v0.Normalize(dimensions);
+    e.v1 = v1.Normalize(dimensions);
+    return e;
+  }
 
   friend bool operator==(const GeoArrowEdge& a, const GeoArrowEdge& b) {
     return a.v0 == b.v0 && a.v1 == b.v1;

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -118,8 +118,7 @@ struct GeoArrowVertex {
   /// \brief The ZM portion of the coordinate
   ///
   /// Whether these values are missing, Z, M, or ZM depends on the
-  /// dimensions of the sequence. These will be NaN in the event that
-  /// there is no Z or M present in the source sequence.
+  /// dimensions of the sequence.
   double zm[2] = {0.0, 0.0};
 
   void SetPoint(const S2Point& pt) {

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -271,10 +271,22 @@ class GeoArrowOutputBuilder {
   }
 
   /// \brief Append an empty geometry of a specified type
-  void AppendEmpty(enum GeoArrowGeometryType geometry_type =
-                       GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION) {
+  void AppendEmpty(
+      uint8_t geometry_type = GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION) {
+    switch (geometry_type) {
+      case GEOARROW_GEOMETRY_TYPE_POINT:
+      case GEOARROW_GEOMETRY_TYPE_LINESTRING:
+      case GEOARROW_GEOMETRY_TYPE_POLYGON:
+      case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
+      case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
+      case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
+        break;
+      default:
+        throw Exception("Unknown geometry type ID");
+    }
+
     FeatureStart();
-    GeomStart(geometry_type);
+    GeomStart(static_cast<GeoArrowGeometryType>(geometry_type));
     GeomEnd();
     FeatureEnd();
   }

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -280,6 +280,7 @@ class GeoArrowOutputBuilder {
       case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
       case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
       case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
+      case GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION:
         break;
       default:
         throw Exception("Unknown geometry type ID");


### PR DESCRIPTION
This PR starts the integration between the GeoArrowGeography, the GeoArrowOutputBuilder, and the S2Builder. Building geometries from an S2Builder::Graph is the foundation of things like SnapToGrid, Simplify, and boolean operations. The interface to do this is quite flexible (the S2Builder::Layer) but the built-in versions of this require explicitly creating an S2Polyline or Polygon which doesn't allow for ZM support or reusing scratch space for vertices. This PR implements the builder layers for the simplest two cases of rebuilding output (i.e., not unions or intersections).

The primary issue with writing output from the builder is that (1) it is super slow, pretty much anytime it is invoked and (2) writing polygons is hard because the shell/hole relationships have to be reconstructed after the graph has been queried for the output. (This is also a pain when writing the S2Polygon with the previous approach because we have to do something similar when walking the loop depths, but at least the nesting has already been computed for us at that point).

I'll tackle the S2BooleanOperation in a follow up PR because we can avoid the builder entirely in a lot of cases (e.g., if we can rule out potential intersection).