### PR TITLE
perf: Improve performance of MaxDistance and add LongestLine

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,9 +3,13 @@
 # clang-diagnostic-c2y-extensions is because of nanoarrow and
 # geoarrow's __COUNTER__ use, which will be fixed in future versions
 # of both.
+# -clang-analyzer-cplusplus.Move is added because operator- triggers
+# this for an S2Point in the S2 headers, which is out of our
+# control.
 ---
 Checks: >-
   clang-analyzer-*,
+  -clang-analyzer-cplusplus.Move
   -clang-analyzer-core.CallAndMessage,
   -clang-analyzer-optin.performance.Padding,
   -clang-analyzer-security.insecureAPI.rand,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,7 @@
 ---
 Checks: >-
   clang-analyzer-*,
-  -clang-analyzer-cplusplus.Move
+  -clang-analyzer-cplusplus.Move,
   -clang-analyzer-core.CallAndMessage,
   -clang-analyzer-optin.performance.Padding,
   -clang-analyzer-security.insecureAPI.rand,

--- a/ci/scripts/run-clang-tidy.sh
+++ b/ci/scripts/run-clang-tidy.sh
@@ -38,6 +38,7 @@ main() {
     set -x
 
     run-clang-tidy -p "${build_dir}" -j$jobs \
+        -header-filter='src/s2geography/.*' \
         $extra_args | \
         tee "${build_dir}/clang-tidy-output.txt"
 

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -6,6 +6,7 @@
 #include <s2/s2debug.h>
 #include <s2/s2earth.h>
 #include <s2/s2edge_crossings.h>
+#include <s2/s2edge_distances.h>
 #include <s2/s2furthest_edge_query.h>
 
 #include "s2geography/geography.h"
@@ -177,10 +178,16 @@ struct MaxDistanceTraits {
     return query.FindFurthestEdge(target);
   }
 
-  // Max distance between two spherical edges is always at endpoints.
+  // Max distance between two spherical edges is at endpoints unless one edge
+  // crosses the antipodal reflection of the other (distance = pi).
   static std::pair<S2Point, S2Point> edge_pair_extremal_points(
       const S2Point& a0, const S2Point& a1, const S2Point& b0,
       const S2Point& b1) {
+    if (S2::CrossingSign(a0, a1, -b0, -b1) >= 0) {
+      throw Exception(
+          "Cannot compute farthest points between edges at antipodal distance "
+          "(max distance = pi)");
+    }
     std::pair<S2Point, S2Point> best{a0, b0};
     S1ChordAngle best_dist(a0, b0);
     auto check = [&](const S2Point& pa, const S2Point& pb) {
@@ -196,10 +203,24 @@ struct MaxDistanceTraits {
     return best;
   }
 
-  // Farthest point on a geodesic edge from a point is at one of the endpoints.
+  // Farthest point on a geodesic edge from a point is at one of the endpoints
+  // unless -point lies interior to the edge (distance = pi).
   static S2Point project_to_edge(const S2Point& point, const S2Point& a,
                                  const S2Point& b) {
-    return (S1ChordAngle(point, a) > S1ChordAngle(point, b)) ? a : b;
+    S1ChordAngle da(point, a);
+    S1ChordAngle db(point, b);
+    // When the farthest endpoint is more than 90 degrees away, the true
+    // farthest point might be interior to the edge (antipodal case).
+    if (std::max(da, db) > S1ChordAngle::Right()) {
+      S1ChordAngle max_dist = S1ChordAngle::Negative();
+      S2::UpdateMaxDistance(point, a, b, &max_dist);
+      if (max_dist == S1ChordAngle::Straight()) {
+        throw Exception(
+            "Cannot compute farthest point on edge at antipodal distance "
+            "(max distance = pi)");
+      }
+    }
+    return (da > db) ? a : b;
   }
 
   static constexpr bool kHandlesInteriors = false;
@@ -419,7 +440,7 @@ void DistanceLineUsingShapeIndex(const S2ShapeIndex& value0,
       out->extremal_points =
           Traits::edge_pair_extremal_points(e0.v0, e0.v1, e1.v0, e1.v1);
     } else {
-      throw Exception("Failed to find farthest edge pair");
+      throw Exception("Failed to find extremal edge pair");
     }
   }
 }

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -132,10 +132,84 @@ struct EdgePair {
   }
 };
 
