### PR TITLE
feat: Add ST_Buffer()

### DIFF
--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -1511,6 +1511,148 @@ struct SymDifferenceOperationExec {
   OutputGeometry output_;
 };
 
+namespace {
+
+bool StrCaseEqual(const std::string& a, const std::string& b) {
+  if (a.size() != b.size()) return false;
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (std::tolower(static_cast<unsigned char>(a[i])) !=
+        std::tolower(static_cast<unsigned char>(b[i])))
+      return false;
+  }
+  return true;
+}
+
+double ParseDouble(const std::string& value, const char* param_name) {
+  try {
+    size_t pos;
+    double result = std::stod(value, &pos);
+    if (pos != value.size()) throw std::invalid_argument("trailing chars");
+    return result;
+  } catch (const std::exception&) {
+    throw Exception(std::string("Invalid ") + param_name + " value: '" +
+                    value + "'. Expected a valid number");
+  }
+}
+
+int ParseInt(const std::string& value, const char* param_name) {
+  try {
+    size_t pos;
+    int result = std::stoi(value, &pos);
+    if (pos != value.size()) throw std::invalid_argument("trailing chars");
+    return result;
+  } catch (const std::exception&) {
+    throw Exception(std::string("Invalid ") + param_name + " value: '" +
+                    value + "'. Expected a valid number");
+  }
+}
+
+}  // namespace
+
+CapStyle ParseCapStyle(const std::string& value) {
+  if (StrCaseEqual(value, "round")) {
+    return CapStyle::kRound;
+  } else if (StrCaseEqual(value, "flat") || StrCaseEqual(value, "butt")) {
+    return CapStyle::kFlat;
+  } else if (StrCaseEqual(value, "square")) {
+    return CapStyle::kSquare;
+  }
+  throw Exception("Invalid endcap style: '" + value +
+                  "'. Valid options: round, flat, butt, square");
+}
+
+JoinStyle ParseJoinStyle(const std::string& value) {
+  if (StrCaseEqual(value, "round")) {
+    return JoinStyle::kRound;
+  } else if (StrCaseEqual(value, "mitre") || StrCaseEqual(value, "miter")) {
+    return JoinStyle::kMitre;
+  } else if (StrCaseEqual(value, "bevel")) {
+    return JoinStyle::kBevel;
+  }
+  throw Exception("Invalid join style: '" + value +
+                  "'. Valid options: round, mitre, miter, bevel");
+}
+
+bool ParseSingleSided(const std::string& value) {
+  if (StrCaseEqual(value, "both")) {
+    return false;
+  } else if (StrCaseEqual(value, "left") || StrCaseEqual(value, "right")) {
+    return true;
+  }
+  throw Exception("Invalid side: '" + value +
+                  "'. Valid options: both, left, right");
+}
+
+std::pair<bool, bool> ParseBufferSideStyle(const std::string& params) {
+  bool left = false;
+  bool right = false;
+  std::istringstream iss(params);
+  std::string tok;
+  while (iss >> tok) {
+    auto eq_pos = tok.find('=');
+    if (eq_pos == std::string::npos) continue;
+    std::string key = tok.substr(0, eq_pos);
+    std::string val = tok.substr(eq_pos + 1);
+    if (StrCaseEqual(key, "side")) {
+      if (StrCaseEqual(val, "left")) {
+        left = true;
+        right = false;
+      } else if (StrCaseEqual(val, "right")) {
+        right = true;
+        left = false;
+      }
+    }
+  }
+  return {left, right};
+}
+
+/// Parameters are space-separated key=value pairs (case-insensitive).
+/// Supported keys: endcap, join, side, mitre_limit, miter_limit,
+/// quad_segs, quadrant_segments.
+BufferParams BufferParams::Parse(const std::string& params_str) {
+  BufferParams params;
+  if (params_str.empty()) return params;
+
+  bool end_cap_specified = false;
+  std::istringstream iss(params_str);
+  std::string param;
+
+  while (iss >> param) {
+    auto eq_pos = param.find('=');
+    if (eq_pos == std::string::npos) {
+      throw Exception("Missing value for buffer parameter: " + param);
+    }
+
+    std::string key = param.substr(0, eq_pos);
+    std::string value = param.substr(eq_pos + 1);
+
+    if (StrCaseEqual(key, "endcap")) {
+      params.end_cap_style = ParseCapStyle(value);
+      end_cap_specified = true;
+    } else if (StrCaseEqual(key, "join")) {
+      params.join_style = ParseJoinStyle(value);
+    } else if (StrCaseEqual(key, "side")) {
+      params.single_sided = ParseSingleSided(value);
+      if (params.single_sided && !end_cap_specified) {
+        params.end_cap_style = CapStyle::kSquare;
+      }
+    } else if (StrCaseEqual(key, "mitre_limit") ||
+               StrCaseEqual(key, "miter_limit")) {
+      params.mitre_limit = ParseDouble(value, "mitre_limit");
+    } else if (StrCaseEqual(key, "quad_segs") ||
+               StrCaseEqual(key, "quadrant_segments")) {
+      params.quadrant_segments = ParseInt(value, "quadrant_segments");
+    } else {
+      throw Exception(
+          "Invalid buffer parameter: " + key +
+          " (accept: 'endcap', 'join', 'mitre_limit', 'miter_limit', "
+          "'quad_segs', 'quadrant_segments' and 'side')");
+    }
+  }
+
+  return params;
+}
+
 struct BufferExec {
   using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = DoubleInputView;

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -1569,41 +1569,22 @@ JoinStyle ParseJoinStyle(const std::string& value) {
   } else if (StrCaseEqual(value, "bevel")) {
     return JoinStyle::kBevel;
   }
+
   throw Exception("Invalid join style: '" + value +
                   "'. Valid options: round, mitre, miter, bevel");
 }
 
