### PR TITLE
feat: Add bounding UDFs and scalar rect bounder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,7 @@ if(S2GEOGRAPHY_BUILD_TESTS)
                  src/s2geography/sedona_udf/sedona_udf_internal_test.cc)
   add_executable(accessors_geog_test src/s2geography/accessors-geog_test.cc)
   add_executable(build_test src/s2geography/build_test.cc)
+  add_executable(coverings_test src/s2geography/coverings_test.cc)
   add_executable(distance_test src/s2geography/distance_test.cc)
   add_executable(geoarrow_test src/s2geography/geoarrow_test.cc)
   add_executable(geography_test src/s2geography/geography_test.cc)
@@ -396,6 +397,9 @@ if(S2GEOGRAPHY_BUILD_TESTS)
   target_link_libraries(build_test s2geography ${S2GEOGRAPHY_NANOARROW_TARGET}
                         GTest::gtest_main GTest::gmock)
   target_link_libraries(
+    coverings_test s2geography ${S2GEOGRAPHY_NANOARROW_TARGET}
+    GTest::gtest_main GTest::gmock)
+  target_link_libraries(
     distance_test s2geography ${S2GEOGRAPHY_NANOARROW_TARGET} GTest::gtest_main
     GTest::gmock)
   target_link_libraries(
@@ -418,6 +422,7 @@ if(S2GEOGRAPHY_BUILD_TESTS)
   target_include_directories(sedona_udf_internal_test PRIVATE src/vendored)
   target_include_directories(accessors_geog_test PRIVATE src/vendored)
   target_include_directories(build_test PRIVATE src/vendored)
+  target_include_directories(coverings_test PRIVATE src/vendored)
   target_include_directories(distance_test PRIVATE src/vendored)
   target_include_directories(geoarrow_test PRIVATE src/vendored)
   target_include_directories(linear_referencing_test PRIVATE src/vendored)
@@ -428,6 +433,7 @@ if(S2GEOGRAPHY_BUILD_TESTS)
   gtest_discover_tests(sedona_udf_internal_test)
   gtest_discover_tests(accessors_geog_test)
   gtest_discover_tests(build_test)
+  gtest_discover_tests(coverings_test)
   gtest_discover_tests(distance_test)
   gtest_discover_tests(geoarrow_test)
   gtest_discover_tests(linear_referencing_test)

--- a/src/s2geography/arrow_abi.h
+++ b/src/s2geography/arrow_abi.h
@@ -97,6 +97,199 @@ struct ArrowArrayStream {
 #endif  // ARROW_C_STREAM_INTERFACE
 #endif  // ARROW_FLAG_DICTIONARY_ORDERED
 
+#ifndef GEOARROW_C_ABI
+#define GEOARROW_C_ABI
+
+/// \brief Geometry type identifiers supported by GeoArrow
+/// \ingroup geoarrow-schema
+///
+/// The values of this enum are intentionally chosen to be equivalent to
+/// well-known binary type identifiers.
+enum GeoArrowGeometryType {
+  GEOARROW_GEOMETRY_TYPE_GEOMETRY = 0,
+  GEOARROW_GEOMETRY_TYPE_POINT = 1,
+  GEOARROW_GEOMETRY_TYPE_LINESTRING = 2,
+  GEOARROW_GEOMETRY_TYPE_POLYGON = 3,
+  GEOARROW_GEOMETRY_TYPE_MULTIPOINT = 4,
+  GEOARROW_GEOMETRY_TYPE_MULTILINESTRING = 5,
+  GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON = 6,
+  GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION = 7,
+  GEOARROW_GEOMETRY_TYPE_BOX = 990
+};
+
+/// \brief Dimension combinations supported by GeoArrow
+/// \ingroup geoarrow-schema
+enum GeoArrowDimensions {
+  GEOARROW_DIMENSIONS_UNKNOWN = 0,
+  GEOARROW_DIMENSIONS_XY = 1,
+  GEOARROW_DIMENSIONS_XYZ = 2,
+  GEOARROW_DIMENSIONS_XYM = 3,
+  GEOARROW_DIMENSIONS_XYZM = 4
+};
+
+/// \brief Coordinate types supported by GeoArrow
+/// \ingroup geoarrow-schema
+enum GeoArrowCoordType {
+  GEOARROW_COORD_TYPE_UNKNOWN = 0,
+  GEOARROW_COORD_TYPE_SEPARATE = 1,
+  GEOARROW_COORD_TYPE_INTERLEAVED = 2
+};
+
+/// \brief Edge types/interpolations supported by GeoArrow
+/// \ingroup geoarrow-schema
+enum GeoArrowEdgeType {
+  GEOARROW_EDGE_TYPE_PLANAR,
+  GEOARROW_EDGE_TYPE_SPHERICAL,
+  GEOARROW_EDGE_TYPE_VINCENTY,
+  GEOARROW_EDGE_TYPE_THOMAS,
+  GEOARROW_EDGE_TYPE_ANDOYER,
+  GEOARROW_EDGE_TYPE_KARNEY
+};
+
+/// \brief Coordinate reference system types supported by GeoArrow
+/// \ingroup geoarrow-schema
+enum GeoArrowCrsType {
+  GEOARROW_CRS_TYPE_NONE,
+  GEOARROW_CRS_TYPE_UNKNOWN,
+  GEOARROW_CRS_TYPE_PROJJSON,
+  GEOARROW_CRS_TYPE_WKT2_2019,
+  GEOARROW_CRS_TYPE_AUTHORITY_CODE,
+  GEOARROW_CRS_TYPE_SRID
+};
+
+/// \brief Flag to indicate that coordinates must be endian-swapped before being
+/// interpreted on the current platform
+#define GEOARROW_GEOMETRY_NODE_FLAG_SWAP_ENDIAN 0x01
+
+/// \brief Generic Geometry node representation
+///
+/// This structure represents a generic view on a geometry, inspired by
+/// DuckDB-spatial's sgl::geometry. The ownership of this struct is typically
+/// managed by a GeoArrowGeometryRoot or a generic sequence type (e.g.,
+/// std::vector). Its design allows for efficient iteration over a wide variety
+/// of underlying structures without the need for recursive structures (but
+/// allowing for recursive iteration where required).
+///
+/// A typical geometry is represented by one or more GeoArrowGeometryNodes
+/// arranged sequentially in memory depth-first such that a node is followed by
+/// its children (if any), then any remaining siblings from a common parent (if
+/// any), and so on. Nodes should be passed by pointer such that a function can
+/// iterate over children; however, function signatures should make this
+/// expectation clear.
+///
+/// This structure is packed such that it is pointer-aligned and occupies 64
+/// bytes.
+struct GeoArrowGeometryNode {
+  /// \brief Coordinate data
+  ///
+  /// Each pointer in coords points to the first coordinate in the sequence when
+  /// geometry_type is GEOARROW_GEOMETRY_TYPE_POINT or
+  /// GEOARROW_GEOMETRY_TYPE_LINESTRING ordered according to the dimensions
+  /// specified in dimensions.
+  ///
+  /// The pointers need not be aligned. The data type must be a float, double,
+  /// or signed 32-bit integer, communicated by a parent structure. Producers
+  /// should produce double coordinates unless absolutely necessary; consumers
+  /// may choose to only support double coordinates. Unless specified by a
+  /// parent structure coordinates are C doubles.
+  ///
+  /// For dimension j, it must be safe to access the range
+  /// [coords[j], coords[j] + size * stride[j] + sizeof(T)].
+  ///
+  /// The pointers in coords must never be NULL. Empty dimensions must point to
+  /// a valid address whose value is NaN (for floating point types) or the most
+  /// negative possible value (for integer types). This is true even when size
+  /// is 0 (i.e., it must always be safe to access at least one value).
+  const uint8_t* coords[4];
+
+  /// \brief Number of bytes between adjacent coordinate values in coords,
+  /// respectively
+  ///
+  /// The number of bytes to advance each pointer in coords when moving to the
+  /// next coordinate. This allow representing a wide variety of coordinate
+  /// layouts:
+  ///
+  /// - Interleaved coordinates: coord_stride is n_dimensions * sizeof(T). For
+  ///   example, interleaved XY coordinates with double precision would have
+  ///   coords set to {data, data + 8, &kNaN, &kNaN} and coord_stride set to
+  ///   {16, 16, 0, 0}
+  /// - Separated coordinates: coord_stride is sizeof(T). For example, separated
+  ///   XY coordinates would have coords set to {x, y, &kNaN, &kNaN} and
+  ///   coord_stride set to {8, 8, 0, 0}.
+  /// - A constant value: coord_stride is 0. For example, the value 30, 10 as
+  ///   a constant would have coords set to {&thirty, &ten, &kNaN, &kNaN} and
+  ///   coord_stride set to {0, 0, 0, 0}.
+  /// - WKB values with constant length packed end-to-end contiguously in memory
+  ///   (e.g., in an Arrow array as the data buffer in an Array that does not
+  ///   contain nulls): coord_stride is the size of one WKB item. For example,
+  ///   an Arrow array of XY points would have coords set to {data + 1 + 4,
+  ///   data + 1 + 4 + 8, &kNaN, &kNaN} and stride set to {21, 21, 0, 0}.
+  /// - Any of the above but reversed (by pointing to the last coordinate
+  ///   and setting the stride to a negative value).
+  int32_t coord_stride[4];
+
+  /// \brief The number of coordinates or children in this geometry
+  ///
+  /// When geometry_type is GEOARROW_GEOMETRY_TYPE_POINT or
+  /// GEOARROW_GEOMETRY_TYPE_LINESTRING, the number of coordinates in the
+  /// sequence. Otherwise, the number of child geometries.
+  uint32_t size;
+
+  /// \brief The GeoArrowGeometryType of this geometry
+  ///
+  /// For the purposes of this structure, rings of a polygon are considered a
+  /// GEOARROW_GEOMETRY_TYPE_LINESTRING. The value
+  /// GEOARROW_GEOMETRY_TYPE_UNINITIALIZED can be used to communicate an invalid
+  /// or null value but must set size to zero.
+  uint8_t geometry_type;
+
+  /// \brief The GeoArrowDimensions
+  uint8_t dimensions;
+
+  /// \brief Flags
+  ///
+  /// The only currently supported flag is
+  /// GEOARROW_GEOMETRY_NODE_FLAG_SWAP_ENDIAN to indicate that coords must be
+  /// endian-swapped before being interpreted on the current platform.
+  uint8_t flags;
+
+  /// \brief The recursion level
+  ///
+  /// A level of 0 represents the root geometry and is incremented for
+  /// child geometries (e.g., polygon ring or child of a multi geometry
+  /// or collection).
+  uint8_t level;
+
+  /// \brief User data
+  ///
+  /// The user data is an opportunity for the producer to attach additional
+  /// information to a node or for the consumer to cache information during
+  /// processing. The producer nor the consumer must not rely on the value of
+  /// this pointer for memory management (i.e., bookkeeping details must be
+  /// handled elsewhere).
+  const void* user_data;
+};
+
+/// \brief View of a geometry represented by a sequence of GeoArrowGeometryNode
+///
+/// This struct owns neither the array of nodes nor the array(s) of coordinates.
+struct GeoArrowGeometryView {
+  /// \brief A pointer to the root geometry node
+  ///
+  /// The memory is managed by the producer of the struct (e.g., a WKBReader
+  /// will hold the array of GeoArrowGeometryNode and populate this struct
+  /// to communicate the result.
+  const struct GeoArrowGeometryNode* root;
+
+  /// \brief The number of valid nodes in the root array
+  ///
+  /// This can be used when iterating over the geometry to ensure the sizes of
+  /// the children are correctly set.
+  int64_t size_nodes;
+};
+
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -160,12 +160,13 @@ S2LatLngRect LatLngRectBounder::BoundLoops(const GeoArrowGeography& value) {
     S2CopyingEdgeCrosser crosser(reference.point, north_pole, v0);
     bool contains_north_pole = reference.contained;
 
-    loop.VisitNativeVertices([&](const internal::GeoArrowVertex& v) {
-      S2LatLng ll = S2LatLng::FromDegrees(v.lat, v.lng).Normalized();
-      bounder.AddLatLng(ll);
-      contains_north_pole ^= crosser.EdgeOrVertexCrossing(ll.ToPoint());
-      return true;
-    });
+    loop.VisitNativeVertices(
+        1, loop.size() - 1, [&](const internal::GeoArrowVertex& v) {
+          S2LatLng ll = S2LatLng::FromDegrees(v.lat, v.lng).Normalized();
+          bounder.AddLatLng(ll);
+          contains_north_pole ^= crosser.EdgeOrVertexCrossing(ll.ToPoint());
+          return true;
+        });
     S2LatLngRect b = bounder.GetBound();
 
     // Check north pole containment

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -107,14 +107,13 @@ S2LatLngRect LatLngRectBounder::BoundPoints(const GeoArrowGeography& value) {
       [&](const internal::GeoArrowVertex& v) {
         S2LatLng ll = S2LatLng::FromDegrees(v.lat, v.lng).Normalized();
         xs.AddPoint(ll.lng().radians());
-        ys.AddPoint(ll.lat().degrees());
+        ys.AddPoint(ll.lat().radians());
         return true;
       });
 
-  S2LatLng lo(S1Angle::Radians(xs.lo()), S1Angle::Degrees(ys.lo()));
-  S2LatLng hi(S1Angle::Radians(xs.hi()), S1Angle::Degrees(ys.hi()));
-
-  return S2LatLngRect();
+  S2LatLng lo(S1Angle::Radians(ys.lo()), S1Angle::Radians(xs.lo()));
+  S2LatLng hi(S1Angle::Radians(ys.hi()), S1Angle::Radians(xs.hi()));
+  return S2LatLngRect(lo, hi);
 }
 
 S2LatLngRect LatLngRectBounder::BoundLines(const GeoArrowGeography& value) {

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -111,6 +111,10 @@ S2LatLngRect LatLngRectBounder::BoundPoints(const GeoArrowGeography& value) {
         return true;
       });
 
+  // Expand for error in rounding for xs. This is the explansion that takes
+  // place during the S2LatLngRectBounder's GetBound().
+  xs.Expanded(2 * DBL_EPSILON);
+
   S2LatLng lo(S1Angle::Radians(ys.lo()), S1Angle::Radians(xs.lo()));
   S2LatLng hi(S1Angle::Radians(ys.hi()), S1Angle::Radians(xs.hi()));
   return S2LatLngRect(lo, hi);

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -273,6 +273,7 @@ struct BoundingBoxExec {
   void Exec(arg0_t::c_type value, out_t* out) {
     if (value.is_empty()) {
       out->AppendNull();
+      return;
     }
 
     bounder_.Clear();
@@ -297,7 +298,7 @@ void CoveringCellIdsKernel(struct SedonaCScalarKernel* out) {
 }
 
 void BoundingBoxKernel(struct SedonaCScalarKernel* out) {
-  InitUnaryKernel<CoveringCellIdsExec>(out, "st_boundingbox");
+  InitUnaryKernel<BoundingBoxExec>(out, "st_boundingbox");
 }
 
 }  // namespace sedona_udf

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -111,9 +111,9 @@ S2LatLngRect LatLngRectBounder::BoundPoints(const GeoArrowGeography& value) {
         return true;
       });
 
-  // Expand for error in rounding for xs. This is the explansion that takes
+  // Expand for error in rounding for xs. This is the expansion that takes
   // place during the S2LatLngRectBounder's GetBound().
-  xs.Expanded(2 * DBL_EPSILON);
+  xs = xs.Expanded(2 * DBL_EPSILON);
 
   S2LatLng lo(S1Angle::Radians(ys.lo()), S1Angle::Radians(xs.lo()));
   S2LatLng hi(S1Angle::Radians(ys.hi()), S1Angle::Radians(xs.hi()));

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -257,6 +257,7 @@ struct BoundingBoxExec {
                                     DoubleOutputBuilder, DoubleOutputBuilder>;
 
   void Init(arg0_t* input, out_t* out) {
+    S2GEOGRAPHY_UNUSED(input);
     out->SetNames({"xmin", "ymin", "xmax", "ymax"});
   }
 

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -156,10 +156,11 @@ S2LatLngRect LatLngRectBounder::BoundLoops(const GeoArrowGeography& value) {
     S2LatLngRectBounder bounder;
 
     S2Point north_pole = S2Point(0, 0, 1);
-    S2Point v0 = loop.vertex(0);
-    S2CopyingEdgeCrosser crosser(reference.point, north_pole, v0);
+    internal::GeoArrowVertex nv0 = loop.native_vertex(0);
+    S2CopyingEdgeCrosser crosser(reference.point, north_pole, nv0.ToPoint());
     bool contains_north_pole = reference.contained;
 
+    bounder.AddLatLng(S2LatLng::FromDegrees(nv0.lat, nv0.lng).Normalized());
     loop.VisitNativeVertices(
         1, loop.size() - 1, [&](const internal::GeoArrowVertex& v) {
           S2LatLng ll = S2LatLng::FromDegrees(v.lat, v.lng).Normalized();
@@ -182,7 +183,7 @@ S2LatLngRect LatLngRectBounder::BoundLoops(const GeoArrowGeography& value) {
     if (b.lng().is_full()) {
       bool contains_south_pole = reference.contained;
       S2Point south_pole(0, 0, -1);
-      S2CopyingEdgeCrosser crosser(reference.point, south_pole, v0);
+      S2CopyingEdgeCrosser crosser(reference.point, south_pole, nv0.ToPoint());
       loop.VisitVertices(1, loop.size() - 1, [&](const S2Point& vertex) {
         contains_south_pole ^= crosser.EdgeOrVertexCrossing(vertex);
         return true;

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -1,6 +1,8 @@
 
 #include "s2geography/coverings.h"
 
+#include <s2/s2edge_crosser.h>
+#include <s2/s2latlng_rect_bounder.h>
 #include <s2/s2region_coverer.h>
 #include <s2/s2shape_index_buffered_region.h>
 
@@ -80,6 +82,128 @@ void s2_covering_buffered(const ShapeIndexGeography& geog,
   coverer.GetCovering(region, covering);
 }
 
+struct LatLngRectBounder {
+ public:
+  void Clear() { bounds_ = S2LatLngRect::Empty(); }
+
+  S2LatLngRect Finish() const { return bounds_; }
+
+  void Update(const GeoArrowGeography& value) {
+    if (value.is_empty()) {
+      return;
+    }
+
+    bounds_ = bounds_.Union(
+        BoundPoints(value).Union(BoundLines(value)).Union(BoundLoops(value)));
+  }
+
+ private:
+  S2LatLngRect BoundPoints(const GeoArrowGeography& value) {
+    if (value.points()->is_empty()) {
+      return S2LatLngRect::Empty();
+    }
+
+    S1Interval xs;
+    R1Interval ys;
+    value.points()->geom().VisitNativeVertices(
+        [&](const internal::GeoArrowVertex& v) {
+          S2LatLng ll = S2LatLng::FromDegrees(v.lat, v.lng).Normalized();
+          xs.AddPoint(ll.lng().radians());
+          ys.AddPoint(ll.lat().degrees());
+          return true;
+        });
+
+    S2LatLng lo(S1Angle::Radians(xs.lo()), S1Angle::Degrees(ys.lo()));
+    S2LatLng hi(S1Angle::Radians(xs.hi()), S1Angle::Degrees(ys.hi()));
+
+    return S2LatLngRect();
+  }
+
+  S2LatLngRect BoundLines(const GeoArrowGeography& value) {
+    S2LatLngRect bounds = S2LatLngRect::Empty();
+
+    value.lines()->geom().VisitChains([&](const GeoArrowChain& c) {
+      S2LatLngRectBounder bounder;
+      c.VisitNativeVertices([&](const internal::GeoArrowVertex& v) {
+        S2LatLng ll = S2LatLng::FromDegrees(v.lat, v.lng).Normalized();
+        bounder.AddLatLng(ll);
+        return true;
+      });
+      bounds = bounds.Union(bounder.GetBound());
+      return true;
+    });
+
+    return bounds;
+  }
+
+  S2LatLngRect BoundLoops(const GeoArrowGeography& value) {
+    S2LatLngRect bounds = S2LatLngRect::Empty();
+    auto reference = value.polygons()->GetReferencePoint();
+
+    // Adapted from the s2loop.cc implementation of bounding
+    value.polygons()->geom().VisitLoops(
+        &scratch_, [&](const GeoArrowLoop& loop) {
+          // Only shells contribute to the bounds of valid polygons
+          if (loop.is_hole()) {
+            return true;
+          }
+
+          // Loop through all the vertices, bounding the edges and checking
+          // for edge crossings between the reference point and the north pole.
+          // We brute force both containment checks because (1) we have to loop
+          // through all the vertices anyway and (2) in most cases we can avoid
+          // the check for south pole containment.
+          S2LatLngRectBounder bounder;
+
+          S2Point north_pole = S2Point(0, 0, 1);
+          S2Point v0 = loop.vertex(0);
+          S2CopyingEdgeCrosser crosser(reference.point, north_pole, v0);
+          bool contains_north_pole = reference.contained;
+
+          loop.VisitNativeVertices([&](const internal::GeoArrowVertex& v) {
+            S2LatLng ll = S2LatLng::FromDegrees(v.lat, v.lng).Normalized();
+            bounder.AddLatLng(ll);
+            contains_north_pole ^= crosser.EdgeOrVertexCrossing(ll.ToPoint());
+            return true;
+          });
+          S2LatLngRect b = bounder.GetBound();
+
+          // Check north pole containment
+          if (contains_north_pole) {
+            b = S2LatLngRect(R1Interval(b.lat().lo(), M_PI_2),
+                             S1Interval::Full());
+          }
+
+          // If a loop contains the south pole, then either it wraps entirely
+          // around the sphere (full longitude range), or it also contains the
+          // north pole in which case b.lng().is_full() due to the test above.
+          // Either way, we only need to do the south pole containment test if
+          // b.lng().is_full().
+          if (b.lng().is_full()) {
+            bool contains_south_pole = reference.contained;
+            S2Point south_pole(0, 0, -1);
+            S2CopyingEdgeCrosser crosser(reference.point, south_pole, v0);
+            loop.VisitVertices(1, loop.size() - 1, [&](const S2Point& vertex) {
+              contains_south_pole ^= crosser.EdgeOrVertexCrossing(vertex);
+              return true;
+            });
+
+            if (contains_south_pole) {
+              b.mutable_lat()->set_lo(-M_PI_2);
+            }
+          }
+
+          bounds = bounds.Union(b);
+          return true;
+        });
+
+    return bounds;
+  }
+
+  S2LatLngRect bounds_;
+  std::vector<S2Point> scratch_;
+};
+
 namespace sedona_udf {
 
 struct CellIdFromPointExec {
@@ -132,12 +256,43 @@ struct CoveringCellIdsExec {
   S2RegionCoverer coverer_;
 };
 
+struct BoundingBoxExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using out_t = StructOutputBuilder<DoubleOutputBuilder, DoubleOutputBuilder,
+                                    DoubleOutputBuilder, DoubleOutputBuilder>;
+
+  void Init(arg0_t* input, out_t* out) {
+    out->SetNames({"xmin", "ymin", "xmax", "ymax"});
+  }
+
+  void Exec(arg0_t::c_type value, out_t* out) {
+    if (value.is_empty()) {
+      out->AppendNull();
+    }
+
+    bounder_.Clear();
+    bounder_.Update(value);
+    S2LatLngRect bounds = bounder_.Finish();
+    out->field<0>().Append(bounds.lng_lo().degrees());
+    out->field<1>().Append(bounds.lat_lo().degrees());
+    out->field<2>().Append(bounds.lng_hi().degrees());
+    out->field<3>().Append(bounds.lat_hi().degrees());
+    out->Append();
+  }
+
+  LatLngRectBounder bounder_;
+};
+
 void CellIdFromPointKernel(struct SedonaCScalarKernel* out) {
   InitUnaryKernel<CellIdFromPointExec>(out, "s2_cellidfrompoint");
 }
 
 void CoveringCellIdsKernel(struct SedonaCScalarKernel* out) {
   InitUnaryKernel<CoveringCellIdsExec>(out, "s2_coveringcellids");
+}
+
+void BoundingBoxKernel(struct SedonaCScalarKernel* out) {
+  InitUnaryKernel<CoveringCellIdsExec>(out, "st_boundingbox");
 }
 
 }  // namespace sedona_udf

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -231,15 +231,24 @@ struct CoveringCellIdsExec {
       return;
     }
 
-    coverer_.mutable_options()->set_max_cells(8);
-    covering_.clear();
-
-    for (const S2CellId id : value.Covering()) {
-      covering_.push_back(id);
+    // Canonically consider the S2CellId of a Point to be
+    // its covering. Otherwise we get funny coverings for points
+    // (no need to have four cells for a single point).
+    auto pt = value.Point();
+    if (pt) {
+      S2CellId id(*pt);
+      out->items().Append(static_cast<int64_t>(id.id()));
+      out->Append();
+      return;
     }
 
-    coverer_.CanonicalizeCovering(&covering_);
-
+    // For now, don't make any attempt to optimize calculating this.
+    // This will build a shape index for each item and may be slow.
+    // We may want to consider just implementing S2Region for the
+    // GeoArrowGeography.
+    coverer_.mutable_options()->set_max_cells(8);
+    covering_.clear();
+    coverer_.GetCovering(*value.Region(), &covering_);
     for (const S2CellId id : covering_) {
       out->items().Append(static_cast<int64_t>(id.id()));
     }

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -6,6 +6,8 @@
 #include <s2/s2region_coverer.h>
 #include <s2/s2shape_index_buffered_region.h>
 
+#include <cfloat>
+
 #include "s2geography/accessors-geog.h"
 #include "s2geography/accessors.h"
 #include "s2geography/geoarrow-geography.h"
@@ -143,8 +145,8 @@ S2LatLngRect LatLngRectBounder::BoundLoops(const GeoArrowGeography& value) {
 
   // Adapted from the s2loop.cc implementation of bounding
   value.polygons()->geom().VisitLoops(&scratch_, [&](const GeoArrowLoop& loop) {
-    // Only shells contribute to the bounds of valid polygons
-    if (loop.is_hole()) {
+    // Only non-empty shells contribute to the bounds of valid polygons
+    if (loop.is_hole() || loop.size() == 0) {
       return true;
     }
 

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -8,6 +8,7 @@
 
 #include "s2geography/accessors-geog.h"
 #include "s2geography/accessors.h"
+#include "s2geography/geoarrow-geography.h"
 #include "s2geography/geography.h"
 #include "s2geography/sedona_udf/sedona_udf_internal.h"
 
@@ -82,127 +83,118 @@ void s2_covering_buffered(const ShapeIndexGeography& geog,
   coverer.GetCovering(region, covering);
 }
 
-struct LatLngRectBounder {
- public:
-  void Clear() { bounds_ = S2LatLngRect::Empty(); }
+void LatLngRectBounder::Clear() { bounds_ = S2LatLngRect::Empty(); }
 
-  S2LatLngRect Finish() const { return bounds_; }
+S2LatLngRect LatLngRectBounder::Finish() const { return bounds_; }
 
-  void Update(const GeoArrowGeography& value) {
-    if (value.is_empty()) {
-      return;
-    }
-
-    bounds_ = bounds_.Union(
-        BoundPoints(value).Union(BoundLines(value)).Union(BoundLoops(value)));
+void LatLngRectBounder::Update(const GeoArrowGeography& value) {
+  if (value.is_empty()) {
+    return;
   }
 
- private:
-  S2LatLngRect BoundPoints(const GeoArrowGeography& value) {
-    if (value.points()->is_empty()) {
-      return S2LatLngRect::Empty();
-    }
+  bounds_ = bounds_.Union(
+      BoundPoints(value).Union(BoundLines(value)).Union(BoundLoops(value)));
+}
 
-    S1Interval xs;
-    R1Interval ys;
-    value.points()->geom().VisitNativeVertices(
-        [&](const internal::GeoArrowVertex& v) {
-          S2LatLng ll = S2LatLng::FromDegrees(v.lat, v.lng).Normalized();
-          xs.AddPoint(ll.lng().radians());
-          ys.AddPoint(ll.lat().degrees());
-          return true;
-        });
-
-    S2LatLng lo(S1Angle::Radians(xs.lo()), S1Angle::Degrees(ys.lo()));
-    S2LatLng hi(S1Angle::Radians(xs.hi()), S1Angle::Degrees(ys.hi()));
-
-    return S2LatLngRect();
+S2LatLngRect LatLngRectBounder::BoundPoints(const GeoArrowGeography& value) {
+  if (value.points()->is_empty()) {
+    return S2LatLngRect::Empty();
   }
 
-  S2LatLngRect BoundLines(const GeoArrowGeography& value) {
-    S2LatLngRect bounds = S2LatLngRect::Empty();
-
-    value.lines()->geom().VisitChains([&](const GeoArrowChain& c) {
-      S2LatLngRectBounder bounder;
-      c.VisitNativeVertices([&](const internal::GeoArrowVertex& v) {
+  S1Interval xs;
+  R1Interval ys;
+  value.points()->geom().VisitNativeVertices(
+      [&](const internal::GeoArrowVertex& v) {
         S2LatLng ll = S2LatLng::FromDegrees(v.lat, v.lng).Normalized();
-        bounder.AddLatLng(ll);
+        xs.AddPoint(ll.lng().radians());
+        ys.AddPoint(ll.lat().degrees());
         return true;
       });
-      bounds = bounds.Union(bounder.GetBound());
+
+  S2LatLng lo(S1Angle::Radians(xs.lo()), S1Angle::Degrees(ys.lo()));
+  S2LatLng hi(S1Angle::Radians(xs.hi()), S1Angle::Degrees(ys.hi()));
+
+  return S2LatLngRect();
+}
+
+S2LatLngRect LatLngRectBounder::BoundLines(const GeoArrowGeography& value) {
+  S2LatLngRect bounds = S2LatLngRect::Empty();
+
+  value.lines()->geom().VisitChains([&](const GeoArrowChain& c) {
+    S2LatLngRectBounder bounder;
+    c.VisitNativeVertices([&](const internal::GeoArrowVertex& v) {
+      S2LatLng ll = S2LatLng::FromDegrees(v.lat, v.lng).Normalized();
+      bounder.AddLatLng(ll);
       return true;
     });
+    bounds = bounds.Union(bounder.GetBound());
+    return true;
+  });
 
-    return bounds;
-  }
+  return bounds;
+}
 
-  S2LatLngRect BoundLoops(const GeoArrowGeography& value) {
-    S2LatLngRect bounds = S2LatLngRect::Empty();
-    auto reference = value.polygons()->GetReferencePoint();
+S2LatLngRect LatLngRectBounder::BoundLoops(const GeoArrowGeography& value) {
+  S2LatLngRect bounds = S2LatLngRect::Empty();
+  auto reference = value.polygons()->GetReferencePoint();
 
-    // Adapted from the s2loop.cc implementation of bounding
-    value.polygons()->geom().VisitLoops(
-        &scratch_, [&](const GeoArrowLoop& loop) {
-          // Only shells contribute to the bounds of valid polygons
-          if (loop.is_hole()) {
-            return true;
-          }
+  // Adapted from the s2loop.cc implementation of bounding
+  value.polygons()->geom().VisitLoops(&scratch_, [&](const GeoArrowLoop& loop) {
+    // Only shells contribute to the bounds of valid polygons
+    if (loop.is_hole()) {
+      return true;
+    }
 
-          // Loop through all the vertices, bounding the edges and checking
-          // for edge crossings between the reference point and the north pole.
-          // We brute force both containment checks because (1) we have to loop
-          // through all the vertices anyway and (2) in most cases we can avoid
-          // the check for south pole containment.
-          S2LatLngRectBounder bounder;
+    // Loop through all the vertices, bounding the edges and checking
+    // for edge crossings between the reference point and the north pole.
+    // We brute force both containment checks because (1) we have to loop
+    // through all the vertices anyway and (2) in most cases we can avoid
+    // the check for south pole containment.
+    S2LatLngRectBounder bounder;
 
-          S2Point north_pole = S2Point(0, 0, 1);
-          S2Point v0 = loop.vertex(0);
-          S2CopyingEdgeCrosser crosser(reference.point, north_pole, v0);
-          bool contains_north_pole = reference.contained;
+    S2Point north_pole = S2Point(0, 0, 1);
+    S2Point v0 = loop.vertex(0);
+    S2CopyingEdgeCrosser crosser(reference.point, north_pole, v0);
+    bool contains_north_pole = reference.contained;
 
-          loop.VisitNativeVertices([&](const internal::GeoArrowVertex& v) {
-            S2LatLng ll = S2LatLng::FromDegrees(v.lat, v.lng).Normalized();
-            bounder.AddLatLng(ll);
-            contains_north_pole ^= crosser.EdgeOrVertexCrossing(ll.ToPoint());
-            return true;
-          });
-          S2LatLngRect b = bounder.GetBound();
+    loop.VisitNativeVertices([&](const internal::GeoArrowVertex& v) {
+      S2LatLng ll = S2LatLng::FromDegrees(v.lat, v.lng).Normalized();
+      bounder.AddLatLng(ll);
+      contains_north_pole ^= crosser.EdgeOrVertexCrossing(ll.ToPoint());
+      return true;
+    });
+    S2LatLngRect b = bounder.GetBound();
 
-          // Check north pole containment
-          if (contains_north_pole) {
-            b = S2LatLngRect(R1Interval(b.lat().lo(), M_PI_2),
-                             S1Interval::Full());
-          }
+    // Check north pole containment
+    if (contains_north_pole) {
+      b = S2LatLngRect(R1Interval(b.lat().lo(), M_PI_2), S1Interval::Full());
+    }
 
-          // If a loop contains the south pole, then either it wraps entirely
-          // around the sphere (full longitude range), or it also contains the
-          // north pole in which case b.lng().is_full() due to the test above.
-          // Either way, we only need to do the south pole containment test if
-          // b.lng().is_full().
-          if (b.lng().is_full()) {
-            bool contains_south_pole = reference.contained;
-            S2Point south_pole(0, 0, -1);
-            S2CopyingEdgeCrosser crosser(reference.point, south_pole, v0);
-            loop.VisitVertices(1, loop.size() - 1, [&](const S2Point& vertex) {
-              contains_south_pole ^= crosser.EdgeOrVertexCrossing(vertex);
-              return true;
-            });
+    // If a loop contains the south pole, then either it wraps entirely
+    // around the sphere (full longitude range), or it also contains the
+    // north pole in which case b.lng().is_full() due to the test above.
+    // Either way, we only need to do the south pole containment test if
+    // b.lng().is_full().
+    if (b.lng().is_full()) {
+      bool contains_south_pole = reference.contained;
+      S2Point south_pole(0, 0, -1);
+      S2CopyingEdgeCrosser crosser(reference.point, south_pole, v0);
+      loop.VisitVertices(1, loop.size() - 1, [&](const S2Point& vertex) {
+        contains_south_pole ^= crosser.EdgeOrVertexCrossing(vertex);
+        return true;
+      });
 
-            if (contains_south_pole) {
-              b.mutable_lat()->set_lo(-M_PI_2);
-            }
-          }
+      if (contains_south_pole) {
+        b.mutable_lat()->set_lo(-M_PI_2);
+      }
+    }
 
-          bounds = bounds.Union(b);
-          return true;
-        });
+    bounds = bounds.Union(b);
+    return true;
+  });
 
-    return bounds;
-  }
-
-  S2LatLngRect bounds_;
-  std::vector<S2Point> scratch_;
-};
+  return bounds;
+}
 
 namespace sedona_udf {
 

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -7,6 +7,7 @@
 #include "s2geography/accessors-geog.h"
 #include "s2geography/accessors.h"
 #include "s2geography/geography.h"
+#include "s2geography/sedona_udf/sedona_udf_internal.h"
 
 namespace s2geography {
 
@@ -78,5 +79,67 @@ void s2_covering_buffered(const ShapeIndexGeography& geog,
                                     S1ChordAngle::Radians(distance_radians));
   coverer.GetCovering(region, covering);
 }
+
+namespace sedona_udf {
+
+struct CellIdFromPointExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using out_t = IntOutputBuilder;
+
+  void Exec(arg0_t::c_type value, out_t* out) {
+    if (value.is_empty()) {
+      out->AppendNull();
+      return;
+    }
+
+    auto pt = value.Point();
+    if (!pt) {
+      throw Exception("Can't compute point cell ID from a non-point geography");
+    }
+
+    S2CellId id(*pt);
+    out->Append(static_cast<int64_t>(id.id()));
+  }
+};
+
+struct CoveringCellIdsExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using out_t = ListOutputBuilder<IntOutputBuilder>;
+
+  void Exec(arg0_t::c_type value, out_t* out) {
+    if (value.is_empty()) {
+      out->Append();
+      return;
+    }
+
+    coverer_.mutable_options()->set_max_cells(8);
+    covering_.clear();
+
+    for (const S2CellId id : value.Covering()) {
+      covering_.push_back(id);
+    }
+
+    coverer_.CanonicalizeCovering(&covering_);
+
+    for (const S2CellId id : covering_) {
+      out->items().Append(static_cast<int64_t>(id.id()));
+    }
+
+    out->Append();
+  }
+
+  std::vector<S2CellId> covering_;
+  S2RegionCoverer coverer_;
+};
+
+void CellIdFromPointKernel(struct SedonaCScalarKernel* out) {
+  InitUnaryKernel<CellIdFromPointExec>(out, "s2_cellidfrompoint");
+}
+
+void CoveringCellIdsKernel(struct SedonaCScalarKernel* out) {
+  InitUnaryKernel<CoveringCellIdsExec>(out, "s2_coveringcellids");
+}
+
+}  // namespace sedona_udf
 
 }  // namespace s2geography

--- a/src/s2geography/coverings.h
+++ b/src/s2geography/coverings.h
@@ -1,11 +1,29 @@
 
 #pragma once
 
+#include <s2/s2latlng_rect.h>
 #include <s2/s2region_coverer.h>
 
 #include "s2geography/geography.h"
 
 namespace s2geography {
+
+class GeoArrowGeography;
+
+class LatLngRectBounder {
+ public:
+  void Clear();
+  S2LatLngRect Finish() const;
+  void Update(const GeoArrowGeography& value);
+
+ private:
+  S2LatLngRect BoundPoints(const GeoArrowGeography& value);
+  S2LatLngRect BoundLines(const GeoArrowGeography& value);
+  S2LatLngRect BoundLoops(const GeoArrowGeography& value);
+
+  S2LatLngRect bounds_;
+  std::vector<S2Point> scratch_;
+};
 
 S2Point s2_point_on_surface(const Geography& geog, S2RegionCoverer& coverer);
 void s2_covering(const Geography& geog, std::vector<S2CellId>* covering,

--- a/src/s2geography/coverings.h
+++ b/src/s2geography/coverings.h
@@ -41,6 +41,7 @@ namespace sedona_udf {
 
 void CellIdFromPointKernel(struct SedonaCScalarKernel* out);
 void CoveringCellIdsKernel(struct SedonaCScalarKernel* out);
+void BoundingBoxKernel(struct SedonaCScalarKernel* out);
 
 }  // namespace sedona_udf
 

--- a/src/s2geography/coverings.h
+++ b/src/s2geography/coverings.h
@@ -5,6 +5,7 @@
 #include <s2/s2region_coverer.h>
 
 #include "s2geography/geography.h"
+#include "s2geography/sedona_udf/sedona_extension.h"
 
 namespace s2geography {
 
@@ -35,5 +36,11 @@ void s2_covering_buffered(const ShapeIndexGeography& geog,
                           double distance_radians,
                           std::vector<S2CellId>* covering,
                           S2RegionCoverer& coverer);
+
+namespace sedona_udf {
+
+void CellIdFromPointKernel(struct SedonaCScalarKernel* out);
+
+}  // namespace sedona_udf
 
 }  // namespace s2geography

--- a/src/s2geography/coverings.h
+++ b/src/s2geography/coverings.h
@@ -4,12 +4,11 @@
 #include <s2/s2latlng_rect.h>
 #include <s2/s2region_coverer.h>
 
+#include "s2geography/geoarrow-geography.h"
 #include "s2geography/geography.h"
 #include "s2geography/sedona_udf/sedona_extension.h"
 
 namespace s2geography {
-
-class GeoArrowGeography;
 
 class LatLngRectBounder {
  public:

--- a/src/s2geography/coverings.h
+++ b/src/s2geography/coverings.h
@@ -40,6 +40,7 @@ void s2_covering_buffered(const ShapeIndexGeography& geog,
 namespace sedona_udf {
 
 void CellIdFromPointKernel(struct SedonaCScalarKernel* out);
+void CoveringCellIdsKernel(struct SedonaCScalarKernel* out);
 
 }  // namespace sedona_udf
 

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -1,0 +1,145 @@
+#include "s2geography/coverings.h"
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string>
+
+#include "s2geography/geoarrow-geography.h"
+#include "s2geography/sedona_udf/sedona_udf_test_internal.h"
+
+using namespace s2geography;
+
+// Test parameter structure for LatLngRectBounder
+struct LatLngRectBounderParam {
+  std::string name;
+  std::string wkt;
+  std::optional<double> xmin;
+  std::optional<double> ymin;
+  std::optional<double> xmax;
+  std::optional<double> ymax;
+
+
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const LatLngRectBounderParam& p) {
+    os << p.name;
+    return os;
+  }
+};
+
+class LatLngRectBounderTest
+    : public ::testing::TestWithParam<LatLngRectBounderParam> {};
+
+TEST_P(LatLngRectBounderTest, Bounds) {
+  const auto& p = GetParam();
+
+  auto test_geom = TestGeometry::FromWKT(p.wkt);
+  GeoArrowGeography geog;
+  geog.Init(test_geom.geom());
+
+  LatLngRectBounder bounder;
+  bounder.Clear();
+  bounder.Update(geog);
+  S2LatLngRect bounds = bounder.Finish();
+
+  if (!p.xmin.has_value()) {
+    // Expect empty bounds
+    EXPECT_TRUE(bounds.is_empty()) << "Expected empty bounds for " << p.wkt;
+  } else {
+    EXPECT_FALSE(bounds.is_empty()) << "Expected non-empty bounds for " << p.wkt;
+
+    // Use larger tolerance for polygons due to geodesic edge bulging
+    constexpr double kTolerance = 0.1;  // degrees
+    EXPECT_NEAR(bounds.lng_lo().degrees(), *p.xmin, kTolerance)
+        << "xmin mismatch for " << p.wkt;
+    EXPECT_NEAR(bounds.lat_lo().degrees(), *p.ymin, kTolerance)
+        << "ymin mismatch for " << p.wkt;
+    EXPECT_NEAR(bounds.lng_hi().degrees(), *p.xmax, kTolerance)
+        << "xmax mismatch for " << p.wkt;
+    EXPECT_NEAR(bounds.lat_hi().degrees(), *p.ymax, kTolerance)
+        << "ymax mismatch for " << p.wkt;
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Coverings, LatLngRectBounderTest,
+    ::testing::Values(
+        // Empty geometries
+        LatLngRectBounderParam{"point_empty", "POINT EMPTY", std::nullopt,
+                               std::nullopt, std::nullopt, std::nullopt},
+        LatLngRectBounderParam{"linestring_empty", "LINESTRING EMPTY",
+                               std::nullopt, std::nullopt, std::nullopt,
+                               std::nullopt},
+        LatLngRectBounderParam{"polygon_empty", "POLYGON EMPTY", std::nullopt,
+                               std::nullopt, std::nullopt, std::nullopt},
+
+        // Points
+        LatLngRectBounderParam{"point_origin", "POINT (0 0)", 0.0, 0.0, 0.0,
+                               0.0},
+        LatLngRectBounderParam{"point_positive", "POINT (10 20)", 10.0, 20.0,
+                               10.0, 20.0},
+        LatLngRectBounderParam{"point_negative", "POINT (-30 -40)", -30.0,
+                               -40.0, -30.0, -40.0},
+
+        // MultiPoints
+        LatLngRectBounderParam{"multipoint_two", "MULTIPOINT ((0 0), (10 20))",
+                               0.0, 0.0, 10.0, 20.0},
+        LatLngRectBounderParam{
+            "multipoint_spanning", "MULTIPOINT ((-10 -20), (30 40))", -10.0,
+            -20.0, 30.0, 40.0},
+
+        // LineStrings
+        LatLngRectBounderParam{"linestring_horizontal",
+                               "LINESTRING (0 0, 10 0)", 0.0, 0.0, 10.0, 0.0},
+        LatLngRectBounderParam{"linestring_vertical", "LINESTRING (0 0, 0 10)",
+                               0.0, 0.0, 0.0, 10.0},
+        LatLngRectBounderParam{"linestring_diagonal",
+                               "LINESTRING (0 0, 10 10)", 0.0, 0.0, 10.0, 10.0},
+
+        // Polygons (simple cases)
+        LatLngRectBounderParam{"triangle", "POLYGON ((0 0, 10 0, 5 10, 0 0))",
+                               0.0, 0.0, 10.0, 10.0},
+        LatLngRectBounderParam{"square", "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))",
+                               0.0, 0.0, 10.0, 10.0}));
+
+// Test that Clear() resets state properly
+TEST(LatLngRectBounderTest, ClearResetsState) {
+  auto test_geom = TestGeometry::FromWKT("POINT (10 20)");
+  GeoArrowGeography geog;
+  geog.Init(test_geom.geom());
+
+  LatLngRectBounder bounder;
+  bounder.Clear();
+  bounder.Update(geog);
+
+  S2LatLngRect bounds1 = bounder.Finish();
+  ASSERT_FALSE(bounds1.is_empty());
+
+  // Clear and verify it's empty again
+  bounder.Clear();
+  S2LatLngRect bounds2 = bounder.Finish();
+  EXPECT_TRUE(bounds2.is_empty());
+}
+
+// Test that multiple Update() calls accumulate bounds
+TEST(LatLngRectBounderTest, AccumulatesBounds) {
+  auto geom1 = TestGeometry::FromWKT("POINT (0 0)");
+  auto geom2 = TestGeometry::FromWKT("POINT (10 20)");
+
+  GeoArrowGeography geog1, geog2;
+  geog1.Init(geom1.geom());
+  geog2.Init(geom2.geom());
+
+  LatLngRectBounder bounder;
+  bounder.Clear();
+  bounder.Update(geog1);
+  bounder.Update(geog2);
+  S2LatLngRect bounds = bounder.Finish();
+
+  constexpr double kTolerance = 1e-6;
+  EXPECT_NEAR(bounds.lng_lo().degrees(), 0.0, kTolerance);
+  EXPECT_NEAR(bounds.lat_lo().degrees(), 0.0, kTolerance);
+  EXPECT_NEAR(bounds.lng_hi().degrees(), 10.0, kTolerance);
+  EXPECT_NEAR(bounds.lat_hi().degrees(), 20.0, kTolerance);
+}

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -214,10 +214,9 @@ TEST(Coverings, SedonaUdfCoveringCellIdsArray) {
   EXPECT_EQ(offsets[1] - offsets[0], 1);
   // Row 1: POINT (0 1) - should have 1 cell
   EXPECT_EQ(offsets[2] - offsets[1], 1);
-  // Row 2: LINESTRING (0 0, 100 50) - should have multiple cells
+  // Row 2: LINESTRING (0 0, 100 50) - should have max_cells
   int linestring_cells = offsets[3] - offsets[2];
-  EXPECT_GE(linestring_cells, 1);
-  EXPECT_LE(linestring_cells, 8);  // max_cells is 8
+  EXPECT_EQ(linestring_cells, 8);
   // Row 3: POINT EMPTY - should have 0 cells
   EXPECT_EQ(offsets[4] - offsets[3], 0);
   // Row 4: null - should have 0 cells
@@ -231,23 +230,14 @@ TEST(Coverings, SedonaUdfCoveringCellIdsArray) {
   ASSERT_NE(child->buffers[1], nullptr);
   auto* cell_ids = reinterpret_cast<const int64_t*>(child->buffers[1]);
 
-  // Verify each cell ID is valid by reconstructing and checking
+  // The point cell IDs should correspond to the input points
   S2CellId id0(cell_ids[0]);
   S2CellId id1(cell_ids[1]);
-  EXPECT_TRUE(id0.is_valid());
-  EXPECT_TRUE(id1.is_valid());
 
-  // The cell IDs should correspond to the input points
   S2CellId expected_id0(S2LatLng::FromDegrees(0, 0).ToPoint());
   S2CellId expected_id1(S2LatLng::FromDegrees(1, 0).ToPoint());
   EXPECT_EQ(id0, expected_id0);
   EXPECT_EQ(id1, expected_id1);
-
-  // Verify the linestring's covering cells are all valid
-  for (int i = 2; i < total_cells; i++) {
-    S2CellId id(cell_ids[i]);
-    EXPECT_TRUE(id.is_valid()) << "Cell ID at index " << i << " is invalid";
-  }
 
   impl.release(&impl);
   kernel.release(&kernel);

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -73,12 +73,14 @@ INSTANTIATE_TEST_SUITE_P(
         LatLngRectBounderParam{"polygon_empty", "POLYGON EMPTY", std::nullopt,
                                std::nullopt, std::nullopt, std::nullopt},
 
-        // Points
-        LatLngRectBounderParam{"point_origin", "POINT (0 0)", 0.0, 0.0, 0.0,
-                               0.0},
-        LatLngRectBounderParam{"multipoint_spanning",
-                               "MULTIPOINT ((-10 -20), (30 40))", -10.0, -20.0,
-                               30.0, 40.0},
+        // Points (note: longitude is expanded by 2*DBL_EPSILON radians for
+        // rounding error)
+        LatLngRectBounderParam{"point_origin", "POINT (0 0)",
+                               -2.5444437451708134e-14, 0.0,
+                               2.5444437451708134e-14, 0.0},
+        LatLngRectBounderParam{
+            "multipoint_spanning", "MULTIPOINT ((-10 -20), (30 40))",
+            -10.000000000000025, -20.0, 30.000000000000025, 40.0},
         LatLngRectBounderParam{"multipoint_antimeridian",
                                "MULTIPOINT ((170 10), (-170 11))", 170.0, 10.0,
                                -170.0, 11.0},
@@ -154,9 +156,9 @@ TEST(LatLngRectBounderTest, AccumulatesBounds) {
   bounder.Update(geog2);
   S2LatLngRect bounds = bounder.Finish();
 
-  EXPECT_DOUBLE_EQ(bounds.lng_lo().degrees(), 0.0);
+  EXPECT_DOUBLE_EQ(bounds.lng_lo().degrees(), -2.5444437451708134e-14);
   EXPECT_DOUBLE_EQ(bounds.lat_lo().degrees(), 0.0);
-  EXPECT_DOUBLE_EQ(bounds.lng_hi().degrees(), 10.0);
+  EXPECT_DOUBLE_EQ(bounds.lng_hi().degrees(), 10.000000000000025);
   EXPECT_DOUBLE_EQ(bounds.lat_hi().degrees(), 20.0);
 }
 
@@ -274,13 +276,15 @@ TEST(Coverings, SedonaUdfBoundingBox) {
   // so we only check the non-null rows' values
   // Child 0: xmin
   ASSERT_NO_FATAL_FAILURE(TestResultArrow(
-      out_array->children[0], NANOARROW_TYPE_DOUBLE, {0.0, -10.0, 0.0, 0.0}));
+      out_array->children[0], NANOARROW_TYPE_DOUBLE,
+      {-2.5444437451708134e-14, -10.000000000000025, 0.0, 0.0}));
   // Child 1: ymin
   ASSERT_NO_FATAL_FAILURE(TestResultArrow(
       out_array->children[1], NANOARROW_TYPE_DOUBLE, {0.0, -20.0, 0.0, 0.0}));
   // Child 2: xmax
-  ASSERT_NO_FATAL_FAILURE(TestResultArrow(
-      out_array->children[2], NANOARROW_TYPE_DOUBLE, {0.0, 30.0, 0.0, 0.0}));
+  ASSERT_NO_FATAL_FAILURE(
+      TestResultArrow(out_array->children[2], NANOARROW_TYPE_DOUBLE,
+                      {2.5444437451708134e-14, 30.000000000000025, 0.0, 0.0}));
   // Child 3: ymax
   ASSERT_NO_FATAL_FAILURE(TestResultArrow(
       out_array->children[3], NANOARROW_TYPE_DOUBLE, {0.0, 40.0, 0.0, 0.0}));

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -184,5 +184,3 @@ TEST(Coverings, SedonaUdfCellIdFromPointArray) {
       {static_cast<double>(id_origin.id()), static_cast<double>(id_point1.id()),
        std::nullopt, std::nullopt}));
 }
-
-

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -187,3 +187,68 @@ TEST(Coverings, SedonaUdfCellIdFromPointArray) {
       {static_cast<double>(id_origin.id()), static_cast<double>(id_point1.id()),
        std::nullopt, std::nullopt}));
 }
+
+TEST(Coverings, SedonaUdfCoveringCellIdsArray) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::CoveringCellIdsKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(
+      TestInitKernel(&kernel, &impl, {ARROW_TYPE_WKB}, NANOARROW_TYPE_LIST));
+
+  // Linestring spanning ~100 degrees should require multiple cells
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
+      &impl, {ARROW_TYPE_WKB},
+      {{"POINT (0 0)", "POINT (0 1)", "LINESTRING (0 0, 100 50)", "POINT EMPTY",
+        std::nullopt}},
+      {}, out_array.get()));
+
+  // Check the list structure
+  ASSERT_EQ(out_array->length, 5);
+  ASSERT_EQ(out_array->n_children, 1);
+  ASSERT_NE(out_array->buffers[1], nullptr);
+
+  // Get offsets (int32 for NANOARROW_TYPE_LIST)
+  auto* offsets = reinterpret_cast<const int32_t*>(out_array->buffers[1]);
+  // Row 0: POINT (0 0) - should have 1 cell
+  EXPECT_EQ(offsets[1] - offsets[0], 1);
+  // Row 1: POINT (0 1) - should have 1 cell
+  EXPECT_EQ(offsets[2] - offsets[1], 1);
+  // Row 2: LINESTRING (0 0, 100 50) - should have multiple cells
+  int linestring_cells = offsets[3] - offsets[2];
+  EXPECT_GE(linestring_cells, 1);
+  EXPECT_LE(linestring_cells, 8);  // max_cells is 8
+  // Row 3: POINT EMPTY - should have 0 cells
+  EXPECT_EQ(offsets[4] - offsets[3], 0);
+  // Row 4: null - should have 0 cells
+  EXPECT_EQ(offsets[5] - offsets[4], 0);
+
+  // Check child array contains valid cell IDs
+  auto* child = out_array->children[0];
+  ASSERT_NE(child, nullptr);
+  int total_cells = 1 + 1 + linestring_cells;
+  EXPECT_EQ(child->length, total_cells);
+  ASSERT_NE(child->buffers[1], nullptr);
+  auto* cell_ids = reinterpret_cast<const int64_t*>(child->buffers[1]);
+
+  // Verify each cell ID is valid by reconstructing and checking
+  S2CellId id0(cell_ids[0]);
+  S2CellId id1(cell_ids[1]);
+  EXPECT_TRUE(id0.is_valid());
+  EXPECT_TRUE(id1.is_valid());
+
+  // The cell IDs should correspond to the input points
+  S2CellId expected_id0(S2LatLng::FromDegrees(0, 0).ToPoint());
+  S2CellId expected_id1(S2LatLng::FromDegrees(1, 0).ToPoint());
+  EXPECT_EQ(id0, expected_id0);
+  EXPECT_EQ(id1, expected_id1);
+
+  // Verify the linestring's covering cells are all valid
+  for (int i = 2; i < total_cells; i++) {
+    S2CellId id(cell_ids[i]);
+    EXPECT_TRUE(id.is_valid()) << "Cell ID at index " << i << " is invalid";
+  }
+
+  impl.release(&impl);
+  kernel.release(&kernel);
+}

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -1,6 +1,8 @@
 #include "s2geography/coverings.h"
 
 #include <gtest/gtest.h>
+#include <s2/s2cell_id.h>
+#include <s2/s2latlng.h>
 
 #include <optional>
 #include <string>
@@ -156,6 +158,31 @@ TEST(LatLngRectBounderTest, AccumulatesBounds) {
   EXPECT_DOUBLE_EQ(bounds.lat_lo().degrees(), 0.0);
   EXPECT_DOUBLE_EQ(bounds.lng_hi().degrees(), 10.0);
   EXPECT_DOUBLE_EQ(bounds.lat_hi().degrees(), 20.0);
+}
+
+TEST(Coverings, SedonaUdfCellIdFromPointArray) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::CellIdFromPointKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(
+      TestInitKernel(&kernel, &impl, {ARROW_TYPE_WKB}, NANOARROW_TYPE_INT64));
+
+  // Compute expected cell IDs
+  S2CellId id_origin(S2LatLng::FromDegrees(0, 0).ToPoint());
+  S2CellId id_point1(S2LatLng::FromDegrees(1, 0).ToPoint());
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
+      &impl, {ARROW_TYPE_WKB},
+      {{"POINT (0 0)", "POINT (0 1)", "POINT EMPTY", std::nullopt}}, {},
+      out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(TestResultArrow(
+      out_array.get(), NANOARROW_TYPE_INT64,
+      {static_cast<double>(id_origin.id()), static_cast<double>(id_point1.id()),
+       std::nullopt, std::nullopt}));
 }
 
 

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -157,3 +157,5 @@ TEST(LatLngRectBounderTest, AccumulatesBounds) {
   EXPECT_DOUBLE_EQ(bounds.lng_hi().degrees(), 10.0);
   EXPECT_DOUBLE_EQ(bounds.lat_hi().degrees(), 20.0);
 }
+
+

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -19,8 +19,6 @@ struct LatLngRectBounderParam {
   std::optional<double> xmax;
   std::optional<double> ymax;
 
-
-
   friend std::ostream& operator<<(std::ostream& os,
                                   const LatLngRectBounderParam& p) {
     os << p.name;
@@ -47,17 +45,16 @@ TEST_P(LatLngRectBounderTest, Bounds) {
     // Expect empty bounds
     EXPECT_TRUE(bounds.is_empty()) << "Expected empty bounds for " << p.wkt;
   } else {
-    EXPECT_FALSE(bounds.is_empty()) << "Expected non-empty bounds for " << p.wkt;
+    EXPECT_FALSE(bounds.is_empty())
+        << "Expected non-empty bounds for " << p.wkt;
 
-    // Use larger tolerance for polygons due to geodesic edge bulging
-    constexpr double kTolerance = 0.1;  // degrees
-    EXPECT_NEAR(bounds.lng_lo().degrees(), *p.xmin, kTolerance)
+    EXPECT_DOUBLE_EQ(bounds.lng_lo().degrees(), *p.xmin)
         << "xmin mismatch for " << p.wkt;
-    EXPECT_NEAR(bounds.lat_lo().degrees(), *p.ymin, kTolerance)
+    EXPECT_DOUBLE_EQ(bounds.lat_lo().degrees(), *p.ymin)
         << "ymin mismatch for " << p.wkt;
-    EXPECT_NEAR(bounds.lng_hi().degrees(), *p.xmax, kTolerance)
+    EXPECT_DOUBLE_EQ(bounds.lng_hi().degrees(), *p.xmax)
         << "xmax mismatch for " << p.wkt;
-    EXPECT_NEAR(bounds.lat_hi().degrees(), *p.ymax, kTolerance)
+    EXPECT_DOUBLE_EQ(bounds.lat_hi().degrees(), *p.ymax)
         << "ymax mismatch for " << p.wkt;
   }
 }
@@ -77,31 +74,49 @@ INSTANTIATE_TEST_SUITE_P(
         // Points
         LatLngRectBounderParam{"point_origin", "POINT (0 0)", 0.0, 0.0, 0.0,
                                0.0},
-        LatLngRectBounderParam{"point_positive", "POINT (10 20)", 10.0, 20.0,
-                               10.0, 20.0},
-        LatLngRectBounderParam{"point_negative", "POINT (-30 -40)", -30.0,
-                               -40.0, -30.0, -40.0},
-
-        // MultiPoints
-        LatLngRectBounderParam{"multipoint_two", "MULTIPOINT ((0 0), (10 20))",
-                               0.0, 0.0, 10.0, 20.0},
-        LatLngRectBounderParam{
-            "multipoint_spanning", "MULTIPOINT ((-10 -20), (30 40))", -10.0,
-            -20.0, 30.0, 40.0},
+        LatLngRectBounderParam{"multipoint_spanning",
+                               "MULTIPOINT ((-10 -20), (30 40))", -10.0, -20.0,
+                               30.0, 40.0},
+        LatLngRectBounderParam{"multipoint_antimeridian",
+                               "MULTIPOINT ((170 10), (-170 11))", 170.0, 10.0,
+                               -170.0, 11.0},
 
         // LineStrings
-        LatLngRectBounderParam{"linestring_horizontal",
-                               "LINESTRING (0 0, 10 0)", 0.0, 0.0, 10.0, 0.0},
+        LatLngRectBounderParam{
+            "linestring_horizontal_equator", "LINESTRING (0 0, 10 0)", 0.0,
+            -4.1493099444912135e-14, 10.0, 4.1493099444912135e-14},
         LatLngRectBounderParam{"linestring_vertical", "LINESTRING (0 0, 0 10)",
-                               0.0, 0.0, 0.0, 10.0},
-        LatLngRectBounderParam{"linestring_diagonal",
-                               "LINESTRING (0 0, 10 10)", 0.0, 0.0, 10.0, 10.0},
+                               0.0, -2.5444437451708134e-14, 0.0,
+                               10.000000000000025},
+        LatLngRectBounderParam{"linestring_diagonal", "LINESTRING (0 1, 10 11)",
+                               0.0, 0.99999999999997458, 10.0,
+                               11.000000000000025},
+        LatLngRectBounderParam{"linestring_north_pole",
+                               "LINESTRING (90 80, -90 80)", -180.0, 80.0,
+                               180.0, 90.0},
+        LatLngRectBounderParam{"linestring_south_pole",
+                               "LINESTRING (90 -80, -90 -80)", -180.0, -90.0,
+                               180.0, -80.0},
+        LatLngRectBounderParam{"linestring_antimeridian",
+                               "LINESTRING (170 10, -170 10)", 170.0,
+                               9.9999999999999787, -170.0, 10.151081711048198},
+        LatLngRectBounderParam{
+            "multilinestring_antimeridian",
+            "MULTILINESTRING ((160 10, 170 10), (-170 10, -160 10))", 160.0,
+            9.9999999999999787, -160.0, 10.037423045910776},
 
-        // Polygons (simple cases)
+        // Polygons
         LatLngRectBounderParam{"triangle", "POLYGON ((0 0, 10 0, 5 10, 0 0))",
-                               0.0, 0.0, 10.0, 10.0},
-        LatLngRectBounderParam{"square", "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))",
-                               0.0, 0.0, 10.0, 10.0}));
+                               0.0, -4.1493099444912135e-14, 10.0,
+                               10.000000000000025},
+        LatLngRectBounderParam{"triangle_north_pole",
+                               "POLYGON ((0 80, 120 80, -120 80, 0 80))",
+                               -180.0, 80.0, 180.0, 90.0},
+        LatLngRectBounderParam{"triangle_south_pole",
+                               "POLYGON ((0 -80, -120 -80, 120 -80, 0 -80))",
+                               -180.0, -90.0, 180.0, -80.0}
+
+        ));
 
 // Test that Clear() resets state properly
 TEST(LatLngRectBounderTest, ClearResetsState) {
@@ -137,9 +152,8 @@ TEST(LatLngRectBounderTest, AccumulatesBounds) {
   bounder.Update(geog2);
   S2LatLngRect bounds = bounder.Finish();
 
-  constexpr double kTolerance = 1e-6;
-  EXPECT_NEAR(bounds.lng_lo().degrees(), 0.0, kTolerance);
-  EXPECT_NEAR(bounds.lat_lo().degrees(), 0.0, kTolerance);
-  EXPECT_NEAR(bounds.lng_hi().degrees(), 10.0, kTolerance);
-  EXPECT_NEAR(bounds.lat_hi().degrees(), 20.0, kTolerance);
+  EXPECT_DOUBLE_EQ(bounds.lng_lo().degrees(), 0.0);
+  EXPECT_DOUBLE_EQ(bounds.lat_lo().degrees(), 0.0);
+  EXPECT_DOUBLE_EQ(bounds.lng_hi().degrees(), 10.0);
+  EXPECT_DOUBLE_EQ(bounds.lat_hi().degrees(), 20.0);
 }

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -242,3 +242,49 @@ TEST(Coverings, SedonaUdfCoveringCellIdsArray) {
   impl.release(&impl);
   kernel.release(&kernel);
 }
+
+TEST(Coverings, SedonaUdfBoundingBox) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::BoundingBoxKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(
+      TestInitKernel(&kernel, &impl, {ARROW_TYPE_WKB}, NANOARROW_TYPE_STRUCT));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB},
+                        {{"POINT (0 0)", "MULTIPOINT ((-10 -20), (30 40))",
+                          "POINT EMPTY", std::nullopt}},
+                        {}, out_array.get()));
+
+  // Check the struct has 4 rows and 4 children (xmin, ymin, xmax, ymax)
+  ASSERT_EQ(out_array->length, 4);
+  ASSERT_EQ(out_array->n_children, 4);
+
+  // For struct output, nulls are at the struct level, not in children.
+  ASSERT_NE(out_array->buffers[0], nullptr);  // validity bitmap should exist
+  auto* validity = static_cast<const uint8_t*>(out_array->buffers[0]);
+  EXPECT_TRUE(ArrowBitGet(validity, 0));
+  EXPECT_TRUE(ArrowBitGet(validity, 1));
+  EXPECT_FALSE(ArrowBitGet(validity, 2));
+  EXPECT_FALSE(ArrowBitGet(validity, 3));
+
+  // Test children values for non-null rows using TestResultArrow
+  // Note: Children have placeholder values (0.0) for null struct rows,
+  // so we only check the non-null rows' values
+  // Child 0: xmin
+  ASSERT_NO_FATAL_FAILURE(TestResultArrow(
+      out_array->children[0], NANOARROW_TYPE_DOUBLE, {0.0, -10.0, 0.0, 0.0}));
+  // Child 1: ymin
+  ASSERT_NO_FATAL_FAILURE(TestResultArrow(
+      out_array->children[1], NANOARROW_TYPE_DOUBLE, {0.0, -20.0, 0.0, 0.0}));
+  // Child 2: xmax
+  ASSERT_NO_FATAL_FAILURE(TestResultArrow(
+      out_array->children[2], NANOARROW_TYPE_DOUBLE, {0.0, 30.0, 0.0, 0.0}));
+  // Child 3: ymax
+  ASSERT_NO_FATAL_FAILURE(TestResultArrow(
+      out_array->children[3], NANOARROW_TYPE_DOUBLE, {0.0, 40.0, 0.0, 0.0}));
+
+  impl.release(&impl);
+  kernel.release(&kernel);
+}

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -179,6 +179,9 @@ TEST(Coverings, SedonaUdfCellIdFromPointArray) {
   impl.release(&impl);
   kernel.release(&kernel);
 
+  // We use doubles to test as the expected value to simplify the signature of
+  // TestResultArrow (even though it is usually dubious to do this type of
+  // cast unchecked)
   ASSERT_NO_FATAL_FAILURE(TestResultArrow(
       out_array.get(), NANOARROW_TYPE_INT64,
       {static_cast<double>(id_origin.id()), static_cast<double>(id_point1.id()),

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <limits>
 
+#include "geoarrow/geoarrow.h"
 #include "s2/s2point_region.h"
 #include "s2geography/geography_interface.h"
 

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -628,35 +628,39 @@ TEST(GeoArrowPointShape, MultiPoint) {
   ValidateShape(shape);
 }
 
-TEST(GeoArrowPointShape, BigEndianWKB) {
+TEST(GeoArrowLaxPolylineShape, BigEndianWKBWithZM) {
   // clang-format off
-  // Big-endian WKB for POINT ZM (30 10 5 15)
+  // Big-endian WKB for LINESTRING ZM (30 10 5 15, 40 20 6 16)
   std::vector<uint8_t> wkb = {
     0x00,                                      // big endian
-    0x00, 0x00, 0x0b, 0xb9,                    // type: Point ZM (3001)
+    0x00, 0x00, 0x0b, 0xba,                    // type: LineString ZM (3002)
+    0x00, 0x00, 0x00, 0x02,                    // num points: 2
     0x40, 0x3e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // x: 30.0
     0x40, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // y: 10.0
     0x40, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // z: 5.0
     0x40, 0x2e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // m: 15.0
+    0x40, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // x: 40.0
+    0x40, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // y: 20.0
+    0x40, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // z: 6.0
+    0x40, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // m: 16.0
   };
   // clang-format on
 
   auto geom = TestGeometry::FromWKB(wkb);
-  GeoArrowPointShape shape(geom.geom());
-  EXPECT_EQ(shape.num_vertices(), 1);
+  GeoArrowLaxPolylineShape shape(geom.geom());
   EXPECT_EQ(shape.num_edges(), 1);
   EXPECT_EQ(shape.num_chains(), 1);
 
-  // The point's degenerate edge should have correct native coordinates
+  // The edge should have correct native coordinates
   auto e = shape.native_edge(0);
   EXPECT_DOUBLE_EQ(e.v0.lng, 30);
   EXPECT_DOUBLE_EQ(e.v0.lat, 10);
   EXPECT_DOUBLE_EQ(e.v0.zm[0], 5);
   EXPECT_DOUBLE_EQ(e.v0.zm[1], 15);
-  EXPECT_DOUBLE_EQ(e.v1.lng, 30);
-  EXPECT_DOUBLE_EQ(e.v1.lat, 10);
-  EXPECT_DOUBLE_EQ(e.v1.zm[0], 5);
-  EXPECT_DOUBLE_EQ(e.v1.zm[1], 15);
+  EXPECT_DOUBLE_EQ(e.v1.lng, 40);
+  EXPECT_DOUBLE_EQ(e.v1.lat, 20);
+  EXPECT_DOUBLE_EQ(e.v1.zm[0], 6);
+  EXPECT_DOUBLE_EQ(e.v1.zm[1], 16);
 
   // Also check the chain edge
   auto chain_e = shape.native_chain_edge(0, 0);

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include <absl/numeric/bits.h>
 #include <s2/s2latlng.h>
 #include <s2/s2shape.h>
 
@@ -9,7 +10,7 @@
 #include <cstring>
 #include <vector>
 
-#include "geoarrow/geoarrow.h"
+#include "s2geography/arrow_abi.h"
 #include "s2geography/macros.h"
 
 namespace s2geography {
@@ -81,11 +82,11 @@ bool VisitLngLat(const struct GeoArrowGeometryNode* node, int64_t offset,
     uint64_t tmp;
     for (int64_t i = 0; i < n; ++i) {
       memcpy(&tmp, lngs, sizeof(double));
-      tmp = GEOARROW_BSWAP64(tmp);
+      tmp = absl::byteswap(tmp);
       memcpy(&lng, &tmp, sizeof(double));
 
       memcpy(&tmp, lats, sizeof(double));
-      tmp = GEOARROW_BSWAP64(tmp);
+      tmp = absl::byteswap(tmp);
       memcpy(&lat, &tmp, sizeof(double));
       if (!visit(lng, lat)) return false;
 
@@ -220,19 +221,19 @@ bool VisitLngLatZM(const struct GeoArrowGeometryNode* node, int64_t offset,
     uint64_t tmp;
     for (int64_t i = 0; i < n; ++i) {
       memcpy(&tmp, lngs, sizeof(double));
-      tmp = GEOARROW_BSWAP64(tmp);
+      tmp = absl::byteswap(tmp);
       memcpy(&v.lng, &tmp, sizeof(double));
 
       memcpy(&tmp, lats, sizeof(double));
-      tmp = GEOARROW_BSWAP64(tmp);
+      tmp = absl::byteswap(tmp);
       memcpy(&v.lat, &tmp, sizeof(double));
 
       memcpy(&tmp, zm0s, sizeof(double));
-      tmp = GEOARROW_BSWAP64(tmp);
+      tmp = absl::byteswap(tmp);
       memcpy(&v.zm[0], &tmp, sizeof(double));
 
       memcpy(&tmp, zm1s, sizeof(double));
-      tmp = GEOARROW_BSWAP64(tmp);
+      tmp = absl::byteswap(tmp);
       memcpy(&v.zm[1], &tmp, sizeof(double));
 
       if (!visit(v)) return false;

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -392,31 +392,31 @@ class GeoArrowChain {
 
   /// \brief Call a function for each S2Point in this sequence
   template <typename Visit>
-  bool VisitVertices(Visit&& visit) {
+  bool VisitVertices(Visit&& visit) const {
     return internal::VisitVertices(node, visit);
   }
 
   /// \brief Call a function for each S2Point in a slice of this sequence
   template <typename Visit>
-  bool VisitVertices(int64_t offset, int64_t n, Visit&& visit) {
+  bool VisitVertices(int64_t offset, int64_t n, Visit&& visit) const {
     return internal::VisitVertices(node, offset, n, visit);
   }
 
   /// \brief Call a function for each pair of S2Points in this sequence
   template <typename Visit>
-  bool VisitEdges(Visit&& visit) {
+  bool VisitEdges(Visit&& visit) const {
     return internal::VisitEdges(node, visit);
   }
 
   /// \brief Call a function for each pair of S2Points in a slice of this
   /// sequence
   template <typename Visit>
-  bool VisitEdges(int64_t offset, int64_t n, Visit&& visit) {
+  bool VisitEdges(int64_t offset, int64_t n, Visit&& visit) const {
     return internal::VisitEdges(node, offset, n, visit);
   }
 
   /// \brief Copy a single vertex out of this sequence
-  S2Point vertex(int64_t i) {
+  S2Point vertex(int64_t i) const {
     S2Point v{};
     this->VisitVertices(i, 1, [&](const S2Point& pt) {
       v = pt;
@@ -426,7 +426,7 @@ class GeoArrowChain {
   }
 
   /// \brief Copy a single pair of vertices out of this sequence
-  S2Shape::Edge edge(int64_t i) {
+  S2Shape::Edge edge(int64_t i) const {
     S2Shape::Edge e{};
     this->VisitEdges(i, 1, [&](const S2Shape::Edge& edge) {
       e = edge;

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -172,6 +172,7 @@ class ListOutputBuilder {
     lengths_.push_back(0);
 
     nulls_.clear();
+    null_count_ = 0;
 
     // We could do a better job exposing the expected list size. It is
     // unlikely to have a list that is completely empty with all elements
@@ -900,15 +901,15 @@ class SedonaUnaryKernelAdapter {
       data->arg0->SetPrepareScalar(data->prepare_arg0_scalar);
       data->out = std::make_unique<typename Exec::out_t>();
 
+      if constexpr (has_exec_init<Exec>::value) {
+        data->exec.Init(data->arg0.get(), data->out.get());
+      }
+
       std::string crs_out = data->arg0->GetCrs();
       if (crs_out.empty()) {
         data->out->InitOutputType(out);
       } else {
         data->out->InitOutputTypeWithCrs(out, crs_out);
-      }
-
-      if constexpr (has_exec_init<Exec>::value) {
-        data->exec.Init(data->arg0.get(), data->out.get());
       }
 
       return NANOARROW_OK;
@@ -1010,6 +1011,10 @@ class SedonaBinaryKernelAdapter {
       data->arg1->SetPrepareScalar(data->prepare_arg1_scalar);
       data->out = std::make_unique<typename Exec::out_t>();
 
+      if constexpr (has_exec_init<Exec>::value) {
+        data->exec.Init(data->arg0.get(), data->out.get());
+      }
+
       // We don't have a reliable way to check the equality of CRSes, so
       // here we just return the first CRS.
       std::string crs_out = data->arg0->GetCrs();
@@ -1017,10 +1022,6 @@ class SedonaBinaryKernelAdapter {
         data->out->InitOutputType(out);
       } else {
         data->out->InitOutputTypeWithCrs(out, crs_out);
-      }
-
-      if constexpr (has_exec_init<Exec>::value) {
-        data->exec.Init(data->arg0.get(), data->out.get());
       }
 
       return 0;
@@ -1131,6 +1132,10 @@ class SedonaTernaryKernelAdapter {
       data->arg2->SetPrepareScalar(data->prepare_arg2_scalar);
       data->out = std::make_unique<typename Exec::out_t>();
 
+      if constexpr (has_exec_init<Exec>::value) {
+        data->exec.Init(data->arg0.get(), data->out.get());
+      }
+
       // We don't have a reliable way to check the equality of CRSes, so
       // here we just return the first CRS.
       std::string crs_out = data->arg0->GetCrs();
@@ -1138,10 +1143,6 @@ class SedonaTernaryKernelAdapter {
         data->out->InitOutputType(out);
       } else {
         data->out->InitOutputTypeWithCrs(out, crs_out);
-      }
-
-      if constexpr (has_exec_init<Exec>::value) {
-        data->exec.Init(data->arg0.get(), data->out.get());
       }
 
       return 0;

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -169,6 +169,11 @@ class ListOutputBuilder {
     lengths_.push_back(0);
 
     nulls_.clear();
+
+    // We could do a better job exposing the expected list size. It is
+    // unlikely to have a list that is completely empty with all elements
+    // and this could be optimized at some point.
+    items_.Reserve(0);
   }
 
   void AppendNull() { Append(false); }
@@ -183,36 +188,42 @@ class ListOutputBuilder {
       nulls_.reserve(lengths_.capacity());
       nulls_.resize(current_length_);
       std::fill_n(nulls_.begin(), current_length_, 1);
-    }
-
-    if (!nulls_.empty()) {
+      nulls_.push_back(0);
+    } else if (!nulls_.empty()) {
       nulls_.push_back(is_valid);
     }
 
     lengths_.push_back(static_cast<int32_t>(items_.current_length()));
 
-    null_count_ += is_valid;
+    null_count_ += !is_valid;
     ++current_length_;
   }
 
   void Finish(struct ArrowArray* out) {
     nanoarrow::UniqueArray tmp;
     NANOARROW_THROW_NOT_OK(
-        ArrowArrayInitFromType(tmp.get(), NANOARROW_TYPE_UNINITIALIZED));
+        ArrowArrayInitFromType(tmp.get(), NANOARROW_TYPE_LIST));
     NANOARROW_THROW_NOT_OK(ArrowArrayAllocateChildren(tmp.get(), 1));
     items_.Finish(tmp->children[0]);
 
-    nanoarrow::UniqueBitmap nulls;
-    ArrowBitmapInit(nulls.get());
-    NANOARROW_THROW_NOT_OK(ArrowBitmapReserve(nulls.get(), current_length_));
-    ArrowBitmapAppendInt8Unsafe(nulls.get(), nulls_.data(), current_length_);
-    ArrowArraySetValidityBitmap(tmp.get(), nulls.get());
+    if (null_count_ > 0) {
+      nanoarrow::UniqueBitmap nulls;
+      ArrowBitmapInit(nulls.get());
+      NANOARROW_THROW_NOT_OK(ArrowBitmapReserve(nulls.get(), current_length_));
+      ArrowBitmapAppendInt8Unsafe(nulls.get(), nulls_.data(), current_length_);
+      ArrowArraySetValidityBitmap(tmp.get(), nulls.get());
+    }
 
     nanoarrow::UniqueBuffer offsets;
     nanoarrow::BufferInitSequence(offsets.get(), lengths_);
     lengths_.clear();
     NANOARROW_THROW_NOT_OK(ArrowArraySetBuffer(tmp.get(), 1, offsets.get()));
 
+    // Set the array metadata
+    tmp->length = current_length_;
+    tmp->null_count = null_count_;
+
+    NANOARROW_THROW_NOT_OK(ArrowArrayFinishBuildingDefault(tmp.get(), nullptr));
     ArrowArrayMove(tmp.get(), out);
   }
 

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -211,7 +211,7 @@ class ListOutputBuilder {
     nanoarrow::UniqueBuffer offsets;
     nanoarrow::BufferInitSequence(offsets.get(), lengths_);
     lengths_.clear();
-    ArrowArraySetBuffer(tmp.get(), 1, offsets.get());
+    NANOARROW_THROW_NOT_OK(ArrowArraySetBuffer(tmp.get(), 1, offsets.get()));
 
     ArrowArrayMove(tmp.get(), out);
   }

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -20,6 +20,16 @@ namespace sedona_udf {
 template <class... T>
 struct always_false : std::false_type {};
 
+/// \brief Detection trait for optional Exec::Init(arg0_t*, out_t*) method
+template <typename T, typename = void>
+struct has_exec_init : std::false_type {};
+
+template <typename T>
+struct has_exec_init<T, std::void_t<decltype(std::declval<T>().Init(
+                            std::declval<typename T::arg0_t*>(),
+                            std::declval<typename T::out_t*>()))>>
+    : std::true_type {};
+
 /// \defgroup sedona_udf-utils Arrow UDF Utilities
 ///
 /// To simplify implementations of a large number of functions, we
@@ -101,6 +111,10 @@ class ArrowOutputBuilder {
     NANOARROW_THROW_NOT_OK(ArrowArrayAppendNull(array_.get(), 1));
   }
 
+  void AppendEmpty() {
+    NANOARROW_THROW_NOT_OK(ArrowArrayAppendEmpty(array_.get(), 1));
+  }
+
   void Append(c_type value) {
     if constexpr (std::is_integral_v<c_type>) {
       NANOARROW_THROW_NOT_OK(ArrowArrayAppendInt(array_.get(), value));
@@ -127,10 +141,9 @@ using BoolOutputBuilder = ArrowOutputBuilder<bool, NANOARROW_TYPE_BOOL>;
 using IntOutputBuilder = ArrowOutputBuilder<int32_t, NANOARROW_TYPE_INT64>;
 using DoubleOutputBuilder = ArrowOutputBuilder<double, NANOARROW_TYPE_DOUBLE>;
 
-template<typename Child>
+template <typename Child>
 class ListOutputBuilder {
  public:
-
   ListOutputBuilder() = default;
   ListOutputBuilder(const ListOutputBuilder&) = delete;
   ListOutputBuilder& operator=(const ListOutputBuilder&) = delete;
@@ -230,17 +243,19 @@ class StructOutputBuilder {
 
   static constexpr size_t kNumFields = sizeof...(Children);
 
-  void InitOutputType(struct ArrowSchema* out,
-                      const std::array<const char*, kNumFields>& names = {}) {
-    NANOARROW_THROW_NOT_OK(ArrowSchemaInitFromType(out, NANOARROW_TYPE_STRUCT));
-    NANOARROW_THROW_NOT_OK(ArrowSchemaAllocateChildren(out, kNumFields));
-    InitFieldsOutputType(out, names, std::index_sequence_for<Children...>{});
+  void SetNames(const std::array<const char*, kNumFields>& names) {
+    names_ = names;
   }
 
-  void InitOutputTypeWithCrs(struct ArrowSchema* out, const std::string& crs,
-                             const std::array<const char*, kNumFields>& names = {}) {
+  void InitOutputType(struct ArrowSchema* out) {
+    NANOARROW_THROW_NOT_OK(ArrowSchemaInitFromType(out, NANOARROW_TYPE_STRUCT));
+    NANOARROW_THROW_NOT_OK(ArrowSchemaAllocateChildren(out, kNumFields));
+    InitFieldsOutputType(out, std::index_sequence_for<Children...>{});
+  }
+
+  void InitOutputTypeWithCrs(struct ArrowSchema* out, const std::string& crs) {
     S2GEOGRAPHY_UNUSED(crs);
-    InitOutputType(out, names);
+    InitOutputType(out);
   }
 
   void Reserve(int64_t additional_size) {
@@ -250,7 +265,10 @@ class StructOutputBuilder {
     ReserveFields(additional_size, std::index_sequence_for<Children...>{});
   }
 
-  void AppendNull() { Append(false); }
+  void AppendNull() {
+    AppendEmptyFields(std::index_sequence_for<Children...>{});
+    Append(false);
+  }
 
   void Append(bool is_valid = true) {
     if (nulls_.empty() && !is_valid) {
@@ -294,27 +312,32 @@ class StructOutputBuilder {
  private:
   std::tuple<Children...> fields_;
   std::vector<int8_t> nulls_;
+  std::array<const char*, kNumFields> names_{};
   int64_t current_length_{0};
   int64_t null_count_{0};
 
   template <size_t... Is>
   void InitFieldsOutputType(struct ArrowSchema* out,
-                            const std::array<const char*, kNumFields>& names,
                             std::index_sequence<Is...>) {
-    (InitField<Is>(out->children[Is], names[Is]), ...);
+    (InitField<Is>(out->children[Is]), ...);
   }
 
   template <size_t I>
-  void InitField(struct ArrowSchema* child, const char* name) {
+  void InitField(struct ArrowSchema* child) {
     std::get<I>(fields_).InitOutputType(child);
-    if (name != nullptr) {
-      NANOARROW_THROW_NOT_OK(ArrowSchemaSetName(child, name));
+    if (names_[I] != nullptr) {
+      NANOARROW_THROW_NOT_OK(ArrowSchemaSetName(child, names_[I]));
     }
   }
 
   template <size_t... Is>
   void ReserveFields(int64_t additional_size, std::index_sequence<Is...>) {
     (std::get<Is>(fields_).Reserve(additional_size), ...);
+  }
+
+  template <size_t... Is>
+  void AppendEmptyFields(std::index_sequence<Is...>) {
+    (std::get<Is>(fields_).AppendEmpty(), ...);
   }
 
   template <size_t... Is>
@@ -870,6 +893,10 @@ class SedonaUnaryKernelAdapter {
         data->out->InitOutputTypeWithCrs(out, crs_out);
       }
 
+      if constexpr (has_exec_init<Exec>::value) {
+        data->exec.Init(data->arg0.get(), data->out.get());
+      }
+
       return NANOARROW_OK;
     } catch (std::exception& e) {
       data->last_error = e.what();
@@ -976,6 +1003,10 @@ class SedonaBinaryKernelAdapter {
         data->out->InitOutputType(out);
       } else {
         data->out->InitOutputTypeWithCrs(out, crs_out);
+      }
+
+      if constexpr (has_exec_init<Exec>::value) {
+        data->exec.Init(data->arg0.get(), data->out.get());
       }
 
       return 0;
@@ -1093,6 +1124,10 @@ class SedonaTernaryKernelAdapter {
         data->out->InitOutputType(out);
       } else {
         data->out->InitOutputTypeWithCrs(out, crs_out);
+      }
+
+      if constexpr (has_exec_init<Exec>::value) {
+        data->exec.Init(data->arg0.get(), data->out.get());
       }
 
       return 0;

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -152,7 +152,7 @@ class ListOutputBuilder {
 
   void InitOutputType(struct ArrowSchema* out) {
     ArrowSchemaInit(out);
-    NANOARROW_THROW_NOT_OK(S2GeographyArrowSchemaSetFormat(out, "+l"));
+    NANOARROW_THROW_NOT_OK(ArrowSchemaSetFormat(out, "+l"));
     NANOARROW_THROW_NOT_OK(ArrowSchemaAllocateChildren(out, 1));
     items_.InitOutputType(out->children[0]);
     NANOARROW_THROW_NOT_OK(ArrowSchemaSetName(out->children[0], "item"));

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -138,7 +138,7 @@ class ArrowOutputBuilder {
 };
 
 using BoolOutputBuilder = ArrowOutputBuilder<bool, NANOARROW_TYPE_BOOL>;
-using IntOutputBuilder = ArrowOutputBuilder<int32_t, NANOARROW_TYPE_INT64>;
+using IntOutputBuilder = ArrowOutputBuilder<int64_t, NANOARROW_TYPE_INT64>;
 using DoubleOutputBuilder = ArrowOutputBuilder<double, NANOARROW_TYPE_DOUBLE>;
 
 template <typename Child>

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -30,6 +30,31 @@ struct has_exec_init<T, std::void_t<decltype(std::declval<T>().Init(
                             std::declval<typename T::out_t*>()))>>
     : std::true_type {};
 
+/// \brief Detection trait for optional Exec::Init(arg0_t*, arg1_t*, out_t*)
+/// method
+template <typename T, typename = void>
+struct has_exec_init_binary : std::false_type {};
+
+template <typename T>
+struct has_exec_init_binary<T, std::void_t<decltype(std::declval<T>().Init(
+                                   std::declval<typename T::arg0_t*>(),
+                                   std::declval<typename T::arg1_t*>(),
+                                   std::declval<typename T::out_t*>()))>>
+    : std::true_type {};
+
+/// \brief Detection trait for optional Exec::Init(arg0_t*, arg1_t*, arg2_t*,
+/// out_t*) method
+template <typename T, typename = void>
+struct has_exec_init_ternary : std::false_type {};
+
+template <typename T>
+struct has_exec_init_ternary<T, std::void_t<decltype(std::declval<T>().Init(
+                                    std::declval<typename T::arg0_t*>(),
+                                    std::declval<typename T::arg1_t*>(),
+                                    std::declval<typename T::arg2_t*>(),
+                                    std::declval<typename T::out_t*>()))>>
+    : std::true_type {};
+
 /// \defgroup sedona_udf-utils Arrow UDF Utilities
 ///
 /// To simplify implementations of a large number of functions, we
@@ -235,8 +260,8 @@ class ListOutputBuilder {
   std::vector<int8_t> nulls_;
   std::vector<int32_t> lengths_;
   nanoarrow::UniqueArray array_;
-  int64_t current_length_;
-  int64_t null_count_;
+  int64_t current_length_{};
+  int64_t null_count_{};
 };
 
 template <typename... Children>
@@ -1011,8 +1036,8 @@ class SedonaBinaryKernelAdapter {
       data->arg1->SetPrepareScalar(data->prepare_arg1_scalar);
       data->out = std::make_unique<typename Exec::out_t>();
 
-      if constexpr (has_exec_init<Exec>::value) {
-        data->exec.Init(data->arg0.get(), data->out.get());
+      if constexpr (has_exec_init_binary<Exec>::value) {
+        data->exec.Init(data->arg0.get(), data->arg1.get(), data->out.get());
       }
 
       // We don't have a reliable way to check the equality of CRSes, so
@@ -1132,8 +1157,9 @@ class SedonaTernaryKernelAdapter {
       data->arg2->SetPrepareScalar(data->prepare_arg2_scalar);
       data->out = std::make_unique<typename Exec::out_t>();
 
-      if constexpr (has_exec_init<Exec>::value) {
-        data->exec.Init(data->arg0.get(), data->out.get());
+      if constexpr (has_exec_init_ternary<Exec>::value) {
+        data->exec.Init(data->arg0.get(), data->arg1.get(), data->arg2.get(),
+                        data->out.get());
       }
 
       // We don't have a reliable way to check the equality of CRSes, so

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -151,8 +151,11 @@ class ListOutputBuilder {
   Child& items() { return items_; }
 
   void InitOutputType(struct ArrowSchema* out) {
-    NANOARROW_THROW_NOT_OK(ArrowSchemaInitFromType(out, NANOARROW_TYPE_LIST));
+    ArrowSchemaInit(out);
+    NANOARROW_THROW_NOT_OK(S2GeographyArrowSchemaSetFormat(out, "+l"));
+    NANOARROW_THROW_NOT_OK(ArrowSchemaAllocateChildren(out, 1));
     items_.InitOutputType(out->children[0]);
+    NANOARROW_THROW_NOT_OK(ArrowSchemaSetName(out->children[0], "item"));
   }
 
   void InitOutputTypeWithCrs(struct ArrowSchema* out, const std::string& crs) {

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -211,6 +211,118 @@ class ListOutputBuilder {
   int64_t null_count_;
 };
 
+template <typename... Children>
+class StructOutputBuilder {
+ public:
+  StructOutputBuilder() = default;
+  StructOutputBuilder(const StructOutputBuilder&) = delete;
+  StructOutputBuilder& operator=(const StructOutputBuilder&) = delete;
+
+  template <size_t I>
+  auto& field() {
+    return std::get<I>(fields_);
+  }
+
+  template <size_t I>
+  const auto& field() const {
+    return std::get<I>(fields_);
+  }
+
+  static constexpr size_t kNumFields = sizeof...(Children);
+
+  void InitOutputType(struct ArrowSchema* out,
+                      const std::array<const char*, kNumFields>& names = {}) {
+    NANOARROW_THROW_NOT_OK(ArrowSchemaInitFromType(out, NANOARROW_TYPE_STRUCT));
+    NANOARROW_THROW_NOT_OK(ArrowSchemaAllocateChildren(out, kNumFields));
+    InitFieldsOutputType(out, names, std::index_sequence_for<Children...>{});
+  }
+
+  void InitOutputTypeWithCrs(struct ArrowSchema* out, const std::string& crs,
+                             const std::array<const char*, kNumFields>& names = {}) {
+    S2GEOGRAPHY_UNUSED(crs);
+    InitOutputType(out, names);
+  }
+
+  void Reserve(int64_t additional_size) {
+    current_length_ = 0;
+    null_count_ = 0;
+    nulls_.clear();
+    ReserveFields(additional_size, std::index_sequence_for<Children...>{});
+  }
+
+  void AppendNull() { Append(false); }
+
+  void Append(bool is_valid = true) {
+    if (nulls_.empty() && !is_valid) {
+      nulls_.reserve(current_length_ + 1);
+      nulls_.resize(current_length_);
+      std::fill_n(nulls_.begin(), current_length_, 1);
+    }
+
+    if (!nulls_.empty()) {
+      nulls_.push_back(is_valid);
+    }
+
+    null_count_ += !is_valid;
+    ++current_length_;
+  }
+
+  int64_t current_length() const { return current_length_; }
+
+  void Finish(struct ArrowArray* out) {
+    nanoarrow::UniqueArray tmp;
+    NANOARROW_THROW_NOT_OK(
+        ArrowArrayInitFromType(tmp.get(), NANOARROW_TYPE_STRUCT));
+    NANOARROW_THROW_NOT_OK(
+        ArrowArrayAllocateChildren(tmp.get(), sizeof...(Children)));
+    FinishFields(tmp.get(), std::index_sequence_for<Children...>{});
+
+    tmp->length = current_length_;
+    tmp->null_count = null_count_;
+
+    if (!nulls_.empty()) {
+      nanoarrow::UniqueBitmap nulls;
+      ArrowBitmapInit(nulls.get());
+      NANOARROW_THROW_NOT_OK(ArrowBitmapReserve(nulls.get(), current_length_));
+      ArrowBitmapAppendInt8Unsafe(nulls.get(), nulls_.data(), current_length_);
+      ArrowArraySetValidityBitmap(tmp.get(), nulls.get());
+    }
+
+    ArrowArrayMove(tmp.get(), out);
+  }
+
+ private:
+  std::tuple<Children...> fields_;
+  std::vector<int8_t> nulls_;
+  int64_t current_length_{0};
+  int64_t null_count_{0};
+
+  template <size_t... Is>
+  void InitFieldsOutputType(struct ArrowSchema* out,
+                            const std::array<const char*, kNumFields>& names,
+                            std::index_sequence<Is...>) {
+    (InitField<Is>(out->children[Is], names[Is]), ...);
+  }
+
+  template <size_t I>
+  void InitField(struct ArrowSchema* child, const char* name) {
+    std::get<I>(fields_).InitOutputType(child);
+    if (name != nullptr) {
+      NANOARROW_THROW_NOT_OK(ArrowSchemaSetName(child, name));
+    }
+  }
+
+  template <size_t... Is>
+  void ReserveFields(int64_t additional_size, std::index_sequence<Is...>) {
+    (std::get<Is>(fields_).Reserve(additional_size), ...);
+  }
+
+  template <size_t... Is>
+  void FinishFields(struct ArrowArray* out, std::index_sequence<Is...>) {
+    (std::get<Is>(fields_).Finish(out->children[Is]), ...);
+  }
+};
+
 /// \brief Low-level output builder for Geography as WKB
 ///
 /// This builder handles output from functions that return geometry

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -111,6 +111,8 @@ class ArrowOutputBuilder {
     }
   }
 
+  int64_t current_length() { return array_->length; }
+
   void Finish(struct ArrowArray* out) {
     NANOARROW_THROW_NOT_OK(
         ArrowArrayFinishBuildingDefault(array_.get(), nullptr));
@@ -122,8 +124,92 @@ class ArrowOutputBuilder {
 };
 
 using BoolOutputBuilder = ArrowOutputBuilder<bool, NANOARROW_TYPE_BOOL>;
-using IntOutputBuilder = ArrowOutputBuilder<int32_t, NANOARROW_TYPE_INT32>;
+using IntOutputBuilder = ArrowOutputBuilder<int32_t, NANOARROW_TYPE_INT64>;
 using DoubleOutputBuilder = ArrowOutputBuilder<double, NANOARROW_TYPE_DOUBLE>;
+
+template<typename Child>
+class ListOutputBuilder {
+ public:
+
+  ListOutputBuilder() = default;
+  ListOutputBuilder(const ListOutputBuilder&) = delete;
+  ListOutputBuilder& operator=(const ListOutputBuilder&) = delete;
+
+  Child& items() { return items_; }
+
+  void InitOutputType(struct ArrowSchema* out) {
+    NANOARROW_THROW_NOT_OK(ArrowSchemaInitFromType(out, NANOARROW_TYPE_LIST));
+    items_.InitOutputType(out->children[0]);
+  }
+
+  void InitOutputTypeWithCrs(struct ArrowSchema* out, const std::string& crs) {
+    S2GEOGRAPHY_UNUSED(crs);
+    InitOutputType(out);
+  }
+
+  void Reserve(int64_t additional_size) {
+    array_.reset();
+
+    current_length_ = 0;
+    lengths_.clear();
+    lengths_.reserve(additional_size + 1);
+    lengths_.push_back(0);
+
+    nulls_.clear();
+  }
+
+  void AppendNull() { Append(false); }
+
+  void Append(bool is_valid = true) {
+    if (items_.current_length() > std::numeric_limits<int32_t>::max()) {
+      throw Exception(
+          "Can't build nested list output with >INT32_MAX child elements");
+    }
+
+    if (nulls_.empty() && !is_valid) {
+      nulls_.reserve(lengths_.capacity());
+      nulls_.resize(current_length_);
+      std::fill_n(nulls_.begin(), current_length_, 1);
+    }
+
+    if (!nulls_.empty()) {
+      nulls_.push_back(is_valid);
+    }
+
+    lengths_.push_back(static_cast<int32_t>(items_.current_length()));
+
+    null_count_ += is_valid;
+    ++current_length_;
+  }
+
+  void Finish(struct ArrowArray* out) {
+    nanoarrow::UniqueArray tmp;
+    NANOARROW_THROW_NOT_OK(
+        ArrowArrayInitFromType(tmp.get(), NANOARROW_TYPE_UNINITIALIZED));
+    NANOARROW_THROW_NOT_OK(ArrowArrayAllocateChildren(tmp.get(), 1));
+    items_.Finish(tmp->children[0]);
+
+    nanoarrow::UniqueBitmap nulls;
+    ArrowBitmapInit(nulls.get());
+    NANOARROW_THROW_NOT_OK(ArrowBitmapReserve(nulls.get(), current_length_));
+    ArrowBitmapAppendInt8Unsafe(nulls.get(), nulls_.data(), current_length_);
+    ArrowArraySetValidityBitmap(tmp.get(), nulls.get());
+
+    nanoarrow::UniqueBuffer offsets;
+    nanoarrow::BufferInitSequence(offsets.get(), lengths_);
+    lengths_.clear();
+    ArrowArraySetBuffer(tmp.get(), 1, offsets.get());
+
+    ArrowArrayMove(tmp.get(), out);
+  }
+
+  Child items_;
+  std::vector<int8_t> nulls_;
+  std::vector<int32_t> lengths_;
+  nanoarrow::UniqueArray array_;
+  int64_t current_length_;
+  int64_t null_count_;
+};
 
 /// \brief Low-level output builder for Geography as WKB
 ///

--- a/src/s2geography/sedona_udf/sedona_udf_test_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_test_internal.h
@@ -58,8 +58,8 @@ class TestGeometry {
     GEOARROW_THROW_NOT_OK(nullptr, GeoArrowGeometryViewVisit(geom(), &v));
 
     nanoarrow::UniqueArray out;
-    GEOARROW_THROW_NOT_OK(nullptr, S2GeographyGeoArrowWKTWriterFinish(
-                                       &writer, out.get(), nullptr));
+    GEOARROW_THROW_NOT_OK(nullptr,
+                          GeoArrowWKTWriterFinish(&writer, out.get(), nullptr));
     GeoArrowWKTWriterReset(&writer);
 
     auto* offsets = reinterpret_cast<const int32_t*>(out->buffers[1]);

--- a/src/s2geography/sedona_udf/sedona_udf_test_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_test_internal.h
@@ -418,7 +418,8 @@ inline void TestResultArrow(struct ArrowArray* result,
   for (int64_t i = 0; i < array_view->length; i++) {
     if (ArrowArrayViewIsNull(array_view.get(), i)) {
       actual.push_back(ARROW_TYPE_WKB);
-    } else if (result_type == NANOARROW_TYPE_BOOL) {
+    } else if (result_type == NANOARROW_TYPE_BOOL ||
+               result_type == NANOARROW_TYPE_INT64) {
       actual.push_back(
           static_cast<double>(ArrowArrayViewGetIntUnsafe(array_view.get(), i)));
     } else {

--- a/src/vendored/geoarrow/geoarrow.h
+++ b/src/vendored/geoarrow/geoarrow.h
@@ -405,6 +405,9 @@ enum GeoArrowType {
 
 };
 
+#ifndef GEOARROW_C_ABI
+#define GEOARROW_C_ABI
+
 /// \brief Geometry type identifiers supported by GeoArrow
 /// \ingroup geoarrow-schema
 ///
@@ -584,6 +587,8 @@ struct GeoArrowGeometryView {
   /// the children are correctly set.
   int64_t size_nodes;
 };
+
+#endif
 
 /// \brief Variant of the GeoArrowGeometry that owns its GeoArrowGeometryNode and/or
 /// its coordinates


### PR DESCRIPTION
This PR adds support for computing the rectangle and covering bounds (corresponding to the BigQuery functions ST_BoundingBox, S2_CellIdFromPoint, and S2CoveringCellIds). Most of the change is computing output and testing list and struct output since these functions return nested types that hadn't been considered yet.

I also shuffled the headers to expose the GeoArrowGeography, which had previously relied on geoarrow.h (which is not public). I'll make this change in geoarrow-c as well...there is basically a small subset of that header which can be considered ABI stable which allows that to be public.