-void ClearanceLineOnlyEdgesBruteForce(const GeoArrowGeography& value0,
-                                      const GeoArrowGeography& value1,
-                                      EdgePair* out) {
+// Traits for parameterizing distance computations over min (closest) and
+// max (furthest) distance queries. Both S2ClosestEdgeQuery and
+// S2FurthestEdgeQuery share the same base template
+// (S2ClosestEdgeQueryBase<Distance>) and have nearly identical APIs.
+struct MinDistanceTraits {
+  using Query = S2ClosestEdgeQuery;
+
+  static S1ChordAngle default_distance() { return S1ChordAngle::Infinity(); }
+
+  static bool is_better(S1ChordAngle candidate, S1ChordAngle current) {
+    return candidate < current;
+  }
+
+  static Query::Result find_edge(Query& query, Query::Target* target) {
+    return query.FindClosestEdge(target);
+  }
+
+  static std::pair<S2Point, S2Point> edge_pair_extremal_points(
+      const S2Point& a0, const S2Point& a1, const S2Point& b0,
+      const S2Point& b1) {
+    return S2::GetEdgePairClosestPoints(a0, a1, b0, b1);
+  }
+
+  static S2Point project_to_edge(const S2Point& point, const S2Point& a,
+                                 const S2Point& b) {
+    return S2::Project(point, a, b);
+  }
+
+  static constexpr bool kHandlesInteriors = true;
+};
+
+struct MaxDistanceTraits {
+  using Query = S2FurthestEdgeQuery;
+
+  static S1ChordAngle default_distance() { return S1ChordAngle::Negative(); }
+
+  static bool is_better(S1ChordAngle candidate, S1ChordAngle current) {
+    return candidate > current;
+  }
+
+  static Query::Result find_edge(Query& query, Query::Target* target) {
+    return query.FindFurthestEdge(target);
+  }
+
+  // Max distance between two spherical edges is always at endpoints.
+  static std::pair<S2Point, S2Point> edge_pair_extremal_points(
+      const S2Point& a0, const S2Point& a1, const S2Point& b0,
+      const S2Point& b1) {
+    std::pair<S2Point, S2Point> best{a0, b0};
+    S1ChordAngle best_dist(a0, b0);
+    auto check = [&](const S2Point& pa, const S2Point& pb) {
+      S1ChordAngle d(pa, pb);
+      if (d > best_dist) {
+        best = {pa, pb};
+        best_dist = d;
+      }
+    };
+    check(a0, b1);
+    check(a1, b0);
+    check(a1, b1);
+    return best;
+  }
+
+  // Farthest point on a geodesic edge from a point is at one of the endpoints.
+  static S2Point project_to_edge(const S2Point& point, const S2Point& a,
+                                 const S2Point& b) {
+    return (S1ChordAngle(point, a) > S1ChordAngle(point, b)) ? a : b;
+  }
+
+  static constexpr bool kHandlesInteriors = false;
+};
+
+template <typename Traits>
+void DistanceLineOnlyEdgesBruteForce(const GeoArrowGeography& value0,
+                                     const GeoArrowGeography& value1,
+                                     EdgePair* out) {
   *out = {};
+  out->distance = Traits::default_distance();
   S2GEOGRAPHY_DCHECK(value0.polygons()->is_empty());
   S2GEOGRAPHY_DCHECK(value1.polygons()->is_empty());
 
@@ -146,11 +220,11 @@ void ClearanceLineOnlyEdgesBruteForce(const GeoArrowGeography& value0,
     value1.VisitEdges([&](S2Shape::Edge& e1) {
       ++edge_id1;
 
-      auto closest_points_candidate =
-          S2::GetEdgePairClosestPoints(e0.v0, e0.v1, e1.v0, e1.v1);
-      S1ChordAngle distance_candidate = S1ChordAngle(
-          closest_points_candidate.first, closest_points_candidate.second);
-      if (distance_candidate < out->distance) {
+      auto points_candidate =
+          Traits::edge_pair_extremal_points(e0.v0, e0.v1, e1.v0, e1.v1);
+      S1ChordAngle distance_candidate(points_candidate.first,
+                                      points_candidate.second);
+      if (Traits::is_better(distance_candidate, out->distance)) {
         auto resolved0 = value0.ResolveGlobalEdgeId(edge_id0);
         out->shape_id0 = resolved0.first;
         out->edge_id0 = resolved0.second;
@@ -160,7 +234,7 @@ void ClearanceLineOnlyEdgesBruteForce(const GeoArrowGeography& value0,
         out->edge_id1 = resolved1.second;
 
         out->distance = distance_candidate;
-        out->closest_points = closest_points_candidate;
+        out->closest_points = points_candidate;
       }
 
       return true;
@@ -169,61 +243,69 @@ void ClearanceLineOnlyEdgesBruteForce(const GeoArrowGeography& value0,
   });
 }
 
-void ClearanceLineOnlyEdgesSemiBruteForce(const S2ShapeIndex& value0,
-                                          const GeoArrowGeography& value1,
-                                          EdgePair* out, int flags) {
+template <typename Traits>
+void DistanceLineOnlyEdgesSemiBruteForce(const S2ShapeIndex& value0,
+                                         const GeoArrowGeography& value1,
+                                         EdgePair* out, int flags) {
   *out = {};
+  out->distance = Traits::default_distance();
   S2GEOGRAPHY_DCHECK(value1.polygons()->is_empty());
 
-  S2ClosestEdgeQuery query0(&value0);
-  query0.mutable_options()->set_include_interiors(true);
+  typename Traits::Query query0(&value0);
+  if constexpr (Traits::kHandlesInteriors) {
+    query0.mutable_options()->set_include_interiors(true);
+  }
 
   int edge_id1 = -1;
   value1.VisitEdges([&](S2Shape::Edge& e1) {
     ++edge_id1;
 
-    S2ClosestEdgeQuery::EdgeTarget target(e1.v0, e1.v1);
-    const auto& result0 = query0.FindClosestEdge(&target);
+    typename Traits::Query::EdgeTarget target(e1.v0, e1.v1);
+    const auto result0 = Traits::find_edge(query0, &target);
 
     if (result0.is_empty()) {
       // No matching edges
       return true;
-    } else if (result0.is_interior()) {
-      // Edge interior intersects a polygon in the index.
-      out->shape_id0 = result0.shape_id();
-      out->edge_id0 = -1;
+    }
 
-      auto resolved_id1 = value1.ResolveGlobalEdgeId(edge_id1);
-      out->shape_id1 = resolved_id1.first;
-      out->edge_id1 = resolved_id1.second;
+    if constexpr (Traits::kHandlesInteriors) {
+      if (result0.is_interior()) {
+        // Edge interior intersects a polygon in the index.
+        out->shape_id0 = result0.shape_id();
+        out->edge_id0 = -1;
 
-      out->distance = S1ChordAngle::Zero();
+        auto resolved_id1 = value1.ResolveGlobalEdgeId(edge_id1);
+        out->shape_id1 = resolved_id1.first;
+        out->edge_id1 = resolved_id1.second;
 
-      // Find the actual intersection point using a crossing edge query. Only do
-      // this if requested.
-      if (flags & kFlagComputePoints) {
-        S2CrossingEdgeQuery crossing_query(&value0);
-        std::vector<s2shapeutil::ShapeEdge> crossing_edges;
-        crossing_query.GetCrossingEdges(
-            e1.v0, e1.v1, s2shapeutil::CrossingType::ALL, &crossing_edges);
+        out->distance = S1ChordAngle::Zero();
 
-        S2Point intersection_point = e1.v0;  // fallback
-        if (!crossing_edges.empty()) {
-          const auto& ce = crossing_edges[0];
-          intersection_point =
-              S2::GetIntersection(e1.v0, e1.v1, ce.v0(), ce.v1());
+        // Find the actual intersection point using a crossing edge query. Only
+        // do this if requested.
+        if (flags & kFlagComputePoints) {
+          S2CrossingEdgeQuery crossing_query(&value0);
+          std::vector<s2shapeutil::ShapeEdge> crossing_edges;
+          crossing_query.GetCrossingEdges(
+              e1.v0, e1.v1, s2shapeutil::CrossingType::ALL, &crossing_edges);
+
+          S2Point intersection_point = e1.v0;  // fallback
+          if (!crossing_edges.empty()) {
+            const auto& ce = crossing_edges[0];
+            intersection_point =
+                S2::GetIntersection(e1.v0, e1.v1, ce.v0(), ce.v1());
+          }
+
+          out->closest_points =
+              std::make_pair(intersection_point, intersection_point);
         }
 
-        out->closest_points =
-            std::make_pair(intersection_point, intersection_point);
+        // Stop iterating because no distance can be less than zero
+        return false;
       }
-
-      // Stop iterating because no distance can be less than zero
-      return false;
     }
 
     auto distance_candidate = result0.distance();
-    if (distance_candidate < out->distance) {
+    if (Traits::is_better(distance_candidate, out->distance)) {
       out->shape_id0 = result0.shape_id();
       out->edge_id0 = result0.edge_id();
 
@@ -236,7 +318,7 @@ void ClearanceLineOnlyEdgesSemiBruteForce(const S2ShapeIndex& value0,
       if (flags & kFlagComputePoints) {
         S2Shape::Edge e0 = query0.GetEdge(result0);
         out->closest_points =
-            S2::GetEdgePairClosestPoints(e0.v0, e0.v1, e1.v0, e1.v1);
+            Traits::edge_pair_extremal_points(e0.v0, e0.v1, e1.v0, e1.v1);
       }
     }
 
@@ -254,80 +336,86 @@ void ClearanceLineFromPoints(const S2Point& value0, const S2Point& value1,
   out->distance = S1ChordAngle(value0, value1);
 }
 
-void ClearanceLineUsingShapeIndex(const S2ShapeIndex& value0,
-                                  const S2ShapeIndex& value1, EdgePair* out,
-                                  int flags) {
+template <typename Traits>
+void DistanceLineUsingShapeIndex(const S2ShapeIndex& value0,
+                                 const S2ShapeIndex& value1, EdgePair* out,
+                                 int flags) {
   *out = {};
+  out->distance = Traits::default_distance();
 
-  S2ClosestEdgeQuery query0(&value0);
-  query0.mutable_options()->set_include_interiors(true);
+  typename Traits::Query query0(&value0);
+  if constexpr (Traits::kHandlesInteriors) {
+    query0.mutable_options()->set_include_interiors(true);
+  }
   query0.mutable_options()->set_max_results(1);
-  S2ClosestEdgeQuery::ShapeIndexTarget target(&value1);
+  typename Traits::Query::ShapeIndexTarget target(&value1);
 
-  // Get the edge from value0 that is closest to value1.
-  const auto& result0 = query0.FindClosestEdge(&target);
+  // Get the extremal edge from value0 relative to value1.
+  const auto result0 = Traits::find_edge(query0, &target);
   if (result0.is_empty()) {
     return;
   }
 
-  // If distance is zero, the geometries touch or overlap.
-  if (result0.distance().is_zero()) {
-    out->distance = S1ChordAngle::Zero();
-    out->shape_id0 = result0.shape_id();
-    out->edge_id0 = result0.edge_id();
+  if constexpr (Traits::kHandlesInteriors) {
+    // If distance is zero, the geometries touch or overlap.
+    if (result0.distance().is_zero()) {
+      out->distance = S1ChordAngle::Zero();
+      out->shape_id0 = result0.shape_id();
+      out->edge_id0 = result0.edge_id();
 
-    if (flags & kFlagComputePoints) {
-      if (!result0.is_interior()) {
-        // result0 gives us the edge from value0 that touches value1.
-        // Use value1's index to find the crossing edge.
-        S2Shape::Edge e0 = query0.GetEdge(result0);
-        S2CrossingEdgeQuery crossing_query(&value1);
-        std::vector<s2shapeutil::ShapeEdge> crossing_edges;
-        crossing_query.GetCrossingEdges(
-            e0.v0, e0.v1, s2shapeutil::CrossingType::ALL, &crossing_edges);
-        if (!crossing_edges.empty()) {
-          auto pt = S2::GetIntersection(e0.v0, e0.v1, crossing_edges[0].v0(),
-                                        crossing_edges[0].v1());
-          out->closest_points = std::make_pair(pt, pt);
-          out->shape_id1 = crossing_edges[0].id().shape_id;
-          out->edge_id1 = crossing_edges[0].id().edge_id;
-        } else {
-          // Shared vertex, no proper crossing.
-          out->closest_points = std::make_pair(e0.v0, e0.v0);
-        }
-      } else {
-        // Interior match: one fully contains the other. Use a vertex from
-        // value1.
-        for (int s = 0; s < value1.num_shape_ids(); ++s) {
-          const S2Shape* shape = value1.shape(s);
-          if (shape != nullptr && shape->num_edges() > 0) {
-            S2Point pt = shape->edge(0).v0;
+      if (flags & kFlagComputePoints) {
+        if (!result0.is_interior()) {
+          // result0 gives us the edge from value0 that touches value1.
+          // Use value1's index to find the crossing edge.
+          S2Shape::Edge e0 = query0.GetEdge(result0);
+          S2CrossingEdgeQuery crossing_query(&value1);
+          std::vector<s2shapeutil::ShapeEdge> crossing_edges;
+          crossing_query.GetCrossingEdges(
+              e0.v0, e0.v1, s2shapeutil::CrossingType::ALL, &crossing_edges);
+          if (!crossing_edges.empty()) {
+            auto pt = S2::GetIntersection(e0.v0, e0.v1, crossing_edges[0].v0(),
+                                          crossing_edges[0].v1());
             out->closest_points = std::make_pair(pt, pt);
-            out->shape_id1 = s;
-            out->edge_id1 = 0;
-            break;
+            out->shape_id1 = crossing_edges[0].id().shape_id;
+            out->edge_id1 = crossing_edges[0].id().edge_id;
+          } else {
+            // Shared vertex, no proper crossing.
+            out->closest_points = std::make_pair(e0.v0, e0.v0);
+          }
+        } else {
+          // Interior match: one fully contains the other. Use a vertex from
+          // value1.
+          for (int s = 0; s < value1.num_shape_ids(); ++s) {
+            const S2Shape* shape = value1.shape(s);
+            if (shape != nullptr && shape->num_edges() > 0) {
+              S2Point pt = shape->edge(0).v0;
+              out->closest_points = std::make_pair(pt, pt);
+              out->shape_id1 = s;
+              out->edge_id1 = 0;
+              break;
+            }
           }
         }
       }
-    }
 
-    return;
+      return;
+    }
   }
 
-  // Distance > 0: find the actual closest edge pair. Interior matches are
-  // impossible at this point.
+  // Non-zero distance: find the actual extremal edge pair.
   out->edge_id0 = result0.edge_id();
   out->shape_id0 = result0.shape_id();
   out->distance = result0.distance();
 
-  // If we need the other point, we need another edge crossing query
   if (flags & kFlagComputePoints) {
-    S2ClosestEdgeQuery query1(&value1);
-    query1.mutable_options()->set_include_interiors(false);
+    typename Traits::Query query1(&value1);
+    if constexpr (Traits::kHandlesInteriors) {
+      query1.mutable_options()->set_include_interiors(false);
+    }
     query1.mutable_options()->set_max_results(1);
     S2Shape::Edge e0 = query0.GetEdge(result0);
-    S2ClosestEdgeQuery::EdgeTarget target2(e0.v0, e0.v1);
-    auto result1 = query1.FindClosestEdge(&target2);
+    typename Traits::Query::EdgeTarget target2(e0.v0, e0.v1);
+    auto result1 = Traits::find_edge(query1, &target2);
     if (result1.is_empty()) {
       return;
     }
@@ -336,38 +424,45 @@ void ClearanceLineUsingShapeIndex(const S2ShapeIndex& value0,
     out->shape_id1 = result1.shape_id();
     S2Shape::Edge e1 = query1.GetEdge(result1);
 
-    // Find the closest point pair on edge1 and edge2.
     out->closest_points =
-        S2::GetEdgePairClosestPoints(e0.v0, e0.v1, e1.v0, e1.v1);
+        Traits::edge_pair_extremal_points(e0.v0, e0.v1, e1.v0, e1.v1);
   }
 }
 
-void ClearanceLineUsingShapeIndexAndPoint(const S2ShapeIndex& value0,
-                                          const S2Point& value1, EdgePair* out,
-                                          int flags) {
+template <typename Traits>
+void DistanceLineUsingShapeIndexAndPoint(const S2ShapeIndex& value0,
+                                         const S2Point& value1, EdgePair* out,
+                                         int flags) {
   *out = {};
+  out->distance = Traits::default_distance();
 
-  S2ClosestEdgeQuery query0(&value0);
-  query0.mutable_options()->set_include_interiors(true);
+  typename Traits::Query query0(&value0);
+  if constexpr (Traits::kHandlesInteriors) {
+    query0.mutable_options()->set_include_interiors(true);
+  }
   query0.mutable_options()->set_max_results(1);
-  S2ClosestEdgeQuery::PointTarget target(value1);
+  typename Traits::Query::PointTarget target(value1);
 
-  const auto& result0 = query0.FindClosestEdge(&target);
+  const auto result0 = Traits::find_edge(query0, &target);
 
   if (result0.is_empty()) {
     // No matching edges
     return;
-  } else if (result0.is_interior()) {
-    // Interior point match
-    out->shape_id0 = result0.shape_id();
-    out->edge_id0 = -1;
+  }
 
-    out->shape_id1 = 0;
-    out->edge_id1 = 0;
+  if constexpr (Traits::kHandlesInteriors) {
+    if (result0.is_interior()) {
+      // Interior point match
+      out->shape_id0 = result0.shape_id();
+      out->edge_id0 = -1;
 
-    out->distance = S1ChordAngle::Zero();
-    out->closest_points = std::make_pair(value1, value1);
-    return;
+      out->shape_id1 = 0;
+      out->edge_id1 = 0;
+
+      out->distance = S1ChordAngle::Zero();
+      out->closest_points = std::make_pair(value1, value1);
+      return;
+    }
   }
 
   out->edge_id0 = result0.edge_id();
@@ -377,8 +472,7 @@ void ClearanceLineUsingShapeIndexAndPoint(const S2ShapeIndex& value0,
   out->edge_id1 = 0;
   out->shape_id1 = 0;
 
-  // Find the closest point pair on edge1 and edge2.
-  S2Point p0 = S2::Project(value1, e0.v0, e0.v1);
+  S2Point p0 = Traits::project_to_edge(value1, e0.v0, e0.v1);
   out->closest_points = std::make_pair(p0, value1);
 
   if (flags & kFlagComputeDistance) {
@@ -405,10 +499,9 @@ bool BothSmallWithoutPolygons(const GeoArrowGeography& value0,
              kMaxBruteForceEdgeComparisons;
 }
 
-void ClearanceLine(GeoArrowGeography& value0, GeoArrowGeography& value1,
-                   EdgePair* out, int flags) {
-  // If either argument is EMPTY, the default constructor of EdgePair() is the
-  // correct output.
+template <typename Traits>
+void DistanceLine(GeoArrowGeography& value0, GeoArrowGeography& value1,
+                  EdgePair* out, int flags) {
   if (value0.is_empty() || value1.is_empty()) {
     *out = {};
     return;
@@ -420,31 +513,37 @@ void ClearanceLine(GeoArrowGeography& value0, GeoArrowGeography& value1,
     ClearanceLineFromPoints(*maybe_point0, *maybe_point1, out);
     return;
   } else if (maybe_point0 && IsAlreadyIndexedOrLargeOrHasPolygons(value1)) {
-    ClearanceLineUsingShapeIndexAndPoint(value1.ShapeIndex(), *maybe_point0,
-                                         out, flags);
+    DistanceLineUsingShapeIndexAndPoint<Traits>(value1.ShapeIndex(),
+                                                *maybe_point0, out, flags);
     std::swap(out->shape_id0, out->shape_id1);
     std::swap(out->edge_id0, out->edge_id1);
     std::swap(out->closest_points.first, out->closest_points.second);
   } else if (maybe_point1 && IsAlreadyIndexedOrLargeOrHasPolygons(value0)) {
-    ClearanceLineUsingShapeIndexAndPoint(value0.ShapeIndex(), *maybe_point1,
-                                         out, flags);
+    DistanceLineUsingShapeIndexAndPoint<Traits>(value0.ShapeIndex(),
+                                                *maybe_point1, out, flags);
   } else if (BothSmallWithoutPolygons(value0, value1)) {
-    ClearanceLineOnlyEdgesBruteForce(value0, value1, out);
+    DistanceLineOnlyEdgesBruteForce<Traits>(value0, value1, out);
   } else if (IsAlreadyIndexedOrLargeOrHasPolygons(value0) &&
              HasNoPolygons(value1)) {
-    ClearanceLineOnlyEdgesSemiBruteForce(value0.ShapeIndex(), value1, out,
-                                         flags);
+    DistanceLineOnlyEdgesSemiBruteForce<Traits>(value0.ShapeIndex(), value1,
+                                                out, flags);
   } else if (IsAlreadyIndexedOrLargeOrHasPolygons(value1) &&
              HasNoPolygons(value0)) {
-    ClearanceLineOnlyEdgesSemiBruteForce(value1.ShapeIndex(), value0, out,
-                                         flags);
+    DistanceLineOnlyEdgesSemiBruteForce<Traits>(value1.ShapeIndex(), value0,
+                                                out, flags);
     std::swap(out->shape_id0, out->shape_id1);
     std::swap(out->edge_id0, out->edge_id1);
     std::swap(out->closest_points.first, out->closest_points.second);
   } else {
-    ClearanceLineUsingShapeIndex(value0.ShapeIndex(), value1.ShapeIndex(), out,
-                                 flags);
+    DistanceLineUsingShapeIndex<Traits>(value0.ShapeIndex(),
+                                        value1.ShapeIndex(), out, flags);
   }
+}
+
+// Backward-compatible wrapper used by S2ClosestPointExec, S2ShortestLineExec.
+void ClearanceLine(GeoArrowGeography& value0, GeoArrowGeography& value1,
+                   EdgePair* out, int flags) {
+  DistanceLine<MinDistanceTraits>(value0, value1, out, flags);
 }
 
 struct S2ClosestPointExec {
@@ -504,9 +603,16 @@ struct S2MaxDistanceExec {
   using out_t = DoubleOutputBuilder;
 
   void Exec(arg0_t::c_type value0, arg1_t::c_type value1, out_t* out) {
-    out->Append(s2_max_distance(value0.ShapeIndex(), value1.ShapeIndex()) *
-                S2Earth::RadiusMeters());
+    DistanceLine<MaxDistanceTraits>(value0, value1, &edge_pair_,
+                                    kFlagComputeDistance);
+    if (edge_pair_.is_empty()) {
+      out->AppendNull();
+    } else {
+      out->Append(edge_pair_.distance.radians() * S2Earth::RadiusMeters());
+    }
   }
+
+  EdgePair edge_pair_;
 };
 
 struct S2ShortestLineExec {

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -101,7 +101,7 @@ struct EdgePair {
   int shape_id1{-1};
   int edge_id0{-1};
   int edge_id1{-1};
-  std::pair<S2Point, S2Point> closest_points{};
+  std::pair<S2Point, S2Point> extremal_points{};
   S1ChordAngle distance{S1ChordAngle::Infinity()};
 
   /// \brief Return true if this represents an empty match
@@ -120,10 +120,11 @@ struct EdgePair {
       const GeoArrowGeography& geog0, const GeoArrowGeography& geog1) const {
     if (edge_id0 == -1) {
       auto e = geog1.native_edge(shape_id1, edge_id1);
-      return e.Interpolate(closest_points.second).Normalize(geog1.dimensions());
+      return e.Interpolate(extremal_points.second)
+          .Normalize(geog1.dimensions());
     } else if (edge_id1 == -1) {
       auto e = geog0.native_edge(shape_id0, edge_id0);
-      return e.Interpolate(closest_points.first).Normalize(geog0.dimensions());
+      return e.Interpolate(extremal_points.first).Normalize(geog0.dimensions());
     } else {
       throw Exception(
           "Can't resolve interior vertex of EdgePair where neither result is "
@@ -234,7 +235,7 @@ void DistanceLineOnlyEdgesBruteForce(const GeoArrowGeography& value0,
         out->edge_id1 = resolved1.second;
 
         out->distance = distance_candidate;
-        out->closest_points = points_candidate;
+        out->extremal_points = points_candidate;
       }
 
       return true;
@@ -252,9 +253,7 @@ void DistanceLineOnlyEdgesSemiBruteForce(const S2ShapeIndex& value0,
   S2GEOGRAPHY_DCHECK(value1.polygons()->is_empty());
 
   typename Traits::Query query0(&value0);
-  if constexpr (Traits::kHandlesInteriors) {
-    query0.mutable_options()->set_include_interiors(true);
-  }
+  query0.mutable_options()->set_include_interiors(Traits::kHandlesInteriors);
 
   int edge_id1 = -1;
   value1.VisitEdges([&](S2Shape::Edge& e1) {
@@ -295,7 +294,7 @@ void DistanceLineOnlyEdgesSemiBruteForce(const S2ShapeIndex& value0,
                 S2::GetIntersection(e1.v0, e1.v1, ce.v0(), ce.v1());
           }
 
-          out->closest_points =
+          out->extremal_points =
               std::make_pair(intersection_point, intersection_point);
         }
 
@@ -317,7 +316,7 @@ void DistanceLineOnlyEdgesSemiBruteForce(const S2ShapeIndex& value0,
 
       if (flags & kFlagComputePoints) {
         S2Shape::Edge e0 = query0.GetEdge(result0);
-        out->closest_points =
+        out->extremal_points =
             Traits::edge_pair_extremal_points(e0.v0, e0.v1, e1.v0, e1.v1);
       }
     }
@@ -328,7 +327,7 @@ void DistanceLineOnlyEdgesSemiBruteForce(const S2ShapeIndex& value0,
 
 void ClearanceLineFromPoints(const S2Point& value0, const S2Point& value1,
                              EdgePair* out) {
-  out->closest_points = std::make_pair(value0, value1);
+  out->extremal_points = std::make_pair(value0, value1);
   out->edge_id0 = 0;
   out->edge_id1 = 0;
   out->shape_id0 = 0;
@@ -344,9 +343,7 @@ void DistanceLineUsingShapeIndex(const S2ShapeIndex& value0,
   out->distance = Traits::default_distance();
 
   typename Traits::Query query0(&value0);
-  if constexpr (Traits::kHandlesInteriors) {
-    query0.mutable_options()->set_include_interiors(true);
-  }
+  query0.mutable_options()->set_include_interiors(Traits::kHandlesInteriors);
   query0.mutable_options()->set_max_results(1);
   typename Traits::Query::ShapeIndexTarget target(&value1);
 
@@ -375,12 +372,12 @@ void DistanceLineUsingShapeIndex(const S2ShapeIndex& value0,
           if (!crossing_edges.empty()) {
             auto pt = S2::GetIntersection(e0.v0, e0.v1, crossing_edges[0].v0(),
                                           crossing_edges[0].v1());
-            out->closest_points = std::make_pair(pt, pt);
+            out->extremal_points = std::make_pair(pt, pt);
             out->shape_id1 = crossing_edges[0].id().shape_id;
             out->edge_id1 = crossing_edges[0].id().edge_id;
           } else {
             // Shared vertex, no proper crossing.
-            out->closest_points = std::make_pair(e0.v0, e0.v0);
+            out->extremal_points = std::make_pair(e0.v0, e0.v0);
           }
         } else {
           // Interior match: one fully contains the other. Use a vertex from
@@ -389,7 +386,7 @@ void DistanceLineUsingShapeIndex(const S2ShapeIndex& value0,
             const S2Shape* shape = value1.shape(s);
             if (shape != nullptr && shape->num_edges() > 0) {
               S2Point pt = shape->edge(0).v0;
-              out->closest_points = std::make_pair(pt, pt);
+              out->extremal_points = std::make_pair(pt, pt);
               out->shape_id1 = s;
               out->edge_id1 = 0;
               break;
@@ -409,23 +406,44 @@ void DistanceLineUsingShapeIndex(const S2ShapeIndex& value0,
 
   if (flags & kFlagComputePoints) {
     typename Traits::Query query1(&value1);
-    if constexpr (Traits::kHandlesInteriors) {
-      query1.mutable_options()->set_include_interiors(false);
-    }
+    query1.mutable_options()->set_include_interiors(false);
     query1.mutable_options()->set_max_results(1);
     S2Shape::Edge e0 = query0.GetEdge(result0);
     typename Traits::Query::EdgeTarget target2(e0.v0, e0.v1);
     auto result1 = Traits::find_edge(query1, &target2);
-    if (result1.is_empty()) {
-      return;
+    if (!result1.is_empty()) {
+      out->edge_id1 = result1.edge_id();
+      out->shape_id1 = result1.shape_id();
+      S2Shape::Edge e1 = query1.GetEdge(result1);
+
+      out->extremal_points =
+          Traits::edge_pair_extremal_points(e0.v0, e0.v1, e1.v0, e1.v1);
+    } else {
+      // Fallback: the indexed query could not find a matching edge (can happen
+      // for near-antipodal geometries with S2FurthestEdgeQuery). Iterate over
+      // all edges in value1 to find the extremal match.
+      S1ChordAngle best_dist = Traits::default_distance();
+      for (int s = 0; s < value1.num_shape_ids(); ++s) {
+        const S2Shape* shape = value1.shape(s);
+        if (shape == nullptr) continue;
+        for (int e = 0; e < shape->num_edges(); ++e) {
+          S2Shape::Edge e1 = shape->edge(e);
+          auto points =
+              Traits::edge_pair_extremal_points(e0.v0, e0.v1, e1.v0, e1.v1);
+          S1ChordAngle d(points.first, points.second);
+          if (Traits::is_better(d, best_dist)) {
+            out->shape_id1 = s;
+            out->edge_id1 = e;
+            out->extremal_points = points;
+            best_dist = d;
+          }
+        }
+      }
+      if (out->edge_id1 < 0) {
+        *out = {};
+        return;
+      }
     }
-
-    out->edge_id1 = result1.edge_id();
-    out->shape_id1 = result1.shape_id();
-    S2Shape::Edge e1 = query1.GetEdge(result1);
-
-    out->closest_points =
-        Traits::edge_pair_extremal_points(e0.v0, e0.v1, e1.v0, e1.v1);
   }
 }
 
@@ -437,9 +455,7 @@ void DistanceLineUsingShapeIndexAndPoint(const S2ShapeIndex& value0,
   out->distance = Traits::default_distance();
 
   typename Traits::Query query0(&value0);
-  if constexpr (Traits::kHandlesInteriors) {
-    query0.mutable_options()->set_include_interiors(true);
-  }
+  query0.mutable_options()->set_include_interiors(Traits::kHandlesInteriors);
   query0.mutable_options()->set_max_results(1);
   typename Traits::Query::PointTarget target(value1);
 
@@ -460,7 +476,7 @@ void DistanceLineUsingShapeIndexAndPoint(const S2ShapeIndex& value0,
       out->edge_id1 = 0;
 
       out->distance = S1ChordAngle::Zero();
-      out->closest_points = std::make_pair(value1, value1);
+      out->extremal_points = std::make_pair(value1, value1);
       return;
     }
   }
@@ -473,7 +489,7 @@ void DistanceLineUsingShapeIndexAndPoint(const S2ShapeIndex& value0,
   out->shape_id1 = 0;
 
   S2Point p0 = Traits::project_to_edge(value1, e0.v0, e0.v1);
-  out->closest_points = std::make_pair(p0, value1);
+  out->extremal_points = std::make_pair(p0, value1);
 
   if (flags & kFlagComputeDistance) {
     out->distance = S1ChordAngle(p0, value1);
@@ -517,7 +533,7 @@ void DistanceLine(GeoArrowGeography& value0, GeoArrowGeography& value1,
                                                 *maybe_point0, out, flags);
     std::swap(out->shape_id0, out->shape_id1);
     std::swap(out->edge_id0, out->edge_id1);
-    std::swap(out->closest_points.first, out->closest_points.second);
+    std::swap(out->extremal_points.first, out->extremal_points.second);
   } else if (maybe_point1 && IsAlreadyIndexedOrLargeOrHasPolygons(value0)) {
     DistanceLineUsingShapeIndexAndPoint<Traits>(value0.ShapeIndex(),
                                                 *maybe_point1, out, flags);
@@ -533,17 +549,11 @@ void DistanceLine(GeoArrowGeography& value0, GeoArrowGeography& value1,
                                                 out, flags);
     std::swap(out->shape_id0, out->shape_id1);
     std::swap(out->edge_id0, out->edge_id1);
-    std::swap(out->closest_points.first, out->closest_points.second);
+    std::swap(out->extremal_points.first, out->extremal_points.second);
   } else {
     DistanceLineUsingShapeIndex<Traits>(value0.ShapeIndex(),
                                         value1.ShapeIndex(), out, flags);
   }
-}
-
-// Backward-compatible wrapper used by S2ClosestPointExec, S2ShortestLineExec.
-void ClearanceLine(GeoArrowGeography& value0, GeoArrowGeography& value1,
-                   EdgePair* out, int flags) {
-  DistanceLine<MinDistanceTraits>(value0, value1, out, flags);
 }
 
 struct S2ClosestPointExec {
@@ -558,7 +568,8 @@ struct S2ClosestPointExec {
     // contained and only contains XY values),
     out->SetDimensions(value0.dimensions());
 
-    ClearanceLine(value0, value1, &edge_pair_, kFlagComputePoints);
+    DistanceLine<MinDistanceTraits>(value0, value1, &edge_pair_,
+                                    kFlagComputePoints);
     if (edge_pair_.is_empty()) {
       out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_POINT);
       return;
@@ -570,7 +581,7 @@ struct S2ClosestPointExec {
     } else {
       auto native_edge =
           value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
-      v = native_edge.Interpolate(edge_pair_.closest_points.first)
+      v = native_edge.Interpolate(edge_pair_.extremal_points.first)
               .Normalize(value0.dimensions());
     }
 
@@ -586,7 +597,8 @@ struct S2DistanceExec {
   using out_t = DoubleOutputBuilder;
 
   void Exec(arg0_t::c_type value0, arg1_t::c_type value1, out_t* out) {
-    ClearanceLine(value0, value1, &edge_pair_, kFlagComputeDistance);
+    DistanceLine<MinDistanceTraits>(value0, value1, &edge_pair_,
+                                    kFlagComputeDistance);
     if (edge_pair_.is_empty()) {
       out->AppendNull();
     } else {
@@ -625,7 +637,8 @@ struct S2ShortestLineExec {
     // use the common dimensions as the output dimensionality
     out->SetDimensionsCommon(value0.dimensions(), value1.dimensions());
 
-    ClearanceLine(value0, value1, &edge_pair_, kFlagComputePoints);
+    DistanceLine<MinDistanceTraits>(value0, value1, &edge_pair_,
+                                    kFlagComputePoints);
     if (edge_pair_.is_empty()) {
       out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_LINESTRING);
       return;
@@ -646,13 +659,13 @@ struct S2ShortestLineExec {
     auto native_edge0 =
         value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
     auto native_vertex0 =
-        native_edge0.Interpolate(edge_pair_.closest_points.first)
+        native_edge0.Interpolate(edge_pair_.extremal_points.first)
             .Normalize(value0.dimensions());
 
     auto native_edge1 =
         value1.native_edge(edge_pair_.shape_id1, edge_pair_.edge_id1);
     auto native_vertex1 =
-        native_edge1.Interpolate(edge_pair_.closest_points.second)
+        native_edge1.Interpolate(edge_pair_.extremal_points.second)
             .Normalize(value1.dimensions());
 
     out->FeatureStart();
@@ -684,13 +697,13 @@ struct S2LongestLineExec {
     auto native_edge0 =
         value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
     auto native_vertex0 =
-        native_edge0.Interpolate(edge_pair_.closest_points.first)
+        native_edge0.Interpolate(edge_pair_.extremal_points.first)
             .Normalize(value0.dimensions());
 
     auto native_edge1 =
         value1.native_edge(edge_pair_.shape_id1, edge_pair_.edge_id1);
     auto native_vertex1 =
-        native_edge1.Interpolate(edge_pair_.closest_points.second)
+        native_edge1.Interpolate(edge_pair_.extremal_points.second)
             .Normalize(value1.dimensions());
 
     out->FeatureStart();

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -666,6 +666,44 @@ struct S2ShortestLineExec {
   EdgePair edge_pair_;
 };
 
+struct S2LongestLineExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = GeoArrowGeographyInputView;
+  using out_t = GeoArrowOutputBuilder;
+
+  void Exec(arg0_t::c_type value0, arg1_t::c_type value1, out_t* out) {
+    out->SetDimensionsCommon(value0.dimensions(), value1.dimensions());
+
+    DistanceLine<MaxDistanceTraits>(value0, value1, &edge_pair_,
+                                    kFlagComputePoints);
+    if (edge_pair_.is_empty()) {
+      out->AppendEmpty(GEOARROW_GEOMETRY_TYPE_LINESTRING);
+      return;
+    }
+
+    auto native_edge0 =
+        value0.native_edge(edge_pair_.shape_id0, edge_pair_.edge_id0);
+    auto native_vertex0 =
+        native_edge0.Interpolate(edge_pair_.closest_points.first)
+            .Normalize(value0.dimensions());
+
+    auto native_edge1 =
+        value1.native_edge(edge_pair_.shape_id1, edge_pair_.edge_id1);
+    auto native_vertex1 =
+        native_edge1.Interpolate(edge_pair_.closest_points.second)
+            .Normalize(value1.dimensions());
+
+    out->FeatureStart();
+    out->GeomStart(GEOARROW_GEOMETRY_TYPE_LINESTRING);
+    out->WriteCoord(native_vertex0);
+    out->WriteCoord(native_vertex1);
+    out->GeomEnd();
+    out->FeatureEnd();
+  }
+
+  EdgePair edge_pair_;
+};
+
 void ClosestPointKernel(struct SedonaCScalarKernel* out) {
   InitBinaryKernel<S2ClosestPointExec>(out, "st_closestpoint");
 }
@@ -676,8 +714,16 @@ void DistanceKernel(struct SedonaCScalarKernel* out, bool prepare_arg0_scalar,
                                    prepare_arg1_scalar);
 }
 
-void MaxDistanceKernel(struct SedonaCScalarKernel* out) {
-  InitBinaryKernel<S2MaxDistanceExec>(out, "st_maxdistance");
+void MaxDistanceKernel(struct SedonaCScalarKernel* out,
+                       bool prepare_arg0_scalar, bool prepare_arg1_scalar) {
+  InitBinaryKernel<S2MaxDistanceExec>(out, "st_maxdistance",
+                                      prepare_arg0_scalar, prepare_arg1_scalar);
+}
+
+void LongestLineKernel(struct SedonaCScalarKernel* out,
+                       bool prepare_arg0_scalar, bool prepare_arg1_scalar) {
+  InitBinaryKernel<S2LongestLineExec>(out, "st_longestline",
+                                      prepare_arg0_scalar, prepare_arg1_scalar);
 }
 
 void ShortestLineKernel(struct SedonaCScalarKernel* out,

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -419,30 +419,7 @@ void DistanceLineUsingShapeIndex(const S2ShapeIndex& value0,
       out->extremal_points =
           Traits::edge_pair_extremal_points(e0.v0, e0.v1, e1.v0, e1.v1);
     } else {
-      // Fallback: the indexed query could not find a matching edge (can happen
-      // for near-antipodal geometries with S2FurthestEdgeQuery). Iterate over
-      // all edges in value1 to find the extremal match.
-      S1ChordAngle best_dist = Traits::default_distance();
-      for (int s = 0; s < value1.num_shape_ids(); ++s) {
-        const S2Shape* shape = value1.shape(s);
-        if (shape == nullptr) continue;
-        for (int e = 0; e < shape->num_edges(); ++e) {
-          S2Shape::Edge e1 = shape->edge(e);
-          auto points =
-              Traits::edge_pair_extremal_points(e0.v0, e0.v1, e1.v0, e1.v1);
-          S1ChordAngle d(points.first, points.second);
-          if (Traits::is_better(d, best_dist)) {
-            out->shape_id1 = s;
-            out->edge_id1 = e;
-            out->extremal_points = points;
-            best_dist = d;
-          }
-        }
-      }
-      if (out->edge_id1 < 0) {
-        *out = {};
-        return;
-      }
+      throw Exception("Failed to find farthest edge pair");
     }
   }
 }

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -184,10 +184,13 @@ struct MaxDistanceTraits {
       const S2Point& a0, const S2Point& a1, const S2Point& b0,
       const S2Point& b1) {
     if (S2::CrossingSign(a0, a1, -b0, -b1) >= 0) {
-      throw Exception(
-          "Cannot compute farthest points between edges at antipodal distance "
-          "(max distance = pi)");
+      // The edges are at antipodal distance (pi). The intersection of edge
+      // (a0,a1) with the reflected edge (-b0,-b1) gives us point p on edge a;
+      // its antipode -p lies on edge b.
+      S2Point p = S2::GetIntersection(a0, a1, -b0, -b1);
+      return {p, -p};
     }
+
     std::pair<S2Point, S2Point> best{a0, b0};
     S1ChordAngle best_dist(a0, b0);
     auto check = [&](const S2Point& pa, const S2Point& pb) {
@@ -215,9 +218,8 @@ struct MaxDistanceTraits {
       S1ChordAngle max_dist = S1ChordAngle::Negative();
       S2::UpdateMaxDistance(point, a, b, &max_dist);
       if (max_dist == S1ChordAngle::Straight()) {
-        throw Exception(
-            "Cannot compute farthest point on edge at antipodal distance "
-            "(max distance = pi)");
+        // -point lies on the edge; the farthest point is its projection.
+        return S2::Project(-point, a, b);
       }
     }
     return (da > db) ? a : b;

--- a/src/s2geography/distance.h
+++ b/src/s2geography/distance.h
@@ -28,10 +28,15 @@ namespace sedona_udf {
 void DistanceKernel(struct SedonaCScalarKernel* out,
                     bool prepare_arg0_scalar = true,
                     bool prepare_arg1_scalar = true);
-void MaxDistanceKernel(struct SedonaCScalarKernel* out);
+void MaxDistanceKernel(struct SedonaCScalarKernel* out,
+                       bool prepare_arg0_scalar = true,
+                       bool prepare_arg1_scalar = true);
 void ShortestLineKernel(struct SedonaCScalarKernel* out,
                         bool prepare_arg0_scalar = true,
                         bool prepare_arg1_scalar = true);
+void LongestLineKernel(struct SedonaCScalarKernel* out,
+                       bool prepare_arg0_scalar = true,
+                       bool prepare_arg1_scalar = true);
 void ClosestPointKernel(struct SedonaCScalarKernel* out);
 
 }  // namespace sedona_udf

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -602,7 +602,38 @@ INSTANTIATE_TEST_SUITE_P(
             // Longest line
             "LINESTRING (31 30, 0 0)",
             // Closest Point
-            "POINT (30 30)"}
+            "POINT (30 30)"},
+
+        DistanceScalarScalarParam{
+            // Polygon x polygon (north pole vs south pole) ----------
+            "polygon_distance_polygon_poles",
+            "POLYGON ((-120 80, 0 80, 120 80, -120 80))",
+            "POLYGON ((-120 -80, 0 -80, 120 -80, -120 -80))",
+            // Distance
+            17791216.188397426,
+            // Max distance
+            20015118.21194711,
+            // Shortest line
+            "LINESTRING (-120 80, -120 -80)",
+            // Longest line
+            "LINESTRING (-120 80, 120 -80)",
+            // Closest Point
+            "POINT (-120 80)"},
+        DistanceScalarScalarParam{
+            // Polygon x polygon (north pole vs south pole, reversed) ----------
+            "polygon_distance_polygon_poles_rev",
+            "POLYGON ((-120 -80, 0 -80, 120 -80, -120 -80))",
+            "POLYGON ((-120 80, 0 80, 120 80, -120 80))",
+            // Distance
+            17791216.188397426,
+            // Max distance
+            20015118.21194711,
+            // Shortest line
+            "LINESTRING (-120 -80, -120 80)",
+            // Longest line
+            "LINESTRING (-120 -80, 0 80)",
+            // Closest Point
+            "POINT (-120 -80)"}
 
         ),
     [](const ::testing::TestParamInfo<DistanceScalarScalarParam>& info) {

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -211,180 +211,398 @@ INSTANTIATE_TEST_SUITE_P(
                                   std::nullopt, "LINESTRING ZM EMPTY",
                                   "LINESTRING ZM EMPTY", "POINT ZM EMPTY"},
 
-        // Point x point
         DistanceScalarScalarParam{
-            "point_distance_same_point", "POINT (0 0)", "POINT (0 0)", 0.0, 0.0,
-            "LINESTRING (0 0, 0 0)", "LINESTRING (0 0, 0 0)", "POINT (0 0)"},
-        DistanceScalarScalarParam{"point_distance_point", "POINT (0 0)",
-                                  "POINT (0 1)", 111195.10117748393,
-                                  111195.10117748393, "LINESTRING (0 0, 0 1)",
-                                  "LINESTRING (0 0, 0 1)", "POINT (0 0)"},
+            // Point x point
+            "point_distance_same_point", "POINT (0 0)", "POINT (0 0)",
+            // Distance
+            0.0,
+            // Max distance
+            0.0,
+            // Shortest line
+            "LINESTRING (0 0, 0 0)",
+            // Longest line
+            "LINESTRING (0 0, 0 0)",
+            // Closest Point
+            "POINT (0 0)"},
+        DistanceScalarScalarParam{
+            // Point x point
+            "point_distance_point", "POINT (0 0)", "POINT (0 1)",
+            // Distance
+            111195.10117748393,
+            // Max distance
+            111195.10117748393,
+            // Shortest line
+            "LINESTRING (0 0, 0 1)",
+            // Longest line
+            "LINESTRING (0 0, 0 1)",
+            // Closest Point
+            "POINT (0 0)"},
 
         DistanceScalarScalarParam{
+            // Point ZM x point ZM -------------------------
             "point_distance_point_zm", "POINT ZM (0 0 1 2)",
-            "POINT ZM (0 1 2 3)", 111195.10117748393, 111195.10117748393,
+            "POINT ZM (0 1 2 3)",
+            // Distance
+            111195.10117748393,
+            // Max distance
+            111195.10117748393,
+            // Shortest line
             "LINESTRING ZM (0 0 1 2, 0 1 2 3)",
-            "LINESTRING ZM (0 0 1 2, 0 1 2 3)", "POINT ZM (0 0 1 2)"},
+            // Longest line
+            "LINESTRING ZM (0 0 1 2, 0 1 2 3)",
+            // Closest Point
+            "POINT ZM (0 0 1 2)"},
 
         DistanceScalarScalarParam{
+            // Point Z x point Z
             "point_distance_point_z", "POINT Z (0 0 1)", "POINT Z (0 1 2)",
-            111195.10117748393, 111195.10117748393,
-            "LINESTRING Z (0 0 1, 0 1 2)", "LINESTRING Z (0 0 1, 0 1 2)",
+            // Distance
+            111195.10117748393,
+            // Max distance
+            111195.10117748393,
+            // Shortest line
+            "LINESTRING Z (0 0 1, 0 1 2)",
+            // Longest line
+            "LINESTRING Z (0 0 1, 0 1 2)",
+            // Closest Point
             "POINT Z (0 0 1)"},
 
         DistanceScalarScalarParam{
+            // Point M x point M
             "point_distance_point_m", "POINT M (0 0 2)", "POINT M (0 1 3)",
-            111195.10117748393, 111195.10117748393,
-            "LINESTRING M (0 0 2, 0 1 3)", "LINESTRING M (0 0 2, 0 1 3)",
+            // Distance
+            111195.10117748393,
+            // Max distance
+            111195.10117748393,
+            // Shortest line
+            "LINESTRING M (0 0 2, 0 1 3)",
+            // Longest line
+            "LINESTRING M (0 0 2, 0 1 3)",
+            // Closest Point
             "POINT M (0 0 2)"},
 
-        // Point x linestring (point on linestring)
-        DistanceScalarScalarParam{"point_distance_linestring_on", "POINT (0 0)",
-                                  "LINESTRING (0 0, 0 1)", 0.0,
-                                  111195.10117748393, "LINESTRING (0 0, 0 0)",
-                                  "LINESTRING (0 0, 0 1)", "POINT (0 0)"},
-        // Point x linestring (point off linestring)
         DistanceScalarScalarParam{
+            // Point x linestring (point on linestring) ----------
+            "point_distance_linestring_on", "POINT (0 0)",
+            "LINESTRING (0 0, 0 1)",
+            // Distance
+            0.0,
+            // Max distance
+            111195.10117748393,
+            // Shortest line
+            "LINESTRING (0 0, 0 0)",
+            // Longest line
+            "LINESTRING (0 0, 0 1)",
+            // Closest Point
+            "POINT (0 0)"},
+        DistanceScalarScalarParam{
+            // Point x linestring (point off linestring) ----------
             "point_distance_linestring_off", "POINT (1 0)",
-            "LINESTRING (0 0, 0 1)", 111195.10117748393, 157249.62809250789,
-            "LINESTRING (1 0, 0 0)", "LINESTRING (1 0, 0 1)", "POINT (1 0)"},
+            "LINESTRING (0 0, 0 1)",
+            // Distance
+            111195.10117748393,
+            // Max distance
+            157249.62809250789,
+            // Shortest line
+            "LINESTRING (1 0, 0 0)",
+            // Longest line
+            "LINESTRING (1 0, 0 1)",
+            // Closest Point
+            "POINT (1 0)"},
 
-        // Point x polygon (point inside)
         DistanceScalarScalarParam{
+            // Point x polygon (point inside)
             "point_distance_polygon_inside", "POINT (0.25 0.25)",
-            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0, 196566.41390163341,
-            "LINESTRING (0.25 0.25, 0.25 0.25)", "LINESTRING (0.25 0.25, 2 0)",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+            // Distance
+            0.0,
+            // Max distance
+            196566.41390163341,
+            // Shortest line
+            "LINESTRING (0.25 0.25, 0.25 0.25)",
+            // Longest line
+            "LINESTRING (0.25 0.25, 2 0)",
+            // Closest Point
             "POINT (0.25 0.25)"},
-        // Point x polygon (point on boundary)
         DistanceScalarScalarParam{
+            // Point x polygon (point on boundary)
             "point_distance_polygon_boundary", "POINT (0 0)",
-            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0, 222390.20235496786,
-            "LINESTRING (0 0, 0 0)", "LINESTRING (0 0, 2 0)", "POINT (0 0)"},
-        // Point x polygon (point outside)
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+            // Distance
+            0.0,
+            // Max distance
+            222390.20235496786,
+            // Shortest line
+            "LINESTRING (0 0, 0 0)",
+            // Longest line
+            "LINESTRING (0 0, 2 0)",
+            // Closest Point
+            "POINT (0 0)"},
         DistanceScalarScalarParam{
+            // Point x polygon (point outside)
             "point_distance_polygon_outside", "POINT (-1 0)",
-            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 111195.10117748393,
-            333585.3035324518, "LINESTRING (-1 0, 0 0)",
-            "LINESTRING (-1 0, 2 0)", "POINT (-1 0)"},
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+            // Distance
+            111195.10117748393,
+            // Max distance
+            333585.3035324518,
+            // Shortest line
+            "LINESTRING (-1 0, 0 0)",
+            // Longest line
+            "LINESTRING (-1 0, 2 0)",
+            // Closest Point
+            "POINT (-1 0)"},
 
-        // Z Point x polygon (point inside)
         DistanceScalarScalarParam{
+            // Z Point x polygon (point inside)
             "point_z_distance_polygon_inside", "POINT Z (0.25 0.25 10)",
-            "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 0.0,
-            196566.41390163341, "LINESTRING Z (0.25 0.25 10, 0.25 0.25 10)",
-            "LINESTRING Z (0.25 0.25 10, 2 0 12)", "POINT Z (0.25 0.25 10)"},
-        // Z Point x polygon (point on boundary)
+            "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))",
+            // Distance
+            0.0,
+            // Max distance
+            196566.41390163341,
+            // Shortest line
+            "LINESTRING Z (0.25 0.25 10, 0.25 0.25 10)",
+            // Longest line
+            "LINESTRING Z (0.25 0.25 10, 2 0 12)",
+            // Closest Point
+            "POINT Z (0.25 0.25 10)"},
         DistanceScalarScalarParam{
+            // Z Point x polygon (point on boundary)
             "point_z_distance_polygon_boundary", "POINT Z (0 0 10)",
-            "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 0.0,
-            222390.20235496786, "LINESTRING Z (0 0 10, 0 0 12)",
-            "LINESTRING Z (0 0 10, 2 0 12)", "POINT Z (0 0 10)"},
-        // Z Point x polygon (point outside)
+            "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))",
+            // Distance
+            0.0,
+            // Max distance
+            222390.20235496786,
+            // Shortest line
+            "LINESTRING Z (0 0 10, 0 0 12)",
+            // Longest line
+            "LINESTRING Z (0 0 10, 2 0 12)",
+            // Closest Point
+            "POINT Z (0 0 10)"},
         DistanceScalarScalarParam{
+            // Z Point x polygon (point outside)
             "point_z_distance_polygon_outside", "POINT Z (-1 0 10)",
-            "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 111195.10117748393,
-            333585.3035324518, "LINESTRING Z (-1 0 10, 0 0 12)",
-            "LINESTRING Z (-1 0 10, 2 0 12)", "POINT Z (-1 0 10)"},
+            "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))",
+            // Distance
+            111195.10117748393,
+            // Max distance
+            333585.3035324518,
+            // Shortest line
+            "LINESTRING Z (-1 0 10, 0 0 12)",
+            // Longest line
+            "LINESTRING Z (-1 0 10, 2 0 12)",
+            // Closest Point
+            "POINT Z (-1 0 10)"},
 
-        // Linestring x polygon (linestring fully inside)
         DistanceScalarScalarParam{
+            // Linestring x polygon (linestring fully inside)
             "linestring_distance_polygon_inside",
             "LINESTRING (0.25 0.25, 0.5 0.5)", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
-            0.0, 196566.41390163341, "LINESTRING (0.25 0.25, 0.25 0.25)",
-            "LINESTRING (0.25 0.25, 2 0)", "POINT (0.25 0.25)"},
-        // Polygon x linestring (linestring fully inside)
+            // Distance
+            0.0,
+            // Max distance
+            196566.41390163341,
+            // Shortest line
+            "LINESTRING (0.25 0.25, 0.25 0.25)",
+            // Longest line
+            "LINESTRING (0.25 0.25, 2 0)",
+            // Closest Point
+            "POINT (0.25 0.25)"},
         DistanceScalarScalarParam{
+            // Polygon x linestring (linestring fully inside)
             "polygon_distance_linestring_inside",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (0.25 0.25, 0.5 0.5)",
-            0.0, 196566.41390163341, "LINESTRING (0.25 0.25, 0.25 0.25)",
-            "LINESTRING (2 0, 0.25 0.25)", "POINT (0.25 0.25)"},
+            // Distance
+            0.0,
+            // Max distance
+            196566.41390163341,
+            // Shortest line
+            "LINESTRING (0.25 0.25, 0.25 0.25)",
+            // Longest line
+            "LINESTRING (2 0, 0.25 0.25)",
+            // Closest Point
+            "POINT (0.25 0.25)"},
 
-        // Linestring x polygon (linestring partially crosses boundary)
         DistanceScalarScalarParam{
+            // Linestring x polygon (linestring partially crosses boundary)
             "linestring_distance_polygon_crossing",
             "LINESTRING (0.25 0.25, 3 3)", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
-            0.0, 471653.02881023812,
+            // Distance
+            0.0,
+            // Max distance
+            471653.02881023812,
+            // Shortest line
             "LINESTRING (0.999743 1.000714, 0.999743 1.000714)",
-            "LINESTRING (3 3, 0 0)", "POINT (0.999743 1.000714)"},
-        // Polygon x linestring (linestring partially crosses boundary)
+            // Longest line
+            "LINESTRING (3 3, 0 0)",
+            // Closest Point
+            "POINT (0.999743 1.000714)"},
         DistanceScalarScalarParam{
+            // Polygon x linestring (linestring partially crosses boundary)
             "polygon_distance_linestring_crossing",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (0.25 0.25, 3 3)",
-            0.0, 471653.02881023812,
+            // Distance
+            0.0,
+            // Max distance
+            471653.02881023812,
+            // Shortest line
             "LINESTRING (0.999743 1.000714, 0.999743 1.000714)",
-            "LINESTRING (0 0, 3 3)", "POINT (0.999743 1.000714)"},
+            // Longest line
+            "LINESTRING (0 0, 3 3)",
+            // Closest Point
+            "POINT (0.999743 1.000714)"},
 
-        // Linestring x polygon (linestring crosses through, neither vertex
-        // inside)
         DistanceScalarScalarParam{
+            // Linestring x polygon (linestring crosses through, neither vertex
+            // inside)
             "linestring_distance_polygon_through", "LINESTRING (-1 0.5, 3 0.5)",
-            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0, 372880.15844616242,
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+            // Distance
+            0.0,
+            // Max distance
+            372880.15844616242,
+            // Shortest line
             "LINESTRING (1.5 0.500286, 1.5 0.500286)",
-            "LINESTRING (3 0.5, 0 2)", "POINT (1.5 0.500286)"},
-        // Polygon x linestring (linestring crosses through, neither vertex
-        // inside)
+            // Longest line
+            "LINESTRING (3 0.5, 0 2)",
+            // Closest Point
+            "POINT (1.5 0.500286)"},
         DistanceScalarScalarParam{
+            // Polygon x linestring (linestring crosses through, neither vertex
+            // inside)
             "polygon_distance_linestring_through",
-            "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (-1 0.5, 3 0.5)", 0.0,
-            372880.15844616242, "LINESTRING (1.5 0.500286, 1.5 0.500286)",
-            "LINESTRING (0 2, 3 0.5)", "POINT (1.5 0.500286)"},
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (-1 0.5, 3 0.5)",
+            // Distance
+            0.0,
+            // Max distance
+            372880.15844616242,
+            // Shortest line
+            "LINESTRING (1.5 0.500286, 1.5 0.500286)",
+            // Longest line
+            "LINESTRING (0 2, 3 0.5)",
+            // Closest Point
+            "POINT (1.5 0.500286)"},
 
-        // Linestring x polygon (linestring fully outside)
         DistanceScalarScalarParam{
+            // Linestring x polygon (linestring fully outside)
             "linestring_distance_polygon_outside", "LINESTRING (3 3, 4 4)",
-            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 314367.35908786184,
-            628758.78426786896, "LINESTRING (3 3, 0.998247 1.00221)",
-            "LINESTRING (4 4, 0 0)", "POINT (3 3)"},
-        // Polygon x linestring (linestring fully outside)
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+            // Distance
+            314367.35908786184,
+            // Max distance
+            628758.78426786896,
+            // Shortest line
+            "LINESTRING (3 3, 0.998247 1.00221)",
+            // Longest line
+            "LINESTRING (4 4, 0 0)",
+            // Closest Point
+            "POINT (3 3)"},
         DistanceScalarScalarParam{
+            // Polygon x linestring (linestring fully outside)
             "polygon_distance_linestring_outside",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (3 3, 4 4)",
-            314367.35908786184, 628758.78426786896,
-            "LINESTRING (0.998247 1.00221, 3 3)", "LINESTRING (0 0, 4 4)",
+            // Distance
+            314367.35908786184,
+            // Max distance
+            628758.78426786896,
+            // Shortest line
+            "LINESTRING (0.998247 1.00221, 3 3)",
+            // Longest line
+            "LINESTRING (0 0, 4 4)",
+            // Closest Point
             "POINT (0.998247 1.00221)"},
 
-        // Polygon x polygon (one fully inside the other)
         DistanceScalarScalarParam{
+            // Polygon x polygon (one fully inside the other)
             "polygon_distance_polygon_inside", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
-            "POLYGON ((0.1 0.1, 0.5 0.1, 0.1 0.5, 0.1 0.1))", 0.0,
-            218461.11755505961, "LINESTRING (0.1 0.1, 0.1 0.1)", std::nullopt,
+            "POLYGON ((0.1 0.1, 0.5 0.1, 0.1 0.5, 0.1 0.1))",
+            // Distance
+            0.0,
+            // Max distance
+            218461.11755505961,
+            // Shortest line
+            "LINESTRING (0.1 0.1, 0.1 0.1)",
+            // Longest line
+            "LINESTRING (2 0, 0.1 0.5)",
+            // Closest Point
             "POINT (0.1 0.1)"},
-        // Polygon x polygon (one fully inside, reversed)
         DistanceScalarScalarParam{
+            // Polygon x polygon (one fully inside, reversed)
             "polygon_distance_polygon_inside_rev",
             "POLYGON ((0.1 0.1, 0.5 0.1, 0.1 0.5, 0.1 0.1))",
-            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0, 218461.11755505961,
-            "LINESTRING (0.1 0.1, 0.1 0.1)", std::nullopt, "POINT (0.1 0.1)"},
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+            // Distance
+            0.0,
+            // Max distance
+            218461.11755505961,
+            // Shortest line
+            "LINESTRING (0.1 0.1, 0.1 0.1)",
+            // Longest line
+            "LINESTRING (0.1 0.5, 2 0)",
+            // Closest Point
+            "POINT (0.1 0.1)"},
 
-        // Polygon x polygon (partially overlapping)
-        DistanceScalarScalarParam{"polygon_distance_polygon_crossing",
-                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))",
-                                  "POLYGON ((1 0, 3 0, 1 2, 1 0))", 0.0,
-                                  400863.2536725945, "LINESTRING (2 0, 2 0)",
-                                  std::nullopt, "POINT (2 0)"},
-        // Polygon x polygon (partially overlapping, reversed)
-        DistanceScalarScalarParam{"polygon_distance_polygon_crossing_rev",
-                                  "POLYGON ((1 0, 3 0, 1 2, 1 0))",
-                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
-                                  400863.2536725945, "LINESTRING (2 0, 2 0)",
-                                  std::nullopt, "POINT (2 0)"},
+        DistanceScalarScalarParam{
+            // Polygon x polygon (partially overlapping) ----------
+            "polygon_distance_polygon_crossing",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", "POLYGON ((1 0, 3 0, 1 2, 1 0))",
+            // Distance
+            0.0,
+            // Max distance
+            400863.2536725945,
+            // Shortest line
+            "LINESTRING (2 0, 2 0)",
+            // Longest line
+            "LINESTRING (0 2, 3 0)",
+            // Closest Point
+            "POINT (2 0)"},
+        DistanceScalarScalarParam{
+            // Polygon x polygon (partially overlapping, reversed)
+            "polygon_distance_polygon_crossing_rev",
+            "POLYGON ((1 0, 3 0, 1 2, 1 0))", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+            // Distance
+            0.0,
+            // Max distance
+            400863.2536725945,
+            // Shortest line
+            "LINESTRING (2 0, 2 0)",
+            // Longest line
+            "LINESTRING (3 0, 0 2)",
+            // Closest Point
+            "POINT (2 0)"},
 
-        // Polygon x polygon (fully outside)
-        DistanceScalarScalarParam{"polygon_distance_polygon_outside",
-                                  "POLYGON ((0 0, 1 0, 0 1, 0 0))",
-                                  "POLYGON ((30 30, 31 30, 30 31, 30 30))",
-                                  4520972.0955287321, 4677959.9936393471,
-                                  "LINESTRING (0 1, 30 30)",
-                                  "LINESTRING (0 0, 31 30)",
-                                  "POINT (0 1)"},
-        // Polygon x polygon (fully outside, reversed)
-        DistanceScalarScalarParam{"polygon_distance_polygon_outside_rev",
-                                  "POLYGON ((30 30, 31 30, 30 31, 30 30))",
-                                  "POLYGON ((0 0, 1 0, 0 1, 0 0))",
-                                  4520972.0955287321, 4677959.9936393471,
-                                  "LINESTRING (30 30, 0 1)",
-                                  "LINESTRING (31 30, 0 0)",
-                                  "POINT (30 30)"}
+        DistanceScalarScalarParam{
+            // Polygon x polygon (fully outside) ----------
+            "polygon_distance_polygon_outside",
+            "POLYGON ((0 0, 1 0, 0 1, 0 0))",
+            "POLYGON ((30 30, 31 30, 30 31, 30 30))",
+            // Distance
+            4520972.0955287321,
+            // Max distance
+            4677959.9936393471,
+            // Shortest line
+            "LINESTRING (0 1, 30 30)",
+            // Longest line
+            "LINESTRING (0 0, 31 30)",
+            // Closest Point
+            "POINT (0 1)"},
+        DistanceScalarScalarParam{
+            // Polygon x polygon (fully outside, reversed) ----------
+            "polygon_distance_polygon_outside_rev",
+            "POLYGON ((30 30, 31 30, 30 31, 30 30))",
+            "POLYGON ((0 0, 1 0, 0 1, 0 0))",
+            // Distance
+            4520972.0955287321,
+            // Max distance
+            4677959.9936393471,
+            // Shortest line
+            "LINESTRING (30 30, 0 1)",
+            // Longest line
+            "LINESTRING (31 30, 0 0)",
+            // Closest Point
+            "POINT (30 30)"}
 
         ),
     [](const ::testing::TestParamInfo<DistanceScalarScalarParam>& info) {

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -44,6 +44,7 @@ struct DistanceScalarScalarParam {
   std::optional<double> expected;
   std::optional<double> expected_max_distance;
   std::optional<std::string> expected_shortest_line;
+  std::optional<std::string> expected_longest_line;
   std::optional<std::string> expected_closest_point;
 
   friend std::ostream& operator<<(std::ostream& os,
@@ -136,7 +137,8 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
       {
         struct SedonaCScalarKernel kernel;
         struct SedonaCScalarKernelImpl impl;
-        s2geography::sedona_udf::MaxDistanceKernel(&kernel);
+        s2geography::sedona_udf::MaxDistanceKernel(&kernel, prepare_arg0,
+                                                   prepare_arg1);
 
         ASSERT_NO_FATAL_FAILURE(TestInitKernel(&kernel, &impl,
                                                {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
@@ -152,6 +154,27 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
         ASSERT_NO_FATAL_FAILURE(TestResultArrow(
             out_array.get(), NANOARROW_TYPE_DOUBLE, {p.expected_max_distance}));
       }
+
+      // Test ST_LongestLine
+      {
+        struct SedonaCScalarKernel kernel;
+        struct SedonaCScalarKernelImpl impl;
+        s2geography::sedona_udf::LongestLineKernel(&kernel, prepare_arg0,
+                                                   prepare_arg1);
+
+        ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+            &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, ARROW_TYPE_WKB));
+
+        nanoarrow::UniqueArray out_array;
+        ASSERT_NO_FATAL_FAILURE(
+            TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                              {{p.lhs}, {p.rhs}}, {}, out_array.get()));
+        impl.release(&impl);
+        kernel.release(&kernel);
+
+        ASSERT_NO_FATAL_FAILURE(
+            TestResultGeography(out_array.get(), {p.expected_longest_line}));
+      }
     }
   }
 }
@@ -162,111 +185,119 @@ INSTANTIATE_TEST_SUITE_P(
         // Nulls
         DistanceScalarScalarParam{"null_distance", std::nullopt, "POINT EMPTY",
                                   std::nullopt, std::nullopt, std::nullopt,
-                                  std::nullopt},
+                                  std::nullopt, std::nullopt},
         DistanceScalarScalarParam{"distance_null", "POINT EMPTY", std::nullopt,
                                   std::nullopt, std::nullopt, std::nullopt,
-                                  std::nullopt},
+                                  std::nullopt, std::nullopt},
         DistanceScalarScalarParam{"null_distance_null", std::nullopt,
                                   std::nullopt, std::nullopt, std::nullopt,
-                                  std::nullopt, std::nullopt},
+                                  std::nullopt, std::nullopt, std::nullopt},
 
         // Empties
         DistanceScalarScalarParam{"distance_empty", "POINT (0 0)",
                                   "POINT EMPTY", std::nullopt, std::nullopt,
-                                  "LINESTRING EMPTY", "POINT EMPTY"},
+                                  "LINESTRING EMPTY", "LINESTRING EMPTY",
+                                  "POINT EMPTY"},
         DistanceScalarScalarParam{"empty_distance", "POINT EMPTY",
                                   "POINT (0 0)", std::nullopt, std::nullopt,
-                                  "LINESTRING EMPTY", "POINT EMPTY"},
+                                  "LINESTRING EMPTY", "LINESTRING EMPTY",
+                                  "POINT EMPTY"},
         DistanceScalarScalarParam{"distance_empty_zm", "POINT ZM (0 0 0 0)",
                                   "POINT ZM EMPTY", std::nullopt, std::nullopt,
-                                  "LINESTRING ZM EMPTY", "POINT ZM EMPTY"},
+                                  "LINESTRING ZM EMPTY", "LINESTRING ZM EMPTY",
+                                  "POINT ZM EMPTY"},
         DistanceScalarScalarParam{"empty_distance_zm", "POINT ZM EMPTY",
                                   "POINT ZM (0 0 0 0)", std::nullopt,
                                   std::nullopt, "LINESTRING ZM EMPTY",
-                                  "POINT ZM EMPTY"},
+                                  "LINESTRING ZM EMPTY", "POINT ZM EMPTY"},
 
         // Point x point
-        DistanceScalarScalarParam{"point_distance_same_point", "POINT (0 0)",
-                                  "POINT (0 0)", 0.0, 0.0,
-                                  "LINESTRING (0 0, 0 0)", "POINT (0 0)"},
+        DistanceScalarScalarParam{
+            "point_distance_same_point", "POINT (0 0)", "POINT (0 0)", 0.0, 0.0,
+            "LINESTRING (0 0, 0 0)", "LINESTRING (0 0, 0 0)", "POINT (0 0)"},
         DistanceScalarScalarParam{"point_distance_point", "POINT (0 0)",
                                   "POINT (0 1)", 111195.10117748393,
                                   111195.10117748393, "LINESTRING (0 0, 0 1)",
-                                  "POINT (0 0)"},
+                                  "LINESTRING (0 0, 0 1)", "POINT (0 0)"},
 
         DistanceScalarScalarParam{
             "point_distance_point_zm", "POINT ZM (0 0 1 2)",
             "POINT ZM (0 1 2 3)", 111195.10117748393, 111195.10117748393,
+            "LINESTRING ZM (0 0 1 2, 0 1 2 3)",
             "LINESTRING ZM (0 0 1 2, 0 1 2 3)", "POINT ZM (0 0 1 2)"},
 
         DistanceScalarScalarParam{
             "point_distance_point_z", "POINT Z (0 0 1)", "POINT Z (0 1 2)",
             111195.10117748393, 111195.10117748393,
-            "LINESTRING Z (0 0 1, 0 1 2)", "POINT Z (0 0 1)"},
+            "LINESTRING Z (0 0 1, 0 1 2)", "LINESTRING Z (0 0 1, 0 1 2)",
+            "POINT Z (0 0 1)"},
 
         DistanceScalarScalarParam{
             "point_distance_point_m", "POINT M (0 0 2)", "POINT M (0 1 3)",
             111195.10117748393, 111195.10117748393,
-            "LINESTRING M (0 0 2, 0 1 3)", "POINT M (0 0 2)"},
+            "LINESTRING M (0 0 2, 0 1 3)", "LINESTRING M (0 0 2, 0 1 3)",
+            "POINT M (0 0 2)"},
 
         // Point x linestring (point on linestring)
         DistanceScalarScalarParam{"point_distance_linestring_on", "POINT (0 0)",
                                   "LINESTRING (0 0, 0 1)", 0.0,
                                   111195.10117748393, "LINESTRING (0 0, 0 0)",
-                                  "POINT (0 0)"},
+                                  "LINESTRING (0 0, 0 1)", "POINT (0 0)"},
         // Point x linestring (point off linestring)
-        DistanceScalarScalarParam{"point_distance_linestring_off",
-                                  "POINT (1 0)", "LINESTRING (0 0, 0 1)",
-                                  111195.10117748393, 157249.62809250789,
-                                  "LINESTRING (1 0, 0 0)", "POINT (1 0)"},
+        DistanceScalarScalarParam{
+            "point_distance_linestring_off", "POINT (1 0)",
+            "LINESTRING (0 0, 0 1)", 111195.10117748393, 157249.62809250789,
+            "LINESTRING (1 0, 0 0)", "LINESTRING (1 0, 0 1)", "POINT (1 0)"},
 
         // Point x polygon (point inside)
         DistanceScalarScalarParam{
             "point_distance_polygon_inside", "POINT (0.25 0.25)",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0, 196566.41390163341,
-            "LINESTRING (0.25 0.25, 0.25 0.25)", "POINT (0.25 0.25)"},
+            "LINESTRING (0.25 0.25, 0.25 0.25)", "LINESTRING (0.25 0.25, 2 0)",
+            "POINT (0.25 0.25)"},
         // Point x polygon (point on boundary)
         DistanceScalarScalarParam{
             "point_distance_polygon_boundary", "POINT (0 0)",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0, 222390.20235496786,
-            "LINESTRING (0 0, 0 0)", "POINT (0 0)"},
+            "LINESTRING (0 0, 0 0)", "LINESTRING (0 0, 2 0)", "POINT (0 0)"},
         // Point x polygon (point outside)
         DistanceScalarScalarParam{
             "point_distance_polygon_outside", "POINT (-1 0)",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", 111195.10117748393,
-            333585.3035324518, "LINESTRING (-1 0, 0 0)", "POINT (-1 0)"},
+            333585.3035324518, "LINESTRING (-1 0, 0 0)",
+            "LINESTRING (-1 0, 2 0)", "POINT (-1 0)"},
 
         // Z Point x polygon (point inside)
         DistanceScalarScalarParam{
             "point_z_distance_polygon_inside", "POINT Z (0.25 0.25 10)",
             "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 0.0,
             196566.41390163341, "LINESTRING Z (0.25 0.25 10, 0.25 0.25 10)",
-            "POINT Z (0.25 0.25 10)"},
+            "LINESTRING Z (0.25 0.25 10, 2 0 12)", "POINT Z (0.25 0.25 10)"},
         // Z Point x polygon (point on boundary)
         DistanceScalarScalarParam{
             "point_z_distance_polygon_boundary", "POINT Z (0 0 10)",
             "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 0.0,
             222390.20235496786, "LINESTRING Z (0 0 10, 0 0 12)",
-            "POINT Z (0 0 10)"},
+            "LINESTRING Z (0 0 10, 2 0 12)", "POINT Z (0 0 10)"},
         // Z Point x polygon (point outside)
         DistanceScalarScalarParam{
             "point_z_distance_polygon_outside", "POINT Z (-1 0 10)",
             "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 111195.10117748393,
             333585.3035324518, "LINESTRING Z (-1 0 10, 0 0 12)",
-            "POINT Z (-1 0 10)"},
+            "LINESTRING Z (-1 0 10, 2 0 12)", "POINT Z (-1 0 10)"},
 
         // Linestring x polygon (linestring fully inside)
         DistanceScalarScalarParam{
             "linestring_distance_polygon_inside",
             "LINESTRING (0.25 0.25, 0.5 0.5)", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
             0.0, 196566.41390163341, "LINESTRING (0.25 0.25, 0.25 0.25)",
-            "POINT (0.25 0.25)"},
+            "LINESTRING (0.25 0.25, 2 0)", "POINT (0.25 0.25)"},
         // Polygon x linestring (linestring fully inside)
         DistanceScalarScalarParam{
             "polygon_distance_linestring_inside",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (0.25 0.25, 0.5 0.5)",
             0.0, 196566.41390163341, "LINESTRING (0.25 0.25, 0.25 0.25)",
-            "POINT (0.25 0.25)"},
+            "LINESTRING (2 0, 0.25 0.25)", "POINT (0.25 0.25)"},
 
         // Linestring x polygon (linestring partially crosses boundary)
         DistanceScalarScalarParam{
@@ -274,78 +305,86 @@ INSTANTIATE_TEST_SUITE_P(
             "LINESTRING (0.25 0.25, 3 3)", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
             0.0, 471653.02881023812,
             "LINESTRING (0.999743 1.000714, 0.999743 1.000714)",
-            "POINT (0.999743 1.000714)"},
+            "LINESTRING (3 3, 0 0)", "POINT (0.999743 1.000714)"},
         // Polygon x linestring (linestring partially crosses boundary)
         DistanceScalarScalarParam{
             "polygon_distance_linestring_crossing",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (0.25 0.25, 3 3)",
             0.0, 471653.02881023812,
             "LINESTRING (0.999743 1.000714, 0.999743 1.000714)",
-            "POINT (0.999743 1.000714)"},
+            "LINESTRING (0 0, 3 3)", "POINT (0.999743 1.000714)"},
 
         // Linestring x polygon (linestring crosses through, neither vertex
         // inside)
         DistanceScalarScalarParam{
             "linestring_distance_polygon_through", "LINESTRING (-1 0.5, 3 0.5)",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0, 372880.15844616242,
-            "LINESTRING (1.5 0.500286, 1.5 0.500286)", "POINT (1.5 0.500286)"},
+            "LINESTRING (1.5 0.500286, 1.5 0.500286)",
+            "LINESTRING (3 0.5, 0 2)", "POINT (1.5 0.500286)"},
         // Polygon x linestring (linestring crosses through, neither vertex
         // inside)
         DistanceScalarScalarParam{
             "polygon_distance_linestring_through",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (-1 0.5, 3 0.5)", 0.0,
             372880.15844616242, "LINESTRING (1.5 0.500286, 1.5 0.500286)",
-            "POINT (1.5 0.500286)"},
+            "LINESTRING (0 2, 3 0.5)", "POINT (1.5 0.500286)"},
 
         // Linestring x polygon (linestring fully outside)
         DistanceScalarScalarParam{
             "linestring_distance_polygon_outside", "LINESTRING (3 3, 4 4)",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", 314367.35908786184,
             628758.78426786896, "LINESTRING (3 3, 0.998247 1.00221)",
-            "POINT (3 3)"},
+            "LINESTRING (4 4, 0 0)", "POINT (3 3)"},
         // Polygon x linestring (linestring fully outside)
         DistanceScalarScalarParam{
             "polygon_distance_linestring_outside",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (3 3, 4 4)",
             314367.35908786184, 628758.78426786896,
-            "LINESTRING (0.998247 1.00221, 3 3)", "POINT (0.998247 1.00221)"},
+            "LINESTRING (0.998247 1.00221, 3 3)", "LINESTRING (0 0, 4 4)",
+            "POINT (0.998247 1.00221)"},
 
         // Polygon x polygon (one fully inside the other)
         DistanceScalarScalarParam{
             "polygon_distance_polygon_inside", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
             "POLYGON ((0.1 0.1, 0.5 0.1, 0.1 0.5, 0.1 0.1))", 0.0,
-            218461.11755505961, "LINESTRING (0.1 0.1, 0.1 0.1)",
+            218461.11755505961, "LINESTRING (0.1 0.1, 0.1 0.1)", std::nullopt,
             "POINT (0.1 0.1)"},
         // Polygon x polygon (one fully inside, reversed)
         DistanceScalarScalarParam{
             "polygon_distance_polygon_inside_rev",
             "POLYGON ((0.1 0.1, 0.5 0.1, 0.1 0.5, 0.1 0.1))",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0, 218461.11755505961,
-            "LINESTRING (0.1 0.1, 0.1 0.1)", "POINT (0.1 0.1)"},
+            "LINESTRING (0.1 0.1, 0.1 0.1)", std::nullopt, "POINT (0.1 0.1)"},
 
         // Polygon x polygon (partially overlapping)
-        DistanceScalarScalarParam{
-            "polygon_distance_polygon_crossing",
-            "POLYGON ((0 0, 2 0, 0 2, 0 0))", "POLYGON ((1 0, 3 0, 1 2, 1 0))",
-            0.0, 400863.2536725945, "LINESTRING (2 0, 2 0)", "POINT (2 0)"},
+        DistanceScalarScalarParam{"polygon_distance_polygon_crossing",
+                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+                                  "POLYGON ((1 0, 3 0, 1 2, 1 0))", 0.0,
+                                  400863.2536725945, "LINESTRING (2 0, 2 0)",
+                                  std::nullopt, "POINT (2 0)"},
         // Polygon x polygon (partially overlapping, reversed)
-        DistanceScalarScalarParam{
-            "polygon_distance_polygon_crossing_rev",
-            "POLYGON ((1 0, 3 0, 1 2, 1 0))", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
-            0.0, 400863.2536725945, "LINESTRING (2 0, 2 0)", "POINT (2 0)"},
+        DistanceScalarScalarParam{"polygon_distance_polygon_crossing_rev",
+                                  "POLYGON ((1 0, 3 0, 1 2, 1 0))",
+                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
+                                  400863.2536725945, "LINESTRING (2 0, 2 0)",
+                                  std::nullopt, "POINT (2 0)"},
 
         // Polygon x polygon (fully outside)
         DistanceScalarScalarParam{"polygon_distance_polygon_outside",
                                   "POLYGON ((0 0, 1 0, 0 1, 0 0))",
                                   "POLYGON ((30 30, 31 30, 30 31, 30 30))",
                                   4520972.0955287321, 4677959.9936393471,
-                                  "LINESTRING (0 1, 30 30)", "POINT (0 1)"},
+                                  "LINESTRING (0 1, 30 30)",
+                                  "LINESTRING (0 0, 31 30)",
+                                  "POINT (0 1)"},
         // Polygon x polygon (fully outside, reversed)
         DistanceScalarScalarParam{"polygon_distance_polygon_outside_rev",
                                   "POLYGON ((30 30, 31 30, 30 31, 30 30))",
                                   "POLYGON ((0 0, 1 0, 0 1, 0 0))",
                                   4520972.0955287321, 4677959.9936393471,
-                                  "LINESTRING (30 30, 0 1)", "POINT (30 30)"}
+                                  "LINESTRING (30 30, 0 1)",
+                                  "LINESTRING (31 30, 0 0)",
+                                  "POINT (30 30)"}
 
         ),
     [](const ::testing::TestParamInfo<DistanceScalarScalarParam>& info) {

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -42,6 +42,7 @@ struct DistanceScalarScalarParam {
   std::optional<std::string> lhs;
   std::optional<std::string> rhs;
   std::optional<double> expected;
+  std::optional<double> expected_max_distance;
   std::optional<std::string> expected_shortest_line;
   std::optional<std::string> expected_closest_point;
 
@@ -130,6 +131,27 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
         ASSERT_NO_FATAL_FAILURE(
             TestResultGeography(out_array.get(), {p.expected_closest_point}));
       }
+
+      // Test ST_MaxDistance
+      {
+        struct SedonaCScalarKernel kernel;
+        struct SedonaCScalarKernelImpl impl;
+        s2geography::sedona_udf::MaxDistanceKernel(&kernel);
+
+        ASSERT_NO_FATAL_FAILURE(TestInitKernel(&kernel, &impl,
+                                               {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                                               NANOARROW_TYPE_DOUBLE));
+
+        nanoarrow::UniqueArray out_array;
+        ASSERT_NO_FATAL_FAILURE(
+            TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                              {{p.lhs}, {p.rhs}}, {}, out_array.get()));
+        impl.release(&impl);
+        kernel.release(&kernel);
+
+        ASSERT_NO_FATAL_FAILURE(TestResultArrow(
+            out_array.get(), NANOARROW_TYPE_DOUBLE, {p.expected_max_distance}));
+      }
     }
   }
 }