-bool ParseSingleSided(const std::string& value) {
+BufferSide ParseBufferSide(const std::string& value) {
   if (StrCaseEqual(value, "both")) {
-    return false;
-  } else if (StrCaseEqual(value, "left") || StrCaseEqual(value, "right")) {
-    return true;
+    return BufferSide::kBoth;
+  } else if (StrCaseEqual(value, "left")) {
+    return BufferSide::kLeft;
+  } else if (StrCaseEqual(value, "right")) {
+    return BufferSide::kRight;
   }
+
   throw Exception("Invalid side: '" + value +
                   "'. Valid options: both, left, right");
-}
-
-std::pair<bool, bool> ParseBufferSideStyle(const std::string& params) {
-  bool left = false;
-  bool right = false;
-  std::istringstream iss(params);
-  std::string tok;
-  while (iss >> tok) {
-    auto eq_pos = tok.find('=');
-    if (eq_pos == std::string::npos) continue;
-    std::string key = tok.substr(0, eq_pos);
-    std::string val = tok.substr(eq_pos + 1);
-    if (StrCaseEqual(key, "side")) {
-      if (StrCaseEqual(val, "left")) {
-        left = true;
-        right = false;
-      } else if (StrCaseEqual(val, "right")) {
-        right = true;
-        left = false;
-      }
-    }
-  }
-  return {left, right};
 }
 
 /// Parameters are space-separated key=value pairs (case-insensitive).
@@ -1632,8 +1613,8 @@ BufferParams BufferParams::Parse(std::string_view params_str) {
     } else if (StrCaseEqual(key, "join")) {
       params.join_style = ParseJoinStyle(value);
     } else if (StrCaseEqual(key, "side")) {
-      params.single_sided = ParseSingleSided(value);
-      if (params.single_sided && !end_cap_specified) {
+      params.side = ParseBufferSide(value);
+      if (params.side != BufferSide::kBoth && !end_cap_specified) {
         params.end_cap_style = CapStyle::kSquare;
       }
     } else if (StrCaseEqual(key, "mitre_limit") ||
@@ -1675,6 +1656,39 @@ struct BufferParamsExec {
       options.set_buffer_radius(
           S1Angle::Radians(distance / S2Earth::RadiusMeters()));
       options.set_circle_segments(parsed.quadrant_segments * 4.0);
+
+      switch (parsed.end_cap_style) {
+        case CapStyle::kRound:
+          options.set_end_cap_style(S2BufferOperation::EndCapStyle::ROUND);
+          break;
+        case CapStyle::kFlat:
+          options.set_end_cap_style(S2BufferOperation::EndCapStyle::FLAT);
+          break;
+        case CapStyle::kSquare:
+          throw Exception(std::string("Unsupported cap style in params ") +
+                          std::string(params));
+          break;
+      }
+
+      switch (parsed.join_style) {
+        case JoinStyle::kRound:
+          break;
+        default:
+          throw Exception(std::string("Unsupported join style in params ") +
+                          std::string(params));
+      }
+
+      switch (parsed.side) {
+        case BufferSide::kLeft:
+          options.set_polyline_side(S2BufferOperation::PolylineSide::LEFT);
+          break;
+        case BufferSide::kRight:
+          options.set_polyline_side(S2BufferOperation::PolylineSide::RIGHT);
+          break;
+        case BufferSide::kBoth:
+          options.set_polyline_side(S2BufferOperation::PolylineSide::BOTH);
+          break;
+      }
 
       options_ = options;
       last_distance_ = distance;

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -2,6 +2,7 @@
 #include "s2geography/build.h"
 
 #include <s2/s2boolean_operation.h>
+#include <s2/s2buffer_operation.h>
 #include <s2/s2builder.h>
 #include <s2/s2builderutil_closed_set_normalizer.h>
 #include <s2/s2builderutil_s2point_vector_layer.h>
@@ -1510,6 +1511,42 @@ struct SymDifferenceOperationExec {
   OutputGeometry output_;
 };
 
+struct BufferExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = DoubleInputView;
+  using out_t = GeoArrowOutputBuilder;
+
+  void Exec(arg0_t::c_type value, arg1_t::c_type distance, out_t* out) {
+    // For what will definitely be empty or degenerate output, we return POLYGON
+    // EMPTY
+    if (value.is_empty() || (value.max_dimension() < 2 && distance <= 0)) {
+      out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_POLYGON);
+      return;
+    }
+
+    double n_quad_seg = 8.0;
+
+    S2BufferOperation::Options options;
+    options.set_buffer_radius(
+        S1Angle::Radians(distance / S2Earth::RadiusMeters()));
+    options.set_circle_segments(n_quad_seg * 4);
+
+    S2BufferOperation op;
+    op.Init(std::make_unique<GeoArrowPolygonLayer>(&output_), options);
+
+    S2Error error;
+    if (!op.Build(&error)) {
+      std::stringstream ss;
+      ss << error;
+      throw Exception(ss.str());
+    }
+
+    output_.WriteTo(out, GEOARROW_GEOMETRY_TYPE_POLYGON);
+  }
+
+  OutputGeometry output_;
+};
+
 void DifferenceKernel(struct SedonaCScalarKernel* out) {
   InitBinaryKernel<DifferenceOperationExec>(out, "st_difference");
 }
@@ -1532,6 +1569,10 @@ void ReducePrecisionKernel(struct SedonaCScalarKernel* out) {
 
 void SimplifyKernel(struct SedonaCScalarKernel* out) {
   InitBinaryKernel<SimplifyExec>(out, "st_simplify");
+}
+
+void BufferKernel(struct SedonaCScalarKernel* out) {
+  InitBinaryKernel<BufferExec>(out, "st_buffer");
 }
 
 }  // namespace sedona_udf

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -1732,8 +1732,8 @@ struct BufferQuadSegsExec {
 
   void Exec(arg0_t::c_type value, arg1_t::c_type distance,
             arg2_t::c_type n_quad_segs, out_t* out) {
-    std::string params =
-        std::string("quad_segs=") + std::to_string(n_quad_segs);
+    std::string params = std::string("quad_segs=") +
+                         std::to_string(static_cast<int>(n_quad_segs));
     buffer_params_.Exec(value, distance, params, out);
   }
 

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -1530,8 +1530,8 @@ double ParseDouble(const std::string& value, const char* param_name) {
     if (pos != value.size()) throw std::invalid_argument("trailing chars");
     return result;
   } catch (const std::exception&) {
-    throw Exception(std::string("Invalid ") + param_name + " value: '" +
-                    value + "'. Expected a valid number");
+    throw Exception(std::string("Invalid ") + param_name + " value: '" + value +
+                    "'. Expected a valid number");
   }
 }
 
@@ -1542,8 +1542,8 @@ int ParseInt(const std::string& value, const char* param_name) {
     if (pos != value.size()) throw std::invalid_argument("trailing chars");
     return result;
   } catch (const std::exception&) {
-    throw Exception(std::string("Invalid ") + param_name + " value: '" +
-                    value + "'. Expected a valid number");
+    throw Exception(std::string("Invalid ") + param_name + " value: '" + value +
+                    "'. Expected a valid number");
   }
 }
 
@@ -1666,17 +1666,24 @@ struct BufferExec {
       return;
     }
 
-    double n_quad_seg = 8.0;
+    std::string params;
+    if (distance != last_distance_ || last_params_ != params) {
+      BufferParams parsed = BufferParams::Parse(params);
+
+      S2BufferOperation::Options options;
+      options.set_buffer_radius(
+          S1Angle::Radians(distance / S2Earth::RadiusMeters()));
+      options.set_circle_segments(parsed.quadrant_segments * 4.0);
+
+      options_ = options;
+      last_distance_ = distance;
+      last_params_ = params;
+    }
 
     output_.Clear();
 
-    S2BufferOperation::Options options;
-    options.set_buffer_radius(
-        S1Angle::Radians(distance / S2Earth::RadiusMeters()));
-    options.set_circle_segments(n_quad_seg * 4);
-
     S2BufferOperation op;
-    op.Init(std::make_unique<GeoArrowPolygonLayer>(&output_), options);
+    op.Init(std::make_unique<GeoArrowPolygonLayer>(&output_), options_);
 
     // AddShape doesn't handle dimension-0 shapes (points); use AddPoint for
     // each point vertex instead.
@@ -1697,6 +1704,9 @@ struct BufferExec {
     output_.WriteTo(out, GEOARROW_GEOMETRY_TYPE_POLYGON);
   }
 
+  double last_distance_;
+  std::string last_params_;
+  S2BufferOperation::Options options_;
   OutputGeometry output_;
 };
 

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -1564,8 +1564,7 @@ BufferSide ParseBufferSide(const std::string& value) {
 }  // namespace
 
 /// Parameters are space-separated key=value pairs (case-insensitive).
-/// Supported keys: endcap, join, side, mitre_limit, miter_limit,
-/// quad_segs, quadrant_segments.
+/// Supported keys: endcap, join, side, quad_segs, and quadrant_segments.
 BufferParams BufferParams::Parse(std::string_view params_str) {
   BufferParams params;
   if (params_str.empty()) return params;
@@ -1597,9 +1596,9 @@ BufferParams BufferParams::Parse(std::string_view params_str) {
                StrCaseEqual(key, "quadrant_segments")) {
       params.quadrant_segments = ParseInt(value, "quadrant_segments");
     } else {
-      throw Exception("Invalid buffer parameter: " + key +
-                      " (accept: 'endcap', 'join', 'quad_segs', "
-                      "'quadrant_segments' and 'side')");
+      throw Exception(
+          "Invalid buffer parameter: " + key +
+          " (accept: 'endcap', 'quad_segs', 'quadrant_segments' and 'side')");
     }
   }
 
@@ -1627,6 +1626,10 @@ struct BufferParamsExec {
       S2BufferOperation::Options options;
       auto buffer_angle = S1Angle::Radians(distance / S2Earth::RadiusMeters());
       options.set_buffer_radius(buffer_angle);
+
+      if (parsed.quadrant_segments < 0) {
+        throw Exception("quadrant_segments must be >0 in ST_Buffer()");
+      }
       options.set_circle_segments(parsed.quadrant_segments * 4.0);
 
       switch (parsed.end_cap_style) {

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -13,9 +13,11 @@
 #include <s2/s2loop.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <limits>
 #include <sstream>
+#include <stdexcept>
 
 #include "s2geography/accessors.h"
 #include "s2geography/geography_interface.h"
@@ -1523,18 +1525,6 @@ bool StrCaseEqual(const std::string& a, const std::string& b) {
   return true;
 }
 
-double ParseDouble(const std::string& value, const char* param_name) {
-  try {
-    size_t pos;
-    double result = std::stod(value, &pos);
-    if (pos != value.size()) throw std::invalid_argument("trailing chars");
-    return result;
-  } catch (const std::exception&) {
-    throw Exception(std::string("Invalid ") + param_name + " value: '" + value +
-                    "'. Expected a valid number");
-  }
-}
-
 int ParseInt(const std::string& value, const char* param_name) {
   try {
     size_t pos;
@@ -1547,31 +1537,15 @@ int ParseInt(const std::string& value, const char* param_name) {
   }
 }
 
-}  // namespace
-
 CapStyle ParseCapStyle(const std::string& value) {
   if (StrCaseEqual(value, "round")) {
     return CapStyle::kRound;
   } else if (StrCaseEqual(value, "flat") || StrCaseEqual(value, "butt")) {
     return CapStyle::kFlat;
-  } else if (StrCaseEqual(value, "square")) {
-    return CapStyle::kSquare;
   }
   throw Exception("Invalid endcap style: '" + value +
-                  "'. Valid options: round, flat, butt, square");
-}
-
-JoinStyle ParseJoinStyle(const std::string& value) {
-  if (StrCaseEqual(value, "round")) {
-    return JoinStyle::kRound;
-  } else if (StrCaseEqual(value, "mitre") || StrCaseEqual(value, "miter")) {
-    return JoinStyle::kMitre;
-  } else if (StrCaseEqual(value, "bevel")) {
-    return JoinStyle::kBevel;
-  }
-
-  throw Exception("Invalid join style: '" + value +
-                  "'. Valid options: round, mitre, miter, bevel");
+                  "'. Valid options: round, flat, butt (square not supported "
+                  "for geography)");
 }
 
 BufferSide ParseBufferSide(const std::string& value) {
@@ -1586,6 +1560,8 @@ BufferSide ParseBufferSide(const std::string& value) {
   throw Exception("Invalid side: '" + value +
                   "'. Valid options: both, left, right");
 }
+
+}  // namespace
 
 /// Parameters are space-separated key=value pairs (case-insensitive).
 /// Supported keys: endcap, join, side, mitre_limit, miter_limit,
@@ -1610,24 +1586,20 @@ BufferParams BufferParams::Parse(std::string_view params_str) {
     if (StrCaseEqual(key, "endcap")) {
       params.end_cap_style = ParseCapStyle(value);
       end_cap_specified = true;
-    } else if (StrCaseEqual(key, "join")) {
-      params.join_style = ParseJoinStyle(value);
     } else if (StrCaseEqual(key, "side")) {
       params.side = ParseBufferSide(value);
       if (params.side != BufferSide::kBoth && !end_cap_specified) {
-        params.end_cap_style = CapStyle::kSquare;
+        // In PostGIS this defaults to square ends; however, s2geometry doesn't
+        // support that
+        params.end_cap_style = CapStyle::kFlat;
       }
-    } else if (StrCaseEqual(key, "mitre_limit") ||
-               StrCaseEqual(key, "miter_limit")) {
-      params.mitre_limit = ParseDouble(value, "mitre_limit");
     } else if (StrCaseEqual(key, "quad_segs") ||
                StrCaseEqual(key, "quadrant_segments")) {
       params.quadrant_segments = ParseInt(value, "quadrant_segments");
     } else {
-      throw Exception(
-          "Invalid buffer parameter: " + key +
-          " (accept: 'endcap', 'join', 'mitre_limit', 'miter_limit', "
-          "'quad_segs', 'quadrant_segments' and 'side')");
+      throw Exception("Invalid buffer parameter: " + key +
+                      " (accept: 'endcap', 'join', 'quad_segs', "
+                      "'quadrant_segments' and 'side')");
     }
   }
 
@@ -1653,8 +1625,8 @@ struct BufferParamsExec {
       BufferParams parsed = BufferParams::Parse(params);
 
       S2BufferOperation::Options options;
-      options.set_buffer_radius(
-          S1Angle::Radians(distance / S2Earth::RadiusMeters()));
+      auto buffer_angle = S1Angle::Radians(distance / S2Earth::RadiusMeters());
+      options.set_buffer_radius(buffer_angle);
       options.set_circle_segments(parsed.quadrant_segments * 4.0);
 
       switch (parsed.end_cap_style) {
@@ -1664,18 +1636,6 @@ struct BufferParamsExec {
         case CapStyle::kFlat:
           options.set_end_cap_style(S2BufferOperation::EndCapStyle::FLAT);
           break;
-        case CapStyle::kSquare:
-          throw Exception(std::string("Unsupported cap style in params ") +
-                          std::string(params));
-          break;
-      }
-
-      switch (parsed.join_style) {
-        case JoinStyle::kRound:
-          break;
-        default:
-          throw Exception(std::string("Unsupported join style in params ") +
-                          std::string(params));
       }
 
       switch (parsed.side) {
@@ -1727,13 +1687,13 @@ struct BufferParamsExec {
 struct BufferQuadSegsExec {
   using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = DoubleInputView;
-  using arg2_t = DoubleInputView;
+  using arg2_t = IntInputView;
   using out_t = GeoArrowOutputBuilder;
 
   void Exec(arg0_t::c_type value, arg1_t::c_type distance,
             arg2_t::c_type n_quad_segs, out_t* out) {
-    std::string params = std::string("quad_segs=") +
-                         std::to_string(static_cast<int>(n_quad_segs));
+    std::string params =
+        std::string("quad_segs=") + std::to_string(n_quad_segs);
     buffer_params_.Exec(value, distance, params, out);
   }
 

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -1526,6 +1526,8 @@ struct BufferExec {
 
     double n_quad_seg = 8.0;
 
+    output_.Clear();
+
     S2BufferOperation::Options options;
     options.set_buffer_radius(
         S1Angle::Radians(distance / S2Earth::RadiusMeters()));
@@ -1533,6 +1535,15 @@ struct BufferExec {
 
     S2BufferOperation op;
     op.Init(std::make_unique<GeoArrowPolygonLayer>(&output_), options);
+
+    // AddShape doesn't handle dimension-0 shapes (points); use AddPoint for
+    // each point vertex instead.
+    value.points()->geom().VisitVertices([&](const S2Point& v) {
+      op.AddPoint(v);
+      return true;
+    });
+    op.AddShape(*value.lines());
+    op.AddShape(*value.polygons());
 
     S2Error error;
     if (!op.Build(&error)) {

--- a/src/s2geography/build.cc
+++ b/src/s2geography/build.cc
@@ -1609,12 +1609,12 @@ std::pair<bool, bool> ParseBufferSideStyle(const std::string& params) {
 /// Parameters are space-separated key=value pairs (case-insensitive).
 /// Supported keys: endcap, join, side, mitre_limit, miter_limit,
 /// quad_segs, quadrant_segments.
-BufferParams BufferParams::Parse(const std::string& params_str) {
+BufferParams BufferParams::Parse(std::string_view params_str) {
   BufferParams params;
   if (params_str.empty()) return params;
 
   bool end_cap_specified = false;
-  std::istringstream iss(params_str);
+  std::istringstream iss((std::string(params_str)));
   std::string param;
 
   while (iss >> param) {
@@ -1653,12 +1653,14 @@ BufferParams BufferParams::Parse(const std::string& params_str) {
   return params;
 }
 
-struct BufferExec {
+struct BufferParamsExec {
   using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = DoubleInputView;
+  using arg2_t = StringInputView;
   using out_t = GeoArrowOutputBuilder;
 
-  void Exec(arg0_t::c_type value, arg1_t::c_type distance, out_t* out) {
+  void Exec(arg0_t::c_type value, arg1_t::c_type distance,
+            arg2_t::c_type params, out_t* out) {
     // For what will definitely be empty or degenerate output, we return POLYGON
     // EMPTY
     if (value.is_empty() || (value.max_dimension() < 2 && distance <= 0)) {
@@ -1666,7 +1668,6 @@ struct BufferExec {
       return;
     }
 
-    std::string params;
     if (distance != last_distance_ || last_params_ != params) {
       BufferParams parsed = BufferParams::Parse(params);
 
@@ -1681,7 +1682,6 @@ struct BufferExec {
     }
 
     output_.Clear();
-
     S2BufferOperation op;
     op.Init(std::make_unique<GeoArrowPolygonLayer>(&output_), options_);
 
@@ -1704,10 +1704,38 @@ struct BufferExec {
     output_.WriteTo(out, GEOARROW_GEOMETRY_TYPE_POLYGON);
   }
 
-  double last_distance_;
+  double last_distance_{-std::numeric_limits<double>::infinity()};
   std::string last_params_;
   S2BufferOperation::Options options_;
   OutputGeometry output_;
+};
+
+struct BufferQuadSegsExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = DoubleInputView;
+  using arg2_t = DoubleInputView;
+  using out_t = GeoArrowOutputBuilder;
+
+  void Exec(arg0_t::c_type value, arg1_t::c_type distance,
+            arg2_t::c_type n_quad_segs, out_t* out) {
+    std::string params =
+        std::string("quad_segs=") + std::to_string(n_quad_segs);
+    buffer_params_.Exec(value, distance, params, out);
+  }
+
+  BufferParamsExec buffer_params_;
+};
+
+struct BufferExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = DoubleInputView;
+  using out_t = GeoArrowOutputBuilder;
+
+  void Exec(arg0_t::c_type value, arg1_t::c_type distance, out_t* out) {
+    buffer_params_.Exec(value, distance, "", out);
+  }
+
+  BufferParamsExec buffer_params_;
 };
 
 void DifferenceKernel(struct SedonaCScalarKernel* out) {
@@ -1736,6 +1764,14 @@ void SimplifyKernel(struct SedonaCScalarKernel* out) {
 
 void BufferKernel(struct SedonaCScalarKernel* out) {
   InitBinaryKernel<BufferExec>(out, "st_buffer");
+}
+
+void BufferQuadSegsKernel(struct SedonaCScalarKernel* out) {
+  InitTernaryKernel<BufferQuadSegsExec>(out, "st_buffer");
+}
+
+void BufferParamsKernel(struct SedonaCScalarKernel* out) {
+  InitTernaryKernel<BufferParamsExec>(out, "st_buffer");
 }
 
 }  // namespace sedona_udf

--- a/src/s2geography/build.h
+++ b/src/s2geography/build.h
@@ -5,6 +5,8 @@
 #include <s2/s2builderutil_s2polygon_layer.h>
 #include <s2/s2builderutil_s2polyline_vector_layer.h>
 
+#include <string>
+
 #include "s2geography/aggregator.h"
 #include "s2geography/geography.h"
 #include "s2geography/sedona_udf/sedona_extension.h"
@@ -112,6 +114,28 @@ void UnionKernel(struct SedonaCScalarKernel* out);
 void ReducePrecisionKernel(struct SedonaCScalarKernel* out);
 void SimplifyKernel(struct SedonaCScalarKernel* out);
 void BufferKernel(struct SedonaCScalarKernel* out);
+
+// Exposed for testing
+enum class CapStyle { kRound, kFlat, kSquare };
+enum class JoinStyle { kRound, kMitre, kBevel };
+
+/// \brief Parsed PostGIS-style buffer parameters.
+///
+/// Buffer parameters are specified as space-separated key=value pairs
+/// (case-insensitive). Supported keys: endcap, join, side, mitre_limit,
+/// miter_limit, quad_segs, quadrant_segments.
+///
+/// Example: "endcap=round join=mitre quad_segs=4"
+struct BufferParams {
+  CapStyle end_cap_style = CapStyle::kRound;
+  JoinStyle join_style = JoinStyle::kRound;
+  bool single_sided = false;
+  double mitre_limit = 5.0;
+  int quadrant_segments = 8;
+
+  /// \brief Parse a PostGIS-style buffer parameter string.
+  static BufferParams Parse(const std::string& params_str);
+};
 
 }  // namespace sedona_udf
 

--- a/src/s2geography/build.h
+++ b/src/s2geography/build.h
@@ -135,6 +135,18 @@ struct BufferParams {
 
   /// \brief Parse a PostGIS-style buffer parameter string.
   static BufferParams Parse(const std::string& params_str);
+
+  friend bool operator==(const BufferParams& a, const BufferParams& b) {
+    return a.end_cap_style == b.end_cap_style &&
+           a.join_style == b.join_style &&
+           a.single_sided == b.single_sided &&
+           a.mitre_limit == b.mitre_limit &&
+           a.quadrant_segments == b.quadrant_segments;
+  }
+
+  friend bool operator!=(const BufferParams& a, const BufferParams& b) {
+    return !(a == b);
+  }
 };
 
 }  // namespace sedona_udf

--- a/src/s2geography/build.h
+++ b/src/s2geography/build.h
@@ -118,8 +118,7 @@ void BufferQuadSegsKernel(struct SedonaCScalarKernel* out);
 void BufferParamsKernel(struct SedonaCScalarKernel* out);
 
 // Exposed for testing
-enum class CapStyle { kRound, kFlat, kSquare };
-enum class JoinStyle { kRound, kMitre, kBevel };
+enum class CapStyle { kRound, kFlat };
 enum class BufferSide { kLeft, kRight, kBoth };
 
 /// \brief Parsed PostGIS-style buffer parameters.
@@ -128,12 +127,10 @@ enum class BufferSide { kLeft, kRight, kBoth };
 /// (case-insensitive). Supported keys: endcap, join, side, mitre_limit,
 /// miter_limit, quad_segs, quadrant_segments.
 ///
-/// Example: "endcap=round join=mitre quad_segs=4"
+/// Example: "endcap=round quad_segs=4"
 struct BufferParams {
   CapStyle end_cap_style = CapStyle::kRound;
-  JoinStyle join_style = JoinStyle::kRound;
   BufferSide side = BufferSide::kBoth;
-  double mitre_limit = 5.0;
   int quadrant_segments = 8;
 
   /// \brief Parse a PostGIS-style buffer parameter string.

--- a/src/s2geography/build.h
+++ b/src/s2geography/build.h
@@ -114,10 +114,12 @@ void UnionKernel(struct SedonaCScalarKernel* out);
 void ReducePrecisionKernel(struct SedonaCScalarKernel* out);
 void SimplifyKernel(struct SedonaCScalarKernel* out);
 void BufferKernel(struct SedonaCScalarKernel* out);
+void BufferParamsKernel(struct SedonaCScalarKernel* out);
 
 // Exposed for testing
 enum class CapStyle { kRound, kFlat, kSquare };
 enum class JoinStyle { kRound, kMitre, kBevel };
+enum class BufferSide { kLeft, kRight, kBoth };
 
 /// \brief Parsed PostGIS-style buffer parameters.
 ///
@@ -129,7 +131,7 @@ enum class JoinStyle { kRound, kMitre, kBevel };
 struct BufferParams {
   CapStyle end_cap_style = CapStyle::kRound;
   JoinStyle join_style = JoinStyle::kRound;
-  bool single_sided = false;
+  BufferSide side = BufferSide::kBoth;
   double mitre_limit = 5.0;
   int quadrant_segments = 8;
 

--- a/src/s2geography/build.h
+++ b/src/s2geography/build.h
@@ -114,6 +114,7 @@ void UnionKernel(struct SedonaCScalarKernel* out);
 void ReducePrecisionKernel(struct SedonaCScalarKernel* out);
 void SimplifyKernel(struct SedonaCScalarKernel* out);
 void BufferKernel(struct SedonaCScalarKernel* out);
+void BufferQuadSegsKernel(struct SedonaCScalarKernel* out);
 void BufferParamsKernel(struct SedonaCScalarKernel* out);
 
 // Exposed for testing

--- a/src/s2geography/build.h
+++ b/src/s2geography/build.h
@@ -111,6 +111,7 @@ void IntersectionKernel(struct SedonaCScalarKernel* out);
 void UnionKernel(struct SedonaCScalarKernel* out);
 void ReducePrecisionKernel(struct SedonaCScalarKernel* out);
 void SimplifyKernel(struct SedonaCScalarKernel* out);
+void BufferKernel(struct SedonaCScalarKernel* out);
 
 }  // namespace sedona_udf
 

--- a/src/s2geography/build.h
+++ b/src/s2geography/build.h
@@ -5,7 +5,7 @@
 #include <s2/s2builderutil_s2polygon_layer.h>
 #include <s2/s2builderutil_s2polyline_vector_layer.h>
 
-#include <string>
+#include <string_view>
 
 #include "s2geography/aggregator.h"
 #include "s2geography/geography.h"
@@ -134,19 +134,7 @@ struct BufferParams {
   int quadrant_segments = 8;
 
   /// \brief Parse a PostGIS-style buffer parameter string.
-  static BufferParams Parse(const std::string& params_str);
-
-  friend bool operator==(const BufferParams& a, const BufferParams& b) {
-    return a.end_cap_style == b.end_cap_style &&
-           a.join_style == b.join_style &&
-           a.single_sided == b.single_sided &&
-           a.mitre_limit == b.mitre_limit &&
-           a.quadrant_segments == b.quadrant_segments;
-  }
-
-  friend bool operator!=(const BufferParams& a, const BufferParams& b) {
-    return !(a == b);
-  }
+  static BufferParams Parse(const std::string_view params_str);
 };
 
 }  // namespace sedona_udf

--- a/src/s2geography/build.h
+++ b/src/s2geography/build.h
@@ -124,8 +124,8 @@ enum class BufferSide { kLeft, kRight, kBoth };
 /// \brief Parsed PostGIS-style buffer parameters.
 ///
 /// Buffer parameters are specified as space-separated key=value pairs
-/// (case-insensitive). Supported keys: endcap, join, side, mitre_limit,
-/// miter_limit, quad_segs, quadrant_segments.
+/// (case-insensitive). Supported keys: endcap, side, quad_segs,
+/// and quadrant_segments.
 ///
 /// Example: "endcap=round quad_segs=4"
 struct BufferParams {

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -1202,11 +1202,189 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.name;
     });
 
+TEST(Build, SedonaUdfBufferParams) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::BufferParamsKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl,
+      {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE, NANOARROW_TYPE_STRING},
+      ARROW_TYPE_WKB));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
+      &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE, NANOARROW_TYPE_STRING},
+      {{"POINT (0 0)", "LINESTRING (0 0, 10 0)", std::nullopt}},
+      {{0.0, 0.0, std::nullopt}}, {{"", "", std::nullopt}}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(TestResultGeography(
+      out_array.get(), {"POLYGON EMPTY", "POLYGON EMPTY", std::nullopt}));
+}
+
+struct BufferParamsOpParam {
+  std::string name;
+  std::optional<std::string> input_wkt;
+  std::optional<double> distance;
+  std::optional<std::string> params;
+  std::optional<std::string> expected_wkt;
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const BufferParamsOpParam& p) {
+    os << (p.input_wkt ? *p.input_wkt : "null")
+       << " dist=" << (p.distance ? std::to_string(*p.distance) : "null")
+       << " params=" << (p.params ? *p.params : "null") << " -> "
+       << (p.expected_wkt ? *p.expected_wkt : "null");
+    return os;
+  }
+};
+
+class BufferParamsTest : public ::testing::TestWithParam<BufferParamsOpParam> {
+};
+
+TEST_P(BufferParamsTest, SedonaUdf) {
+  const auto& p = GetParam();
+
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::BufferParamsKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl,
+      {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE, NANOARROW_TYPE_STRING},
+      ARROW_TYPE_WKB));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
+      &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE, NANOARROW_TYPE_STRING},
+      {{p.input_wkt}}, {{p.distance}}, {{p.params}}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(
+      TestResultGeography(out_array.get(), {p.expected_wkt}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Build, BufferParamsTest,
+    ::testing::Values(
+        // Null inputs
+        BufferParamsOpParam{"null_geom", std::nullopt, 100000.0, "",
+                            std::nullopt},
+        BufferParamsOpParam{"null_distance", "POINT (0 0)", std::nullopt, "",
+                            std::nullopt},
+        BufferParamsOpParam{"null_params", "POINT (0 0)", 100000.0,
+                            std::nullopt, std::nullopt},
+        BufferParamsOpParam{"null_all", std::nullopt, std::nullopt,
+                            std::nullopt, std::nullopt},
+
+        // Empty params: same as default BufferKernel
+        BufferParamsOpParam{"empty_params", "POINT (0 0)", 100000.0, "",
+                            "POLYGON ((-0.899308 0.004766, -0.88296 -0.170765, "
+                            "-0.832686 -0.339735, -0.750414 -0.495651, "
+                            "-0.639303 -0.632523, -0.50362 -0.745089, "
+                            "-0.348578 -0.829023, -0.180135 -0.881096, "
+                            "-0.004767 -0.899308, 0.170785 -0.882956, "
+                            "0.339771 -0.832671, 0.495694 -0.750386, "
+                            "0.632562 -0.639264, 0.745118 -0.503577, "
+                            "0.829038 -0.348541, 0.881101 -0.180114, "
+                            "0.899308 -0.004766, 0.88296 0.170765, "
+                            "0.832686 0.339735, 0.750414 0.495651, "
+                            "0.639303 0.632523, 0.50362 0.745089, "
+                            "0.348578 0.829023, 0.180135 0.881096, "
+                            "0.004767 0.899308, -0.170785 0.882956, "
+                            "-0.339771 0.832671, -0.495694 0.750386, "
+                            "-0.632562 0.639264, -0.745118 0.503577, "
+                            "-0.829038 0.348541, -0.881101 0.180114, "
+                            "-0.899308 0.004766))"},
+
+        // endcap=round: explicit round, same result as default
+        BufferParamsOpParam{"endcap_round", "LINESTRING (0 0, 1 0)", 100000.0,
+                            "endcap=round",
+                            "POLYGON ((0 0.89932, -0.175477 0.882036, "
+                            "-0.344206 0.830847, -0.4997 0.747724, "
+                            "-0.635982 0.635862, -0.747816 0.499561, "
+                            "-0.830907 0.344063, -0.882062 0.175343, "
+                            "-0.89932 -0.000115, -0.882017 -0.175569, "
+                            "-0.830818 -0.344276, -0.747688 -0.499753, "
+                            "-0.635819 -0.636025, -0.499508 -0.747852, "
+                            "-0.343993 -0.830936, -0.175251 -0.882081, "
+                            "0 -0.89932, 1 -0.89932, "
+                            "1.175477 -0.882036, 1.344206 -0.830847, "
+                            "1.4997 -0.747724, 1.635982 -0.635862, "
+                            "1.747816 -0.499561, 1.830907 -0.344063, "
+                            "1.882062 -0.175343, 1.89932 0.000115, "
+                            "1.882017 0.175569, 1.830818 0.344276, "
+                            "1.747688 0.499753, 1.635819 0.636025, "
+                            "1.499508 0.747852, 1.343993 0.830936, "
+                            "1.175251 0.882081, 1 0.89932, 0 0.89932))"},
+
+        // endcap=flat: flat cap on linestring (no semicircular endcaps)
+        BufferParamsOpParam{"endcap_flat", "LINESTRING (0 0, 1 0)", 100000.0,
+                            "endcap=flat",
+                            "POLYGON ((0 0.89932, 0 -0.89932, "
+                            "1 -0.89932, 1 0.89932, 0 0.89932))"},
+
+        // side=left endcap=round: only left side of linestring
+        BufferParamsOpParam{"side_left", "LINESTRING (0 0, 1 0)", 100000.0,
+                            "endcap=round side=left",
+                            "POLYGON ((1.89932 0, 1.88204 0.175456, "
+                            "1.830862 0.34417, 1.747752 0.499657, "
+                            "1.635901 0.635943, 1.499604 0.747788, "
+                            "1.344099 0.830892, 1.175364 0.882058, "
+                            "1 0.89932, 0 0.89932, "
+                            "-0.175477 0.882036, -0.344206 0.830847, "
+                            "-0.4997 0.747724, -0.635982 0.635862, "
+                            "-0.747816 0.499561, -0.830907 0.344063, "
+                            "-0.882062 0.175343, -0.89932 0, "
+                            "0 0, 1 0, 1.89932 0))"},
+
+        // side=right endcap=round: only right side of linestring
+        BufferParamsOpParam{"side_right", "LINESTRING (0 0, 1 0)", 100000.0,
+                            "endcap=round side=right",
+                            "POLYGON ((-0.89932 0, -0.88204 -0.175456, "
+                            "-0.830862 -0.34417, -0.747752 -0.499657, "
+                            "-0.635901 -0.635943, -0.499604 -0.747788, "
+                            "-0.344099 -0.830892, -0.175364 -0.882058, "
+                            "0 -0.89932, 1 -0.89932, "
+                            "1.175477 -0.882036, 1.344206 -0.830847, "
+                            "1.4997 -0.747724, 1.635982 -0.635862, "
+                            "1.747816 -0.499561, 1.830907 -0.344063, "
+                            "1.882062 -0.175343, 1.89932 0, "
+                            "1 0, 0 0, -0.89932 0))"},
+
+        // quad_segs=4: fewer circle segments (16 instead of 32 for a full
+        // circle)
+        BufferParamsOpParam{"quad_segs_4", "POINT (0 0)", 100000.0,
+                            "quad_segs=4",
+                            "POLYGON ((-0.899308 0.004766, "
+                            "-0.832686 -0.339735, "
+                            "-0.639303 -0.632523, "
+                            "-0.348578 -0.829023, "
+                            "-0.004767 -0.899308, "
+                            "0.339771 -0.832671, "
+                            "0.632562 -0.639264, "
+                            "0.829038 -0.348541, "
+                            "0.899308 -0.004766, "
+                            "0.832686 0.339735, "
+                            "0.639303 0.632523, "
+                            "0.348578 0.829023, "
+                            "0.004767 0.899308, "
+                            "-0.339771 0.832671, "
+                            "-0.632562 0.639264, "
+                            "-0.829038 0.348541, "
+                            "-0.899308 0.004766))"}
+
+        ),
+    [](const ::testing::TestParamInfo<BufferParamsOpParam>& info) {
+      return info.param.name;
+    });
+
 TEST(BufferParamsParse, Empty) {
   auto p = sedona_udf::BufferParams::Parse("");
   EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kRound);
   EXPECT_EQ(p.join_style, sedona_udf::JoinStyle::kRound);
-  EXPECT_FALSE(p.single_sided);
+  EXPECT_EQ(p.side, sedona_udf::BufferSide::kBoth);
   EXPECT_DOUBLE_EQ(p.mitre_limit, 5.0);
   EXPECT_EQ(p.quadrant_segments, 8);
 }
@@ -1266,25 +1444,25 @@ TEST(BufferParamsParse, JoinInvalid) {
 
 TEST(BufferParamsParse, SideBoth) {
   auto p = sedona_udf::BufferParams::Parse("side=both");
-  EXPECT_FALSE(p.single_sided);
+  EXPECT_EQ(p.side, sedona_udf::BufferSide::kBoth);
 }
 
 TEST(BufferParamsParse, SideLeft) {
   auto p = sedona_udf::BufferParams::Parse("side=left");
-  EXPECT_TRUE(p.single_sided);
+  EXPECT_EQ(p.side, sedona_udf::BufferSide::kLeft);
   // When side is single-sided and endcap not explicitly set, defaults to square
   EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kSquare);
 }
 
 TEST(BufferParamsParse, SideRight) {
   auto p = sedona_udf::BufferParams::Parse("side=right");
-  EXPECT_TRUE(p.single_sided);
+  EXPECT_EQ(p.side, sedona_udf::BufferSide::kRight);
   EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kSquare);
 }
 
 TEST(BufferParamsParse, SideWithExplicitEndcap) {
   auto p = sedona_udf::BufferParams::Parse("endcap=round side=left");
-  EXPECT_TRUE(p.single_sided);
+  EXPECT_EQ(p.side, sedona_udf::BufferSide::kLeft);
   // Endcap was explicitly set before side, so it stays round
   EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kRound);
 }

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -1418,9 +1418,7 @@ TEST(Build, SedonaUdfBufferQuadSegs) {
 TEST(BufferParamsParse, Empty) {
   auto p = sedona_udf::BufferParams::Parse("");
   EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kRound);
-  EXPECT_EQ(p.join_style, sedona_udf::JoinStyle::kRound);
   EXPECT_EQ(p.side, sedona_udf::BufferSide::kBoth);
-  EXPECT_DOUBLE_EQ(p.mitre_limit, 5.0);
   EXPECT_EQ(p.quadrant_segments, 8);
 }
 
@@ -1439,11 +1437,6 @@ TEST(BufferParamsParse, EndcapButt) {
   EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kFlat);
 }
 
-TEST(BufferParamsParse, EndcapSquare) {
-  auto p = sedona_udf::BufferParams::Parse("endcap=square");
-  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kSquare);
-}
-
 TEST(BufferParamsParse, EndcapCaseInsensitive) {
   auto p = sedona_udf::BufferParams::Parse("ENDCAP=ROUND");
   EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kRound);
@@ -1451,26 +1444,6 @@ TEST(BufferParamsParse, EndcapCaseInsensitive) {
 
 TEST(BufferParamsParse, EndcapInvalid) {
   EXPECT_THROW(sedona_udf::BufferParams::Parse("endcap=invalid"), Exception);
-}
-
-TEST(BufferParamsParse, JoinRound) {
-  auto p = sedona_udf::BufferParams::Parse("join=round");
-  EXPECT_EQ(p.join_style, sedona_udf::JoinStyle::kRound);
-}
-
-TEST(BufferParamsParse, JoinMitre) {
-  auto p = sedona_udf::BufferParams::Parse("join=mitre");
-  EXPECT_EQ(p.join_style, sedona_udf::JoinStyle::kMitre);
-}
-
-TEST(BufferParamsParse, JoinMiter) {
-  auto p = sedona_udf::BufferParams::Parse("join=miter");
-  EXPECT_EQ(p.join_style, sedona_udf::JoinStyle::kMitre);
-}
-
-TEST(BufferParamsParse, JoinBevel) {
-  auto p = sedona_udf::BufferParams::Parse("join=bevel");
-  EXPECT_EQ(p.join_style, sedona_udf::JoinStyle::kBevel);
 }
 
 TEST(BufferParamsParse, JoinInvalid) {
@@ -1485,14 +1458,14 @@ TEST(BufferParamsParse, SideBoth) {
 TEST(BufferParamsParse, SideLeft) {
   auto p = sedona_udf::BufferParams::Parse("side=left");
   EXPECT_EQ(p.side, sedona_udf::BufferSide::kLeft);
-  // When side is single-sided and endcap not explicitly set, defaults to square
-  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kSquare);
+  // When side is single-sided and endcap not explicitly set, defaults to flat
+  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kFlat);
 }
 
 TEST(BufferParamsParse, SideRight) {
   auto p = sedona_udf::BufferParams::Parse("side=right");
   EXPECT_EQ(p.side, sedona_udf::BufferSide::kRight);
-  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kSquare);
+  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kFlat);
 }
 
 TEST(BufferParamsParse, SideWithExplicitEndcap) {
@@ -1504,16 +1477,6 @@ TEST(BufferParamsParse, SideWithExplicitEndcap) {
 
 TEST(BufferParamsParse, SideInvalid) {
   EXPECT_THROW(sedona_udf::BufferParams::Parse("side=invalid"), Exception);
-}
-
-TEST(BufferParamsParse, MitreLimit) {
-  auto p = sedona_udf::BufferParams::Parse("mitre_limit=2.5");
-  EXPECT_DOUBLE_EQ(p.mitre_limit, 2.5);
-}
-
-TEST(BufferParamsParse, MiterLimit) {
-  auto p = sedona_udf::BufferParams::Parse("miter_limit=3.0");
-  EXPECT_DOUBLE_EQ(p.mitre_limit, 3.0);
 }
 
 TEST(BufferParamsParse, MitreLimitInvalid) {
@@ -1535,12 +1498,10 @@ TEST(BufferParamsParse, QuadSegsInvalid) {
 }
 
 TEST(BufferParamsParse, MultipleParams) {
-  auto p = sedona_udf::BufferParams::Parse(
-      "endcap=flat join=mitre mitre_limit=2.0 quad_segs=4");
+  auto p = sedona_udf::BufferParams::Parse("endcap=flat quad_segs=4 side=left");
   EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kFlat);
-  EXPECT_EQ(p.join_style, sedona_udf::JoinStyle::kMitre);
-  EXPECT_DOUBLE_EQ(p.mitre_limit, 2.0);
   EXPECT_EQ(p.quadrant_segments, 4);
+  EXPECT_EQ(p.side, sedona_udf::BufferSide::kLeft);
 }
 
 TEST(BufferParamsParse, UnknownParam) {

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -1050,4 +1050,156 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.name;
     });
 
+TEST(Build, SedonaUdfBuffer) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::BufferKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
+      &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE},
+      {{"POINT (0 0)", "LINESTRING (0 0, 10 0)", std::nullopt}},
+      {{0.0, 0.0, std::nullopt}}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(TestResultGeography(
+      out_array.get(), {"POLYGON EMPTY", "POLYGON EMPTY", std::nullopt}));
+}
+
+class BufferTest : public ::testing::TestWithParam<UnaryScalarOpParam> {};
+
+TEST_P(BufferTest, SedonaUdf) {
+  const auto& p = GetParam();
+
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::BufferKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE}, ARROW_TYPE_WKB));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE},
+                        {{p.input_wkt}}, {{p.scalar_arg}}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(
+      TestResultGeography(out_array.get(), {p.expected_wkt}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Build, BufferTest,
+    ::testing::Values(
+        // Null inputs
+        UnaryScalarOpParam{"null_geom", std::nullopt, 0.0, std::nullopt},
+        UnaryScalarOpParam{"null_distance", "POINT (0 0)", std::nullopt,
+                           std::nullopt},
+        UnaryScalarOpParam{"null_both", std::nullopt, std::nullopt,
+                           std::nullopt},
+
+        // Empty geometry: always POLYGON EMPTY regardless of distance
+        UnaryScalarOpParam{"empty_point_zero", "POINT EMPTY", 0.0,
+                           "POLYGON EMPTY"},
+        UnaryScalarOpParam{"empty_point_positive", "POINT EMPTY", 100000.0,
+                           "POLYGON EMPTY"},
+        UnaryScalarOpParam{"empty_linestring", "LINESTRING EMPTY", 100000.0,
+                           "POLYGON EMPTY"},
+        UnaryScalarOpParam{"empty_polygon", "POLYGON EMPTY", 100000.0,
+                           "POLYGON EMPTY"},
+
+        // Point with zero distance: dimension < 2 and distance <= 0
+        UnaryScalarOpParam{"point_zero_distance", "POINT (0 0)", 0.0,
+                           "POLYGON EMPTY"},
+        // Point with negative distance: dimension < 2 and distance <= 0
+        UnaryScalarOpParam{"point_negative_distance", "POINT (0 0)", -100000.0,
+                           "POLYGON EMPTY"},
+
+        // Linestring with zero distance: dimension < 2 and distance <= 0
+        UnaryScalarOpParam{"linestring_zero_distance", "LINESTRING (0 0, 10 0)",
+                           0.0, "POLYGON EMPTY"},
+        // Linestring with negative distance: dimension < 2 and distance <= 0
+        UnaryScalarOpParam{"linestring_negative_distance",
+                           "LINESTRING (0 0, 10 0)", -100000.0,
+                           "POLYGON EMPTY"},
+
+        // Polygon with negative distance: dimension == 2, goes through buffer
+        // (erosion); a small polygon fully eroded produces empty
+        UnaryScalarOpParam{"polygon_large_negative_distance",
+                           "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", -1000000.0,
+                           "POLYGON EMPTY"},
+
+        // Point with positive distance: produces a polygon approximating a
+        // circle
+        UnaryScalarOpParam{"point_positive_distance", "POINT (0 0)", 100000.0,
+                           "POLYGON ((-0.899308 0.004766, -0.88296 -0.170765, "
+                           "-0.832686 -0.339735, -0.750414 -0.495651, "
+                           "-0.639303 -0.632523, -0.50362 -0.745089, "
+                           "-0.348578 -0.829023, -0.180135 -0.881096, "
+                           "-0.004767 -0.899308, 0.170785 -0.882956, "
+                           "0.339771 -0.832671, 0.495694 -0.750386, "
+                           "0.632562 -0.639264, 0.745118 -0.503577, "
+                           "0.829038 -0.348541, 0.881101 -0.180114, "
+                           "0.899308 -0.004766, 0.88296 0.170765, "
+                           "0.832686 0.339735, 0.750414 0.495651, "
+                           "0.639303 0.632523, 0.50362 0.745089, "
+                           "0.348578 0.829023, 0.180135 0.881096, "
+                           "0.004767 0.899308, -0.170785 0.882956, "
+                           "-0.339771 0.832671, -0.495694 0.750386, "
+                           "-0.632562 0.639264, -0.745118 0.503577, "
+                           "-0.829038 0.348541, -0.881101 0.180114, "
+                           "-0.899308 0.004766))"},
+
+        // Linestring with positive distance: produces a buffered corridor
+        UnaryScalarOpParam{"linestring_positive_distance",
+                           "LINESTRING (0 0, 1 0)", 100000.0,
+                           "POLYGON ((0 0.89932, -0.175477 0.882036, "
+                           "-0.344206 0.830847, -0.4997 0.747724, "
+                           "-0.635982 0.635862, -0.747816 0.499561, "
+                           "-0.830907 0.344063, -0.882062 0.175343, "
+                           "-0.89932 -0.000115, -0.882017 -0.175569, "
+                           "-0.830818 -0.344276, -0.747688 -0.499753, "
+                           "-0.635819 -0.636025, -0.499508 -0.747852, "
+                           "-0.343993 -0.830936, -0.175251 -0.882081, "
+                           "0 -0.89932, 1 -0.89932, "
+                           "1.175477 -0.882036, 1.344206 -0.830847, "
+                           "1.4997 -0.747724, 1.635982 -0.635862, "
+                           "1.747816 -0.499561, 1.830907 -0.344063, "
+                           "1.882062 -0.175343, 1.89932 0.000115, "
+                           "1.882017 0.175569, 1.830818 0.344276, "
+                           "1.747688 0.499753, 1.635819 0.636025, "
+                           "1.499508 0.747852, 1.343993 0.830936, "
+                           "1.175251 0.882081, 1 0.89932, 0 0.89932))"},
+
+        // Polygon with positive distance: expands the polygon
+        UnaryScalarOpParam{"polygon_positive_distance",
+                           "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", 100000.0,
+                           "POLYGON ((0 -0.89932, 1 -0.89932, "
+                           "1.175477 -0.882036, 1.344206 -0.830847, "
+                           "1.4997 -0.747724, 1.635982 -0.635862, "
+                           "1.747816 -0.499561, 1.830907 -0.344063, "
+                           "1.882062 -0.175343, 1.89932 0, "
+                           "1.899457 0.999877, 1.882221 1.175337, "
+                           "1.831076 1.344064, 1.74798 1.499572, "
+                           "1.636121 1.635882, 1.499794 1.74775, "
+                           "1.344239 1.830874, 1.175437 1.882054, "
+                           "1.000137 1.89932, -0.000137 1.89932, "
+                           "-0.175685 1.882004, -0.344472 1.830777, "
+                           "-0.500004 1.74761, -0.636299 1.635703, "
+                           "-0.74812 1.499362, -0.831173 1.343831, "
+                           "-0.882271 1.17509, -0.899457 0.999877, "
+                           "-0.89932 0, -0.88204 -0.175456, "
+                           "-0.830862 -0.34417, -0.747752 -0.499657, "
+                           "-0.635901 -0.635943, -0.499604 -0.747788, "
+                           "-0.344099 -0.830892, -0.175364 -0.882058, "
+                           "0 -0.89932))"}
+
+        ),
+    [](const ::testing::TestParamInfo<UnaryScalarOpParam>& info) {
+      return info.param.name;
+    });
+
 }  // namespace s2geography

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -1202,4 +1202,140 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.name;
     });
 