@@ -139,202 +161,196 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         // Nulls
         DistanceScalarScalarParam{"null_distance", std::nullopt, "POINT EMPTY",
-                                  std::nullopt, std::nullopt, std::nullopt},
-        DistanceScalarScalarParam{"distance_null", "POINT EMPTY", std::nullopt,
-                                  std::nullopt, std::nullopt, std::nullopt},
-        DistanceScalarScalarParam{"null_distance_null", std::nullopt,
                                   std::nullopt, std::nullopt, std::nullopt,
                                   std::nullopt},
+        DistanceScalarScalarParam{"distance_null", "POINT EMPTY", std::nullopt,
+                                  std::nullopt, std::nullopt, std::nullopt,
+                                  std::nullopt},
+        DistanceScalarScalarParam{"null_distance_null", std::nullopt,
+                                  std::nullopt, std::nullopt, std::nullopt,
+                                  std::nullopt, std::nullopt},
 
         // Empties
         DistanceScalarScalarParam{"distance_empty", "POINT (0 0)",
-                                  "POINT EMPTY", std::nullopt,
+                                  "POINT EMPTY", std::nullopt, std::nullopt,
                                   "LINESTRING EMPTY", "POINT EMPTY"},
         DistanceScalarScalarParam{"empty_distance", "POINT EMPTY",
-                                  "POINT (0 0)", std::nullopt,
+                                  "POINT (0 0)", std::nullopt, std::nullopt,
                                   "LINESTRING EMPTY", "POINT EMPTY"},
         DistanceScalarScalarParam{"distance_empty_zm", "POINT ZM (0 0 0 0)",
-                                  "POINT ZM EMPTY", std::nullopt,
+                                  "POINT ZM EMPTY", std::nullopt, std::nullopt,
                                   "LINESTRING ZM EMPTY", "POINT ZM EMPTY"},
         DistanceScalarScalarParam{"empty_distance_zm", "POINT ZM EMPTY",
                                   "POINT ZM (0 0 0 0)", std::nullopt,
-                                  "LINESTRING ZM EMPTY", "POINT ZM EMPTY"},
+                                  std::nullopt, "LINESTRING ZM EMPTY",
+                                  "POINT ZM EMPTY"},
 
         // Point x point
         DistanceScalarScalarParam{"point_distance_same_point", "POINT (0 0)",
-                                  "POINT (0 0)", 0.0, "LINESTRING (0 0, 0 0)",
-                                  "POINT (0 0)"},
+                                  "POINT (0 0)", 0.0, 0.0,
+                                  "LINESTRING (0 0, 0 0)", "POINT (0 0)"},
         DistanceScalarScalarParam{"point_distance_point", "POINT (0 0)",
                                   "POINT (0 1)", 111195.10117748393,
-                                  "LINESTRING (0 0, 0 1)", "POINT (0 0)"},
+                                  111195.10117748393, "LINESTRING (0 0, 0 1)",
+                                  "POINT (0 0)"},
 
         DistanceScalarScalarParam{
             "point_distance_point_zm", "POINT ZM (0 0 1 2)",
-            "POINT ZM (0 1 2 3)", 111195.10117748393,
+            "POINT ZM (0 1 2 3)", 111195.10117748393, 111195.10117748393,
             "LINESTRING ZM (0 0 1 2, 0 1 2 3)", "POINT ZM (0 0 1 2)"},
 
-        DistanceScalarScalarParam{"point_distance_point_z", "POINT Z (0 0 1)",
-                                  "POINT Z (0 1 2)", 111195.10117748393,
-                                  "LINESTRING Z (0 0 1, 0 1 2)",
-                                  "POINT Z (0 0 1)"},
+        DistanceScalarScalarParam{
+            "point_distance_point_z", "POINT Z (0 0 1)", "POINT Z (0 1 2)",
+            111195.10117748393, 111195.10117748393,
+            "LINESTRING Z (0 0 1, 0 1 2)", "POINT Z (0 0 1)"},
 
-        DistanceScalarScalarParam{"point_distance_point_m", "POINT M (0 0 2)",
-                                  "POINT M (0 1 3)", 111195.10117748393,
-                                  "LINESTRING M (0 0 2, 0 1 3)",
-                                  "POINT M (0 0 2)"},
+        DistanceScalarScalarParam{
+            "point_distance_point_m", "POINT M (0 0 2)", "POINT M (0 1 3)",
+            111195.10117748393, 111195.10117748393,
+            "LINESTRING M (0 0 2, 0 1 3)", "POINT M (0 0 2)"},
 
         // Point x linestring (point on linestring)
         DistanceScalarScalarParam{"point_distance_linestring_on", "POINT (0 0)",
                                   "LINESTRING (0 0, 0 1)", 0.0,
-                                  "LINESTRING (0 0, 0 0)", "POINT (0 0)"},
+                                  111195.10117748393, "LINESTRING (0 0, 0 0)",
+                                  "POINT (0 0)"},
         // Point x linestring (point off linestring)
         DistanceScalarScalarParam{"point_distance_linestring_off",
                                   "POINT (1 0)", "LINESTRING (0 0, 0 1)",
-                                  111195.10117748393, "LINESTRING (1 0, 0 0)",
-                                  "POINT (1 0)"},
+                                  111195.10117748393, 157249.62809250789,
+                                  "LINESTRING (1 0, 0 0)", "POINT (1 0)"},
 
         // Point x polygon (point inside)
         DistanceScalarScalarParam{
             "point_distance_polygon_inside", "POINT (0.25 0.25)",
-            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0, 196566.41390163341,
             "LINESTRING (0.25 0.25, 0.25 0.25)", "POINT (0.25 0.25)"},
         // Point x polygon (point on boundary)