+TEST(BufferParamsParse, Empty) {
+  auto p = sedona_udf::BufferParams::Parse("");
+  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kRound);
+  EXPECT_EQ(p.join_style, sedona_udf::JoinStyle::kRound);
+  EXPECT_FALSE(p.single_sided);
+  EXPECT_DOUBLE_EQ(p.mitre_limit, 5.0);
+  EXPECT_EQ(p.quadrant_segments, 8);
+}
+
+TEST(BufferParamsParse, EndcapRound) {
+  auto p = sedona_udf::BufferParams::Parse("endcap=round");
+  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kRound);
+}
+
+TEST(BufferParamsParse, EndcapFlat) {
+  auto p = sedona_udf::BufferParams::Parse("endcap=flat");
+  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kFlat);
+}
+
+TEST(BufferParamsParse, EndcapButt) {
+  auto p = sedona_udf::BufferParams::Parse("endcap=butt");
+  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kFlat);
+}
+
+TEST(BufferParamsParse, EndcapSquare) {
+  auto p = sedona_udf::BufferParams::Parse("endcap=square");
+  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kSquare);
+}
+
+TEST(BufferParamsParse, EndcapCaseInsensitive) {
+  auto p = sedona_udf::BufferParams::Parse("ENDCAP=ROUND");
+  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kRound);
+}
+
+TEST(BufferParamsParse, EndcapInvalid) {
+  EXPECT_THROW(sedona_udf::BufferParams::Parse("endcap=invalid"), Exception);
+}
+
+TEST(BufferParamsParse, JoinRound) {
+  auto p = sedona_udf::BufferParams::Parse("join=round");
+  EXPECT_EQ(p.join_style, sedona_udf::JoinStyle::kRound);
+}
+
+TEST(BufferParamsParse, JoinMitre) {
+  auto p = sedona_udf::BufferParams::Parse("join=mitre");
+  EXPECT_EQ(p.join_style, sedona_udf::JoinStyle::kMitre);
+}
+
+TEST(BufferParamsParse, JoinMiter) {
+  auto p = sedona_udf::BufferParams::Parse("join=miter");
+  EXPECT_EQ(p.join_style, sedona_udf::JoinStyle::kMitre);
+}
+
+TEST(BufferParamsParse, JoinBevel) {
+  auto p = sedona_udf::BufferParams::Parse("join=bevel");
+  EXPECT_EQ(p.join_style, sedona_udf::JoinStyle::kBevel);
+}
+
+TEST(BufferParamsParse, JoinInvalid) {
+  EXPECT_THROW(sedona_udf::BufferParams::Parse("join=invalid"), Exception);
+}
+
+TEST(BufferParamsParse, SideBoth) {
+  auto p = sedona_udf::BufferParams::Parse("side=both");
+  EXPECT_FALSE(p.single_sided);
+}
+
+TEST(BufferParamsParse, SideLeft) {
+  auto p = sedona_udf::BufferParams::Parse("side=left");
+  EXPECT_TRUE(p.single_sided);
+  // When side is single-sided and endcap not explicitly set, defaults to square
+  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kSquare);
+}
+
+TEST(BufferParamsParse, SideRight) {
+  auto p = sedona_udf::BufferParams::Parse("side=right");
+  EXPECT_TRUE(p.single_sided);
+  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kSquare);
+}
+
+TEST(BufferParamsParse, SideWithExplicitEndcap) {
+  auto p = sedona_udf::BufferParams::Parse("endcap=round side=left");
+  EXPECT_TRUE(p.single_sided);
+  // Endcap was explicitly set before side, so it stays round
+  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kRound);
+}
+
+TEST(BufferParamsParse, SideInvalid) {
+  EXPECT_THROW(sedona_udf::BufferParams::Parse("side=invalid"), Exception);
+}
+
+TEST(BufferParamsParse, MitreLimit) {
+  auto p = sedona_udf::BufferParams::Parse("mitre_limit=2.5");
+  EXPECT_DOUBLE_EQ(p.mitre_limit, 2.5);
+}
+
+TEST(BufferParamsParse, MiterLimit) {
+  auto p = sedona_udf::BufferParams::Parse("miter_limit=3.0");
+  EXPECT_DOUBLE_EQ(p.mitre_limit, 3.0);
+}
+
+TEST(BufferParamsParse, MitreLimitInvalid) {
+  EXPECT_THROW(sedona_udf::BufferParams::Parse("mitre_limit=abc"), Exception);
+}
+
+TEST(BufferParamsParse, QuadSegs) {
+  auto p = sedona_udf::BufferParams::Parse("quad_segs=4");
+  EXPECT_EQ(p.quadrant_segments, 4);
+}
+
+TEST(BufferParamsParse, QuadrantSegments) {
+  auto p = sedona_udf::BufferParams::Parse("quadrant_segments=16");
+  EXPECT_EQ(p.quadrant_segments, 16);
+}
+
+TEST(BufferParamsParse, QuadSegsInvalid) {
+  EXPECT_THROW(sedona_udf::BufferParams::Parse("quad_segs=abc"), Exception);
+}
+
+TEST(BufferParamsParse, MultipleParams) {
+  auto p = sedona_udf::BufferParams::Parse(
+      "endcap=flat join=mitre mitre_limit=2.0 quad_segs=4");
+  EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kFlat);
+  EXPECT_EQ(p.join_style, sedona_udf::JoinStyle::kMitre);
+  EXPECT_DOUBLE_EQ(p.mitre_limit, 2.0);
+  EXPECT_EQ(p.quadrant_segments, 4);
+}
+
+TEST(BufferParamsParse, UnknownParam) {
+  EXPECT_THROW(sedona_udf::BufferParams::Parse("unknown=value"), Exception);
+}
+
+TEST(BufferParamsParse, MissingValue) {
+  EXPECT_THROW(sedona_udf::BufferParams::Parse("endcap"), Exception);
+}
+
 }  // namespace s2geography

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -1386,12 +1386,12 @@ TEST(Build, SedonaUdfBufferQuadSegs) {
   struct SedonaCScalarKernelImpl impl;
   ASSERT_NO_FATAL_FAILURE(TestInitKernel(
       &kernel, &impl,
-      {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE, NANOARROW_TYPE_DOUBLE},
+      {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE, NANOARROW_TYPE_INT32},
       ARROW_TYPE_WKB));
 
   nanoarrow::UniqueArray out_array;
   ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
-      &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE, NANOARROW_TYPE_DOUBLE},
+      &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE, NANOARROW_TYPE_INT32},
       {{"POINT (0 0)", "POINT (0 0)"}}, {{100000.0, 100000.0}, {4.0, 2.0}},
       out_array.get()));
   impl.release(&impl);