-        DistanceScalarScalarParam{"point_distance_polygon_boundary",
-                                  "POINT (0 0)",
-                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
-                                  "LINESTRING (0 0, 0 0)", "POINT (0 0)"},
+        DistanceScalarScalarParam{
+            "point_distance_polygon_boundary", "POINT (0 0)",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0, 222390.20235496786,
+            "LINESTRING (0 0, 0 0)", "POINT (0 0)"},
         // Point x polygon (point outside)
         DistanceScalarScalarParam{
             "point_distance_polygon_outside", "POINT (-1 0)",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", 111195.10117748393,
-            "LINESTRING (-1 0, 0 0)", "POINT (-1 0)"},
+            333585.3035324518, "LINESTRING (-1 0, 0 0)", "POINT (-1 0)"},
 
         // Z Point x polygon (point inside)
         DistanceScalarScalarParam{
             "point_z_distance_polygon_inside", "POINT Z (0.25 0.25 10)",
             "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 0.0,
-            "LINESTRING Z (0.25 0.25 10, 0.25 0.25 10)",
+            196566.41390163341, "LINESTRING Z (0.25 0.25 10, 0.25 0.25 10)",
             "POINT Z (0.25 0.25 10)"},
         // Z Point x polygon (point on boundary)
         DistanceScalarScalarParam{
             "point_z_distance_polygon_boundary", "POINT Z (0 0 10)",
             "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 0.0,
-            "LINESTRING Z (0 0 10, 0 0 12)", "POINT Z (0 0 10)"},
+            222390.20235496786, "LINESTRING Z (0 0 10, 0 0 12)",
+            "POINT Z (0 0 10)"},
         // Z Point x polygon (point outside)
         DistanceScalarScalarParam{
             "point_z_distance_polygon_outside", "POINT Z (-1 0 10)",
             "POLYGON Z ((0 0 12, 2 0 12, 0 2 12, 0 0 12))", 111195.10117748393,
-            "LINESTRING Z (-1 0 10, 0 0 12)", "POINT Z (-1 0 10)"},
+            333585.3035324518, "LINESTRING Z (-1 0 10, 0 0 12)",
+            "POINT Z (-1 0 10)"},
 
         // Linestring x polygon (linestring fully inside)
         DistanceScalarScalarParam{
             "linestring_distance_polygon_inside",
             "LINESTRING (0.25 0.25, 0.5 0.5)", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
-            0.0, "LINESTRING (0.25 0.25, 0.25 0.25)", "POINT (0.25 0.25)"},
+            0.0, 196566.41390163341, "LINESTRING (0.25 0.25, 0.25 0.25)",
+            "POINT (0.25 0.25)"},
         // Polygon x linestring (linestring fully inside)
         DistanceScalarScalarParam{
             "polygon_distance_linestring_inside",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (0.25 0.25, 0.5 0.5)",
-            0.0, "LINESTRING (0.25 0.25, 0.25 0.25)", "POINT (0.25 0.25)"},
+            0.0, 196566.41390163341, "LINESTRING (0.25 0.25, 0.25 0.25)",
+            "POINT (0.25 0.25)"},
 
         // Linestring x polygon (linestring partially crosses boundary)
         DistanceScalarScalarParam{
             "linestring_distance_polygon_crossing",
             "LINESTRING (0.25 0.25, 3 3)", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
-            0.0, "LINESTRING (0.999743 1.000714, 0.999743 1.000714)",
+            0.0, 471653.02881023812,
+            "LINESTRING (0.999743 1.000714, 0.999743 1.000714)",
             "POINT (0.999743 1.000714)"},
         // Polygon x linestring (linestring partially crosses boundary)
         DistanceScalarScalarParam{
             "polygon_distance_linestring_crossing",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (0.25 0.25, 3 3)",
-            0.0, "LINESTRING (0.999743 1.000714, 0.999743 1.000714)",
+            0.0, 471653.02881023812,
+            "LINESTRING (0.999743 1.000714, 0.999743 1.000714)",
             "POINT (0.999743 1.000714)"},
 
         // Linestring x polygon (linestring crosses through, neither vertex
         // inside)
         DistanceScalarScalarParam{
             "linestring_distance_polygon_through", "LINESTRING (-1 0.5, 3 0.5)",
-            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0, 372880.15844616242,
             "LINESTRING (1.5 0.500286, 1.5 0.500286)", "POINT (1.5 0.500286)"},
         // Polygon x linestring (linestring crosses through, neither vertex
         // inside)
         DistanceScalarScalarParam{
             "polygon_distance_linestring_through",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (-1 0.5, 3 0.5)", 0.0,
-            "LINESTRING (1.5 0.500286, 1.5 0.500286)", "POINT (1.5 0.500286)"},
+            372880.15844616242, "LINESTRING (1.5 0.500286, 1.5 0.500286)",
+            "POINT (1.5 0.500286)"},
 
         // Linestring x polygon (linestring fully outside)
         DistanceScalarScalarParam{
             "linestring_distance_polygon_outside", "LINESTRING (3 3, 4 4)",
             "POLYGON ((0 0, 2 0, 0 2, 0 0))", 314367.35908786184,
-            "LINESTRING (3 3, 0.998247 1.00221)", "POINT (3 3)"},
+            628758.78426786896, "LINESTRING (3 3, 0.998247 1.00221)",
+            "POINT (3 3)"},
         // Polygon x linestring (linestring fully outside)
-        DistanceScalarScalarParam{"polygon_distance_linestring_outside",
-                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))",
-                                  "LINESTRING (3 3, 4 4)", 314367.35908786184,
-                                  "LINESTRING (0.998247 1.00221, 3 3)",
-                                  "POINT (0.998247 1.00221)"},
+        DistanceScalarScalarParam{
+            "polygon_distance_linestring_outside",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", "LINESTRING (3 3, 4 4)",
+            314367.35908786184, 628758.78426786896,
+            "LINESTRING (0.998247 1.00221, 3 3)", "POINT (0.998247 1.00221)"},
 
         // Polygon x polygon (one fully inside the other)
         DistanceScalarScalarParam{
             "polygon_distance_polygon_inside", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
             "POLYGON ((0.1 0.1, 0.5 0.1, 0.1 0.5, 0.1 0.1))", 0.0,
-            "LINESTRING (0.1 0.1, 0.1 0.1)", "POINT (0.1 0.1)"},
+            218461.11755505961, "LINESTRING (0.1 0.1, 0.1 0.1)",
+            "POINT (0.1 0.1)"},
         // Polygon x polygon (one fully inside, reversed)
         DistanceScalarScalarParam{
             "polygon_distance_polygon_inside_rev",
             "POLYGON ((0.1 0.1, 0.5 0.1, 0.1 0.5, 0.1 0.1))",
-            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0, 218461.11755505961,
             "LINESTRING (0.1 0.1, 0.1 0.1)", "POINT (0.1 0.1)"},
 
         // Polygon x polygon (partially overlapping)