--- a/src/s2geography/build_test.cc
+++ b/src/s2geography/build_test.cc
@@ -1380,6 +1380,41 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.name;
     });
 
+TEST(Build, SedonaUdfBufferQuadSegs) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::BufferQuadSegsKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl,
+      {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE, NANOARROW_TYPE_DOUBLE},
+      ARROW_TYPE_WKB));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
+      &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_DOUBLE, NANOARROW_TYPE_DOUBLE},
+      {{"POINT (0 0)", "POINT (0 0)"}}, {{100000.0, 100000.0}, {4.0, 2.0}},
+      out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  // quad_segs=4 produces 4*4+1=17 vertices; quad_segs=2 produces 4*2+1=9
+  ASSERT_NO_FATAL_FAILURE(TestResultGeography(
+      out_array.get(), {"POLYGON ((-0.899308 0.004766, -0.832686 -0.339735, "
+                        "-0.639303 -0.632523, -0.348578 -0.829023, "
+                        "-0.004767 -0.899308, 0.339771 -0.832671, "
+                        "0.632562 -0.639264, 0.829038 -0.348541, "
+                        "0.899308 -0.004766, 0.832686 0.339735, "
+                        "0.639303 0.632523, 0.348578 0.829023, "
+                        "0.004767 0.899308, -0.339771 0.832671, "
+                        "-0.632562 0.639264, -0.829038 0.348541, "
+                        "-0.899308 0.004766))",
+                        "POLYGON ((-0.899308 0.004766, -0.639303 -0.632523, "
+                        "-0.004767 -0.899308, 0.632562 -0.639264, "
+                        "0.899308 -0.004766, 0.639303 0.632523, "
+                        "0.004767 0.899308, -0.632562 0.639264, "
+                        "-0.899308 0.004766))"}));
+}
+
 TEST(BufferParamsParse, Empty) {
   auto p = sedona_udf::BufferParams::Parse("");
   EXPECT_EQ(p.end_cap_style, sedona_udf::CapStyle::kRound);

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -501,6 +501,7 @@ class ArrowInputView {
 using BoolInputView = ArrowInputView<bool>;
 using IntInputView = ArrowInputView<int64_t>;
 using DoubleInputView = ArrowInputView<double>;
+using StringInputView = ArrowInputView<std::string_view>;
 
 /// \brief View of GeoArrow input
 ///
@@ -614,6 +615,7 @@ struct KernelData {
   std::string name;
   bool prepare_arg0_scalar{true};
   bool prepare_arg1_scalar{true};
+  bool prepare_arg2_scalar{true};
 };
 
 inline const char* KernelFunctionName(const struct SedonaCScalarKernel* self) {
@@ -841,6 +843,127 @@ class SedonaBinaryKernelAdapter {
   }
 };
 
+/// \brief Sedona C ABI adapter for ternary UDFs (three arguments)
+template <typename Exec>
+class SedonaTernaryKernelAdapter {
+ public:
+  struct ImplData {
+    std::string last_error;
+    std::unique_ptr<typename Exec::arg0_t> arg0;
+    std::unique_ptr<typename Exec::arg1_t> arg1;
+    std::unique_ptr<typename Exec::arg2_t> arg2;
+    std::unique_ptr<typename Exec::out_t> out;
+    Exec exec;
+    bool prepare_arg0_scalar{true};
+    bool prepare_arg1_scalar{true};
+    bool prepare_arg2_scalar{true};
+  };
+
+  static int ImplInit(struct SedonaCScalarKernelImpl* self,
+                      const struct ArrowSchema* const* arg_types,
+                      struct ArrowArray* const* /*scalar_args*/, int64_t n_args,
+                      struct ArrowSchema* out) {
+    auto* data = static_cast<ImplData*>(self->private_data);
+    data->last_error.clear();
+    try {
+      // Check if this kernel applies to the input arguments
+      if (n_args != 3 || !Exec::arg0_t::Matches(arg_types[0]) ||
+          !Exec::arg1_t::Matches(arg_types[1]) ||
+          !Exec::arg2_t::Matches(arg_types[2])) {
+        out->release = nullptr;
+        return NANOARROW_OK;
+      }
+
+      data->arg0 = std::make_unique<typename Exec::arg0_t>(arg_types[0]);
+      data->arg1 = std::make_unique<typename Exec::arg1_t>(arg_types[1]);
+      data->arg2 = std::make_unique<typename Exec::arg2_t>(arg_types[2]);
+      data->arg0->SetPrepareScalar(data->prepare_arg0_scalar);
+      data->arg1->SetPrepareScalar(data->prepare_arg1_scalar);
+      data->arg2->SetPrepareScalar(data->prepare_arg2_scalar);
+      data->out = std::make_unique<typename Exec::out_t>();
+
+      // We don't have a reliable way to check the equality of CRSes, so
+      // here we just return the first CRS.
+      std::string crs_out = data->arg0->GetCrs();
+      if (crs_out.empty()) {
+        data->out->InitOutputType(out);
+      } else {
+        data->out->InitOutputTypeWithCrs(out, crs_out);
+      }
+
+      return 0;
+    } catch (std::exception& e) {
+      data->last_error = e.what();
+      return EINVAL;
+    }
+  }
+
+  static int ImplExecute(struct SedonaCScalarKernelImpl* self,
+                         struct ArrowArray* const* args, int64_t n_args,
+                         int64_t n_rows, struct ArrowArray* out) {
+    auto* data = static_cast<ImplData*>(self->private_data);
+    data->last_error.clear();
+    try {
+      if (n_args != 3) {
+        data->last_error =
+            "Expected three arguments in ternary s2geography kernel";
+        return EINVAL;
+      }
+
+      data->arg0->SetArray(args[0], n_rows);
+      data->arg1->SetArray(args[1], n_rows);
+      data->arg2->SetArray(args[2], n_rows);
+      int64_t num_iterations = ExecuteNumIterations(n_rows, args, n_args);
+      data->out->Reserve(num_iterations);
+
+      for (int64_t i = 0; i < num_iterations; i++) {
+        if (data->arg0->IsNull(i) || data->arg1->IsNull(i) ||
+            data->arg2->IsNull(i)) {
+          data->out->AppendNull();
+        } else {
+          typename Exec::arg0_t::c_type item0 = data->arg0->Get(i);
+          typename Exec::arg1_t::c_type item1 = data->arg1->Get(i);
+          typename Exec::arg2_t::c_type item2 = data->arg2->Get(i);
+          data->exec.Exec(item0, item1, item2, data->out.get());
+        }
+      }
+
+      data->out->Finish(out);
+      return 0;
+    } catch (std::exception& e) {
+      data->last_error = e.what();
+      return EINVAL;
+    }
+  }
+
+  static const char* ImplGetLastError(struct SedonaCScalarKernelImpl* self) {
+    return static_cast<ImplData*>(self->private_data)->last_error.c_str();
+  }
+
+  static void ImplRelease(struct SedonaCScalarKernelImpl* self) {
+    if (self->private_data != nullptr) {
+      delete static_cast<ImplData*>(self->private_data);
+      self->private_data = nullptr;
+    }
+    self->release = nullptr;
+  }
+
+  static void NewImpl(const struct SedonaCScalarKernel* self,
+                      struct SedonaCScalarKernelImpl* out) {
+    auto* kernel_private = static_cast<KernelData*>(self->private_data);
+    auto* impl_private = new ImplData();
+    impl_private->prepare_arg0_scalar = kernel_private->prepare_arg0_scalar;
+    impl_private->prepare_arg1_scalar = kernel_private->prepare_arg1_scalar;
+    impl_private->prepare_arg2_scalar = kernel_private->prepare_arg2_scalar;
+
+    out->private_data = impl_private;
+    out->init = &ImplInit;
+    out->execute = &ImplExecute;
+    out->get_last_error = &ImplGetLastError;
+    out->release = &ImplRelease;
+  }
+};
+
 /// \brief Initialize a SedonaCScalarKernel for a unary Exec
 template <typename Exec>
 void InitUnaryKernel(struct SedonaCScalarKernel* out, const char* name,
@@ -861,6 +984,20 @@ void InitBinaryKernel(struct SedonaCScalarKernel* out, const char* name,
   out->private_data = data;
   out->function_name = &KernelFunctionName;
   out->new_impl = &SedonaBinaryKernelAdapter<Exec>::NewImpl;
+  out->release = &KernelRelease;
+}
+
+/// \brief Initialize a SedonaCScalarKernel for a ternary Exec
+template <typename Exec>
+void InitTernaryKernel(struct SedonaCScalarKernel* out, const char* name,
+                       bool prepare_arg0_scalar = true,
+                       bool prepare_arg1_scalar = true,
+                       bool prepare_arg2_scalar = true) {
+  auto* data = new KernelData{name, prepare_arg0_scalar, prepare_arg1_scalar,
+                              prepare_arg2_scalar};
+  out->private_data = data;
+  out->function_name = &KernelFunctionName;
+  out->new_impl = &SedonaTernaryKernelAdapter<Exec>::NewImpl;
   out->release = &KernelRelease;
 }
 

--- a/src/s2geography/sedona_udf/sedona_udf_test_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_test_internal.h
@@ -241,6 +241,28 @@ inline nanoarrow::UniqueArray ArgArrow(
   return array;
 }
 
+// Create an arrow string array argument.
+inline nanoarrow::UniqueArray ArgArrowString(
+    std::vector<std::optional<std::string>> values) {
+  nanoarrow::UniqueArray array;
+  NANOARROW_THROW_NOT_OK(
+      ArrowArrayInitFromType(array.get(), NANOARROW_TYPE_STRING));
+  NANOARROW_THROW_NOT_OK(ArrowArrayStartAppending(array.get()));
+
+  for (const auto& value : values) {
+    if (value.has_value()) {
+      ArrowStringView na_value{value->data(),
+                               static_cast<int64_t>(value->size())};
+      NANOARROW_THROW_NOT_OK(ArrowArrayAppendString(array.get(), na_value));
+    } else {
+      NANOARROW_THROW_NOT_OK(ArrowArrayAppendNull(array.get(), 1));
+    }
+  }
+
+  NANOARROW_THROW_NOT_OK(ArrowArrayFinishBuildingDefault(array.get(), nullptr));
+  return array;
+}
+
 // Test utility to create a SedonaCScalarKernelImpl from a kernel, call init,
 // and check its output type.
 inline void TestInitKernel(struct SedonaCScalarKernel* kernel,
@@ -299,6 +321,64 @@ inline void TestExecuteKernel(
     ASSERT_TRUE(arg_type.has_value());
 
     args.push_back(ArgArrow(*arg_type, arg));
+  }
+
+  ASSERT_EQ(arg_type_it, arg_types.end());
+
+  std::vector<struct ArrowArray*> arg_pointers;
+  for (auto& arg : args) {
+    arg_pointers.push_back(arg.get());
+  }
+
+  // Compute n_rows: the maximum length across all args (scalars have length 1)
+  int64_t n_rows = 1;
+  for (auto& arg : args) {
+    if (arg->length > n_rows) {
+      n_rows = arg->length;
+    }
+  }
+
+  ASSERT_EQ(
+      impl->execute(impl, arg_pointers.data(),
+                    static_cast<int64_t>(arg_pointers.size()), n_rows, out),
+      0)
+      << impl->get_last_error(impl);
+}
+
+// Overload that also accepts string arguments after the numeric arguments.
+// This is needed for ST_Buffer() with params.
+inline void TestExecuteKernel(
+    struct SedonaCScalarKernelImpl* impl, std::vector<ArrowTypeOrWKB> arg_types,
+    std::vector<std::vector<std::optional<std::string>>> geography_args,
+    std::vector<std::vector<std::optional<double>>> other_args,
+    std::vector<std::vector<std::optional<std::string>>> string_args,
+    struct ArrowArray* out) {
+  auto arg_type_it = arg_types.begin();
+  std::vector<nanoarrow::UniqueArray> args;
+
+  for (const auto& geometry_arg : geography_args) {
+    ASSERT_NE(arg_type_it, arg_types.end());
+    auto arg_type = *arg_type_it++;
+    ASSERT_FALSE(arg_type.has_value());
+
+    args.push_back(ArgWkb(geometry_arg));
+  }
+
+  for (const auto& arg : other_args) {
+    ASSERT_NE(arg_type_it, arg_types.end());
+    auto arg_type = *arg_type_it++;
+    ASSERT_TRUE(arg_type.has_value());
+
+    args.push_back(ArgArrow(*arg_type, arg));
+  }
+
+  for (const auto& arg : string_args) {
+    ASSERT_NE(arg_type_it, arg_types.end());
+    auto arg_type = *arg_type_it++;
+    ASSERT_TRUE(arg_type.has_value());
+    ASSERT_EQ(*arg_type, NANOARROW_TYPE_STRING);
+
+    args.push_back(ArgArrowString(arg));
   }
 
   ASSERT_EQ(arg_type_it, arg_types.end());

--- a/src/s2geography/sedona_udf/sedona_udf_test_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_test_internal.h
@@ -243,7 +243,7 @@ inline nanoarrow::UniqueArray ArgArrow(
 
 // Create an arrow string array argument.
 inline nanoarrow::UniqueArray ArgArrowString(
-    std::vector<std::optional<std::string>> values) {
+    const std::vector<std::optional<std::string>>& values) {
   nanoarrow::UniqueArray array;
   NANOARROW_THROW_NOT_OK(
       ArrowArrayInitFromType(array.get(), NANOARROW_TYPE_STRING));


### PR DESCRIPTION
This one is really cool! A spherical buffer is very difficult to replicate in any other way (other than reprojecting to local UTM zones, buffering, and unprojecting like Sedona and PostGIS can do).

Most of the change here is (1) parsing the buffer parameters string and (2) handling three-argument UDFs (which we need for DWithin anyway).