-        DistanceScalarScalarParam{"polygon_distance_polygon_crossing",
-                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))",
-                                  "POLYGON ((1 0, 3 0, 1 2, 1 0))", 0.0,
-                                  "LINESTRING (2 0, 2 0)", "POINT (2 0)"},
+        DistanceScalarScalarParam{
+            "polygon_distance_polygon_crossing",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", "POLYGON ((1 0, 3 0, 1 2, 1 0))",
+            0.0, 400863.2536725945, "LINESTRING (2 0, 2 0)", "POINT (2 0)"},
         // Polygon x polygon (partially overlapping, reversed)
-        DistanceScalarScalarParam{"polygon_distance_polygon_crossing_rev",
-                                  "POLYGON ((1 0, 3 0, 1 2, 1 0))",
-                                  "POLYGON ((0 0, 2 0, 0 2, 0 0))", 0.0,
-                                  "LINESTRING (2 0, 2 0)", "POINT (2 0)"},
+        DistanceScalarScalarParam{
+            "polygon_distance_polygon_crossing_rev",
+            "POLYGON ((1 0, 3 0, 1 2, 1 0))", "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+            0.0, 400863.2536725945, "LINESTRING (2 0, 2 0)", "POINT (2 0)"},
 
         // Polygon x polygon (fully outside)
         DistanceScalarScalarParam{"polygon_distance_polygon_outside",
                                   "POLYGON ((0 0, 1 0, 0 1, 0 0))",
                                   "POLYGON ((30 30, 31 30, 30 31, 30 30))",
-                                  4520972.0955287321, "LINESTRING (0 1, 30 30)",
-                                  "POINT (0 1)"},
+                                  4520972.0955287321, 4677959.9936393471,
+                                  "LINESTRING (0 1, 30 30)", "POINT (0 1)"},
         // Polygon x polygon (fully outside, reversed)
         DistanceScalarScalarParam{"polygon_distance_polygon_outside_rev",
                                   "POLYGON ((30 30, 31 30, 30 31, 30 30))",
                                   "POLYGON ((0 0, 1 0, 0 1, 0 0))",
-                                  4520972.0955287321, "LINESTRING (30 30, 0 1)",
-                                  "POINT (30 30)"}
+                                  4520972.0955287321, 4677959.9936393471,
+                                  "LINESTRING (30 30, 0 1)", "POINT (30 30)"}
 
         ),
     [](const ::testing::TestParamInfo<DistanceScalarScalarParam>& info) {
       return info.param.name;
     });
-
-TEST(Distance, SedonaUdfMaxDistance) {
-  struct SedonaCScalarKernel kernel;
-  s2geography::sedona_udf::MaxDistanceKernel(&kernel);
-  struct SedonaCScalarKernelImpl impl;
-  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
-      &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, NANOARROW_TYPE_DOUBLE));
-
-  nanoarrow::UniqueArray out_array;
-  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
-      &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
-      {{"POINT (0 0)"}, {"POINT (0 1)", "LINESTRING (0 0, 0 1)", std::nullopt}},
-      {}, out_array.get()));
-  impl.release(&impl);
-  kernel.release(&kernel);
-
-  ASSERT_NO_FATAL_FAILURE(
-      TestResultArrow(out_array.get(), NANOARROW_TYPE_DOUBLE,
-                      {111195.10117748393, 111195.10117748393, std::nullopt}));
-}
 
 TEST(Distance, SedonaUdfShortestLine) {
   struct SedonaCScalarKernel kernel;
@@ -373,4 +389,24 @@ TEST(Distance, SedonaUdfClosestPoint) {
 
   ASSERT_NO_FATAL_FAILURE(TestResultGeography(
       out_array.get(), {"POINT (0 1)", "POINT (0 0)", std::nullopt}));
+}
+
+TEST(Distance, SedonaUdfMaxDistance) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::MaxDistanceKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, NANOARROW_TYPE_DOUBLE));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
+      &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+      {{"POINT (0 0)"}, {"POINT (0 1)", "LINESTRING (0 0, 0 1)", std::nullopt}},
+      {}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(
+      TestResultArrow(out_array.get(), NANOARROW_TYPE_DOUBLE,
+                      {111195.10117748393, 111195.10117748393, std::nullopt}));
 }

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -155,8 +155,9 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
             out_array.get(), NANOARROW_TYPE_DOUBLE, {p.expected_max_distance}));
       }
 
-      // Test ST_LongestLine
-      {
+      // Test ST_LongestLine (skip when expected is nullopt with valid inputs,
+      // which indicates an antipodal case that is expected to error)
+      if (p.expected_longest_line || !p.lhs || !p.rhs) {
         struct SedonaCScalarKernel kernel;
         struct SedonaCScalarKernelImpl impl;
         s2geography::sedona_udf::LongestLineKernel(&kernel, prepare_arg0,
@@ -615,8 +616,8 @@ INSTANTIATE_TEST_SUITE_P(
             20015118.21194711,
             // Shortest line
             "LINESTRING (-120 80, -120 -80)",
-            // Longest line
-            "LINESTRING (-120 80, 120 -80)",
+            // Longest line (antipodal: max distance = pi, not yet supported)
+            std::nullopt,
             // Closest Point
             "POINT (-120 80)"},
         DistanceScalarScalarParam{
@@ -630,8 +631,8 @@ INSTANTIATE_TEST_SUITE_P(
             20015118.21194711,
             // Shortest line
             "LINESTRING (-120 -80, -120 80)",
-            // Longest line
-            "LINESTRING (-120 -80, 0 80)",
+            // Longest line (antipodal: max distance = pi, not yet supported)
+            std::nullopt,
             // Closest Point
             "POINT (-120 -80)"}
 

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -159,9 +159,8 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
             out_array.get(), NANOARROW_TYPE_DOUBLE, {p.expected_max_distance}));
       }
 
-      // Test ST_LongestLine (skip when expected is nullopt with valid inputs,
-      // which indicates an antipodal case that is expected to error)
-      if (p.expected_longest_line || !p.lhs || !p.rhs) {
+      // Test ST_LongestLine
+      {
         SCOPED_TRACE("ST_LongestLine()");
 
         struct SedonaCScalarKernel kernel;
@@ -622,8 +621,8 @@ INSTANTIATE_TEST_SUITE_P(
             20015118.21194711,
             // Shortest line
             "LINESTRING (-120 80, -120 -80)",
-            // Longest line (antipodal: max distance = pi, not yet supported)
-            std::nullopt,
+            // Longest line
+            "LINESTRING (-30 84.187176, 150 -84.187176)",
             // Closest Point
             "POINT (-120 80)"},
         DistanceScalarScalarParam{
@@ -637,8 +636,8 @@ INSTANTIATE_TEST_SUITE_P(
             20015118.21194711,
             // Shortest line
             "LINESTRING (-120 -80, -120 80)",
-            // Longest line (antipodal: max distance = pi, not yet supported)
-            std::nullopt,
+            // Longest line
+            "LINESTRING (150 -84.187176, -30 84.187176)",
             // Closest Point
             "POINT (-120 -80)"},
         DistanceScalarScalarParam{
@@ -648,13 +647,55 @@ INSTANTIATE_TEST_SUITE_P(
             // Distance
             18446595.193179362,
             // Max distance
-            20015118.21194711,
+            20015118.022076216,
             // Shortest line
             "LINESTRING (-90 -80, 0 80)",
-            // Longest line (antipodal: max distance = pi, not yet supported)
-            std::nullopt,
+            // Longest line
+            "LINESTRING (-90 -90, 90 90)",
             // Closest Point
-            "POINT (-90 -80)"}
+            "POINT (-90 -80)"},
+        DistanceScalarScalarParam{
+            // Linestring x polygon (antipodal crossing) ----------
+            "linestring_distance_polygon_poles", "LINESTRING (-90 -80, 90 -80)",
+            "POLYGON ((-120 90, 0 90, 120 90, -120 90))",
+            // Distance
+            18903167.200172286,
+            // Max distance
+            20015118.21194711,
+            // Shortest line
+            "LINESTRING (-90 -80, -120 90)",
+            // Longest line
+            "LINESTRING (75.445756 -90, -104.554244 90)",
+            // Closest Point
+            "POINT (-90 -80)"},
+        DistanceScalarScalarParam{
+            // Polygon x linestring (antipodal crossing) ----------
+            "polygon_distance_linestring_poles",
+            "POLYGON ((-120 90, 0 90, 120 90, -120 90))",
+            "LINESTRING (-90 -80, 90 -80)",
+            // Distance
+            18903167.200172286,
+            // Max distance
+            20015118.21194711,
+            // Shortest line
+            "LINESTRING (-120 90, -90 -80)",
+            // Longest line
+            "LINESTRING (-104.554244 90, 75.445756 -90)",
+            // Closest Point
+            "POINT (-120 90)"},
+        DistanceScalarScalarParam{
+            // Point x point (antipodal crossing) ----------
+            "point_distance_point_poles", "POINT (0 -90)", "POINT (0 90)",
+            // Distance
+            20015118.21194711,
+            // Max distance
+            20015118.21194711,
+            // Shortest line
+            "LINESTRING (0 -90, 0 90)",
+            // Longest line
+            "LINESTRING (0 -90, 0 90)",
+            // Closest Point
+            "POINT (0 -90)"}
 
         ),
     [](const ::testing::TestParamInfo<DistanceScalarScalarParam>& info) {

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -72,6 +72,7 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
                    ", prepare_arg1: " + std::to_string(prepare_arg1));
       // Test ST_Distance()
       {
+        SCOPED_TRACE("ST_Distance()");
         struct SedonaCScalarKernel kernel;
         struct SedonaCScalarKernelImpl impl;
         s2geography::sedona_udf::DistanceKernel(&kernel, prepare_arg0,
@@ -94,6 +95,7 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
 
       // Test ST_ShortestLine
       {
+        SCOPED_TRACE("ST_ShortestLine()");
         struct SedonaCScalarKernel kernel;
         struct SedonaCScalarKernelImpl impl;
         s2geography::sedona_udf::ShortestLineKernel(&kernel, prepare_arg0,
@@ -115,6 +117,7 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
 
       // Test ST_ClosestPoint
       {
+        SCOPED_TRACE("ST_ClosestPoint()");
         struct SedonaCScalarKernel kernel;
         struct SedonaCScalarKernelImpl impl;
         s2geography::sedona_udf::ClosestPointKernel(&kernel);
@@ -135,6 +138,7 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
 
       // Test ST_MaxDistance
       {
+        SCOPED_TRACE("ST_MaxDistance()");
         struct SedonaCScalarKernel kernel;
         struct SedonaCScalarKernelImpl impl;
         s2geography::sedona_udf::MaxDistanceKernel(&kernel, prepare_arg0,
@@ -158,6 +162,8 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
       // Test ST_LongestLine (skip when expected is nullopt with valid inputs,
       // which indicates an antipodal case that is expected to error)
       if (p.expected_longest_line || !p.lhs || !p.rhs) {
+        SCOPED_TRACE("ST_LongestLine()");
+
         struct SedonaCScalarKernel kernel;
         struct SedonaCScalarKernelImpl impl;
         s2geography::sedona_udf::LongestLineKernel(&kernel, prepare_arg0,
@@ -634,7 +640,21 @@ INSTANTIATE_TEST_SUITE_P(
             // Longest line (antipodal: max distance = pi, not yet supported)
             std::nullopt,
             // Closest Point
-            "POINT (-120 -80)"}
+            "POINT (-120 -80)"},
+        DistanceScalarScalarParam{
+            // Linestring x linestring (antipodal crossing) ----------
+            "linestring_distance_linestring_poles",
+            "LINESTRING (-90 -80, 90 -80)", "LINESTRING (0 80, 180 80)",
+            // Distance
+            18446595.193179362,
+            // Max distance
+            20015118.21194711,
+            // Shortest line
+            "LINESTRING (-90 -80, 0 80)",
+            // Longest line (antipodal: max distance = pi, not yet supported)
+            std::nullopt,
+            // Closest Point
+            "POINT (-90 -80)"}
 
         ),
     [](const ::testing::TestParamInfo<DistanceScalarScalarParam>& info) {


### PR DESCRIPTION
This PR migrates MaxDistance to use the same infrastructure as MinDistance, which allows a trivial implementation of LongestLine. This could be used to implement the cap bound/bounding circle but exporting a cap is not implemented yet so I'll leave that for a different day.

The change looks big here because it required templating everything to eliminate the duplication and adding a few items to each parameterized test case for distances. Also, antipodal point handling is hard.