### PR TITLE
feat: Add C API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,8 +368,9 @@ target_include_directories(
          $<INSTALL_INTERFACE:include>
   PRIVATE ${GEOARROW_INCLUDE_DIRECTORY} ${NANOARROW_INCLUDE_DIRECTORY})
 
-target_compile_definitions(s2geography_c PRIVATE ${GEOARROW_COMPILE_DEFINITIONS}
-                                                 ${NANOARROW_COMPILE_DEFINITIONS})
+target_compile_definitions(
+  s2geography_c PRIVATE ${GEOARROW_COMPILE_DEFINITIONS}
+                        ${NANOARROW_COMPILE_DEFINITIONS})
 
 target_link_libraries(s2geography_c PUBLIC s2geography)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,15 +374,6 @@ target_compile_definitions(
 
 target_link_libraries(s2geography_c PUBLIC s2geography)
 
-install(
-  TARGETS s2geography_c
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-install(FILES src/capi/s2geography_c.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/capi)
 if(S2GEOGRAPHY_BUILD_TESTS)
 
   enable_testing()
@@ -495,7 +486,7 @@ message("  -> includes: " ${CMAKE_INSTALL_INCLUDEDIR})
 message("  -> cmake config: " ${CMAKECONFIG_INSTALL_DIR})
 
 install(
-  TARGETS s2geography
+  TARGETS s2geography s2geography_c
   EXPORT ${PROJECT_NAME}-targets
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -509,6 +500,7 @@ install(
   FILES_MATCHING
   PATTERN "*.h")
 install(FILES src/s2geography.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(FILES src/s2geography_c.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 if(S2GEOGRAPHY_BUILD_TESTS AND S2GEOGRAPHY_CODE_COVERAGE)
   install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,15 @@ target_compile_definitions(
 
 target_link_libraries(s2geography_c PUBLIC s2geography)
 
+install(
+  TARGETS s2geography_c
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(FILES src/capi/s2geography_c.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/capi)
 if(S2GEOGRAPHY_BUILD_TESTS)
 
   enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,22 @@ if(S2GEOGRAPHY_EXTRA_WARNINGS)
   endif()
 endif()
 
+# Build s2geography_c (C API)
+# ---------------------------
+
+add_library(s2geography_c src/capi/s2geography_c.cc)
+
+target_include_directories(
+  s2geography_c
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+         $<INSTALL_INTERFACE:include>
+  PRIVATE ${GEOARROW_INCLUDE_DIRECTORY} ${NANOARROW_INCLUDE_DIRECTORY})
+
+target_compile_definitions(s2geography_c PRIVATE ${GEOARROW_COMPILE_DEFINITIONS}
+                                                 ${NANOARROW_COMPILE_DEFINITIONS})
+
+target_link_libraries(s2geography_c PUBLIC s2geography)
+
 if(S2GEOGRAPHY_BUILD_TESTS)
 
   enable_testing()
@@ -381,6 +397,7 @@ if(S2GEOGRAPHY_BUILD_TESTS)
   add_executable(wkb_test src/s2geography/wkb_test.cc)
   add_executable(geoarrow_geography_test
                  src/s2geography/geoarrow-geography_test.cc)
+  add_executable(s2geography_c_test src/capi/s2geography_c_test.cc)
 
   if(S2GEOGRAPHY_CODE_COVERAGE)
     target_compile_options(coverage_config INTERFACE -O0 -g --coverage)
@@ -418,6 +435,7 @@ if(S2GEOGRAPHY_BUILD_TESTS)
   target_link_libraries(wkt_writer_test s2geography GTest::gtest_main)
   target_link_libraries(wkb_test s2geography GTest::gtest_main)
   target_link_libraries(geoarrow_geography_test s2geography GTest::gtest_main)
+  target_link_libraries(s2geography_c_test s2geography_c GTest::gtest_main)
 
   target_include_directories(sedona_udf_internal_test PRIVATE src/vendored)
   target_include_directories(accessors_geog_test PRIVATE src/vendored)
@@ -443,6 +461,7 @@ if(S2GEOGRAPHY_BUILD_TESTS)
   gtest_discover_tests(wkt_writer_test)
   gtest_discover_tests(wkb_test)
   gtest_discover_tests(geoarrow_geography_test)
+  gtest_discover_tests(s2geography_c_test)
 endif()
 
 if(S2GEOGRAPHY_BUILD_EXAMPLES)

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -1,36 +1,38 @@
 
 #include "s2geography_c.h"
 
-#include <openssl/opensslv.h>
-#include <s2geography/accessors-geog.h>
-#include <s2geography/accessors.h>
-#include <s2geography/build.h>
-#include <s2geography/coverings.h>
-#include <s2geography/distance.h>
-#include <s2geography/linear-referencing.h>
-#include <s2geography/predicates.h>
-#include <s2geography/sedona_udf/sedona_extension.h>
-
+#include <array>
 #include <cstring>
 #include <string>
 
 #include "absl/base/config.h"
 #include "geoarrow/geoarrow.h"
 #include "nanoarrow/nanoarrow.h"
+#include "openssl/opensslv.h"
+#include "s2geography/accessors-geog.h"
+#include "s2geography/accessors.h"
+#include "s2geography/build.h"
+#include "s2geography/coverings.h"
+#include "s2geography/distance.h"
 #include "s2geography/geoarrow-geography.h"
+#include "s2geography/linear-referencing.h"
+#include "s2geography/predicates.h"
 #include "s2geography/sedona_udf/sedona_extension.h"
 
 // Helper macros
 
-#define S2GEOGRAPHY_SET_ERROR(err, value) \
-  if ((err) != nullptr) {                 \
-    err->message = (value);               \
+#define S2GEOGRAPHY_SET_ERROR(err, value)          \
+  if ((err) != nullptr) {                          \
+    ((struct S2GeogError*)err)->message = (value); \
   }
 
 #define S2GEOGRAPHY_C_BEGIN(err)  \
   S2GEOGRAPHY_SET_ERROR(err, ""); \
   try {
 #define S2GEOGRAPHY_C_END(err)                   \
+  }                                              \
+  catch (std::bad_alloc & e) {                   \
+    return ENOMEM;                               \
   }                                              \
   catch (std::exception & e) {                   \
     S2GEOGRAPHY_SET_ERROR(err, e.what());        \
@@ -91,11 +93,11 @@ struct S2GeogRectBounder {
 // Error handling functions
 
 S2GeogErrorCode S2GeogErrorCreate(struct S2GeogError** err) {
-  if (err == nullptr) {
-    return -1;
-  }
+  S2GEOGRAPHY_C_BEGIN(nullptr);
+  S2GEOGRAPHY_DCHECK(err != nullptr);
   *err = new S2GeogError();
-  return 0;
+  return S2GEOGRAPHY_OK;
+  S2GEOGRAPHY_C_END(nullptr)
 }
 
 const char* S2GeogErrorGetMessage(struct S2GeogError* err) {
@@ -105,11 +107,16 @@ const char* S2GeogErrorGetMessage(struct S2GeogError* err) {
   return err->message.c_str();
 }
 
-void S2GeogErrorDestroy(struct S2GeogError* err) { delete err; }
+void S2GeogErrorDestroy(struct S2GeogError* err) {
+  S2GEOGRAPHY_DCHECK(err != nullptr);
+  delete err;
+}
 
 // Cell ID function
 
 uint64_t S2GeogLngLatToCellId(struct S2GeogVertex* v) {
+  S2GEOGRAPHY_DCHECK(v != nullptr);
+
   if (std::isnan(v->v[0]) || std::isnan(v->v[1])) {
     return S2CellId::Sentinel().id();
   } else {
@@ -121,7 +128,49 @@ uint64_t S2GeogLngLatToCellId(struct S2GeogVertex* v) {
 
 // Kernel functions
 
-size_t S2GeogNumKernels(void) { return 27; }
+using KernelInitFunc = void (*)(struct SedonaCScalarKernel*);
+
+static const std::array<KernelInitFunc, 27> kSedonaKernels = {{
+    s2geography::sedona_udf::AreaKernel,
+    s2geography::sedona_udf::CentroidKernel,
+    s2geography::sedona_udf::ClosestPointKernel,
+    [](SedonaCScalarKernel* k) { s2geography::sedona_udf::ContainsKernel(k); },
+    s2geography::sedona_udf::ConvexHullKernel,
+    s2geography::sedona_udf::DifferenceKernel,
+    [](SedonaCScalarKernel* k) { s2geography::sedona_udf::DistanceKernel(k); },
+    [](SedonaCScalarKernel* k) { s2geography::sedona_udf::EqualsKernel(k); },
+    s2geography::sedona_udf::IntersectionKernel,
+    [](SedonaCScalarKernel* k) {
+      s2geography::sedona_udf::IntersectsKernel(k);
+    },
+    s2geography::sedona_udf::LengthKernel,
+    s2geography::sedona_udf::LineInterpolatePointKernel,
+    s2geography::sedona_udf::LineLocatePointKernel,
+    [](SedonaCScalarKernel* k) {
+      s2geography::sedona_udf::MaxDistanceKernel(k);
+    },
+    s2geography::sedona_udf::PerimeterKernel,
+    [](SedonaCScalarKernel* k) {
+      s2geography::sedona_udf::ShortestLineKernel(k);
+    },
+    s2geography::sedona_udf::SymDifferenceKernel,
+    s2geography::sedona_udf::UnionKernel,
+    s2geography::sedona_udf::ReducePrecisionKernel,
+    s2geography::sedona_udf::SimplifyKernel,
+    s2geography::sedona_udf::BufferKernel,
+    s2geography::sedona_udf::BufferQuadSegsKernel,
+    s2geography::sedona_udf::BufferParamsKernel,
+    [](SedonaCScalarKernel* k) {
+      s2geography::sedona_udf::DistanceWithinKernel(k);
+    },
+    s2geography::sedona_udf::CellIdFromPointKernel,
+    s2geography::sedona_udf::CoveringCellIdsKernel,
+    [](SedonaCScalarKernel* k) {
+      s2geography::sedona_udf::LongestLineKernel(k);
+    },
+}};
+
+size_t S2GeogNumKernels(void) { return kSedonaKernels.size(); }
 
 int S2GeogInitKernels(void* kernels_array, size_t kernels_array_size_bytes,
                       int format) {
@@ -130,40 +179,16 @@ int S2GeogInitKernels(void* kernels_array, size_t kernels_array_size_bytes,
   }
 
   if (kernels_array_size_bytes !=
-      (sizeof(SedonaCScalarKernel) * S2GeogNumKernels())) {
+      (sizeof(SedonaCScalarKernel) * kSedonaKernels.size())) {
     return EINVAL;
   }
 
   auto* kernel_ptr =
       reinterpret_cast<struct SedonaCScalarKernel*>(kernels_array);
 
-  s2geography::sedona_udf::AreaKernel(kernel_ptr++);
-  s2geography::sedona_udf::CentroidKernel(kernel_ptr++);
-  s2geography::sedona_udf::ClosestPointKernel(kernel_ptr++);
-  s2geography::sedona_udf::ContainsKernel(kernel_ptr++);
-  s2geography::sedona_udf::ConvexHullKernel(kernel_ptr++);
-  s2geography::sedona_udf::DifferenceKernel(kernel_ptr++);
-  s2geography::sedona_udf::DistanceKernel(kernel_ptr++);
-  s2geography::sedona_udf::EqualsKernel(kernel_ptr++);
-  s2geography::sedona_udf::IntersectionKernel(kernel_ptr++);
-  s2geography::sedona_udf::IntersectsKernel(kernel_ptr++);
-  s2geography::sedona_udf::LengthKernel(kernel_ptr++);
-  s2geography::sedona_udf::LineInterpolatePointKernel(kernel_ptr++);
-  s2geography::sedona_udf::LineLocatePointKernel(kernel_ptr++);
-  s2geography::sedona_udf::MaxDistanceKernel(kernel_ptr++);
-  s2geography::sedona_udf::PerimeterKernel(kernel_ptr++);
-  s2geography::sedona_udf::ShortestLineKernel(kernel_ptr++);
-  s2geography::sedona_udf::SymDifferenceKernel(kernel_ptr++);
-  s2geography::sedona_udf::UnionKernel(kernel_ptr++);
-  s2geography::sedona_udf::ReducePrecisionKernel(kernel_ptr++);
-  s2geography::sedona_udf::SimplifyKernel(kernel_ptr++);
-  s2geography::sedona_udf::BufferKernel(kernel_ptr++);
-  s2geography::sedona_udf::BufferQuadSegsKernel(kernel_ptr++);
-  s2geography::sedona_udf::BufferParamsKernel(kernel_ptr++);
-  s2geography::sedona_udf::DistanceWithinKernel(kernel_ptr++);
-  s2geography::sedona_udf::CellIdFromPointKernel(kernel_ptr++);
-  s2geography::sedona_udf::CoveringCellIdsKernel(kernel_ptr++);
-  s2geography::sedona_udf::LongestLineKernel(kernel_ptr++);
+  for (auto init_func : kSedonaKernels) {
+    init_func(kernel_ptr++);
+  }
 
   return 0;
 }
@@ -171,24 +196,26 @@ int S2GeogInitKernels(void* kernels_array, size_t kernels_array_size_bytes,
 // Geography functions
 
 S2GeogErrorCode S2GeogCreate(struct S2Geog** geog) {
-  if (geog == nullptr) {
-    return EINVAL;
-  }
+  S2GEOGRAPHY_C_BEGIN(nullptr);
+  S2GEOGRAPHY_DCHECK(geog != nullptr);
   *geog = new S2Geog();
-  return 0;
+  return S2GEOGRAPHY_OK;
+  S2GEOGRAPHY_C_END(nullptr)
 }
 
-void S2GeogDestroy(struct S2Geog* geog) { delete geog; }
+void S2GeogDestroy(struct S2Geog* geog) {
+  S2GEOGRAPHY_DCHECK(geog != nullptr);
+  delete geog;
+}
 
 // Factory functions
 
 S2GeogErrorCode S2GeogFactoryCreate(struct S2GeogFactory** geog_factory) {
-  if (geog_factory == nullptr) {
-    return EINVAL;
-  }
-
+  S2GEOGRAPHY_C_BEGIN(nullptr);
+  S2GEOGRAPHY_DCHECK(geog_factory != nullptr);
   *geog_factory = new S2GeogFactory();
-  return 0;
+  return S2GEOGRAPHY_OK;
+  S2GEOGRAPHY_C_END(nullptr)
 }
 
 S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
@@ -218,6 +245,7 @@ S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
   ec = GeoArrowGeometryShallowCopy(parsed, &out->geom);
   if (ec != GEOARROW_OK) {
     S2GEOGRAPHY_SET_ERROR(err, "error copying geometry nodes");
+    return ec;
   }
 
   out->geog.Init(GeoArrowGeometryAsView(&out->geom));
@@ -227,6 +255,7 @@ S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
 }
 
 void S2GeogFactoryDestroy(struct S2GeogFactory* geog_factory) {
+  S2GEOGRAPHY_DCHECK(geog_factory != nullptr);
   delete geog_factory;
 }
 
@@ -234,11 +263,11 @@ void S2GeogFactoryDestroy(struct S2GeogFactory* geog_factory) {
 
 S2GeogErrorCode S2GeogRectBounderCreate(
     struct S2GeogRectBounder** rect_bounder) {
-  if (rect_bounder == nullptr) {
-    return EINVAL;
-  }
+  S2GEOGRAPHY_C_BEGIN(nullptr);
+  S2GEOGRAPHY_DCHECK(rect_bounder != nullptr);
   *rect_bounder = new S2GeogRectBounder();
   return S2GEOGRAPHY_OK;
+  S2GEOGRAPHY_C_END(nullptr)
 }
 
 void S2GeogRectBounderClear(struct S2GeogRectBounder* rect_bounder) {
@@ -262,7 +291,7 @@ S2GeogErrorCode S2GeogRectBounderBound(struct S2GeogRectBounder* rect_bounder,
 
 uint8_t S2GeogRectBounderIsEmpty(struct S2GeogRectBounder* rect_bounder) {
   S2GEOGRAPHY_DCHECK(rect_bounder != nullptr);
-  return rect_bounder->bounder.Finish().is_empty() ? 1 : 0;
+  return rect_bounder->bounder.is_empty();
 }
 
 S2GeogErrorCode S2GeogRectBounderFinish(struct S2GeogRectBounder* rect_bounder,
@@ -292,6 +321,7 @@ S2GeogErrorCode S2GeogRectBounderFinish(struct S2GeogRectBounder* rect_bounder,
 }
 
 void S2GeogRectBounderDestroy(struct S2GeogRectBounder* rect_bounder) {
+  S2GEOGRAPHY_DCHECK(rect_bounder != nullptr);
   delete rect_bounder;
 }
 

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -100,7 +100,7 @@ S2GeogErrorCode S2GeogErrorCreate(struct S2GeogError** err) {
   S2GEOGRAPHY_C_END(nullptr)
 }
 
-const char* S2GeogErrorGetMessage(struct S2GeogError* err) {
+const char* S2GeogErrorGetMessage(const struct S2GeogError* err) {
   if (err == nullptr) {
     return "";
   }
@@ -235,8 +235,8 @@ S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
   src.size_bytes = static_cast<int64_t>(buf_size);
 
   struct GeoArrowGeometryView parsed;
-  GeoArrowErrorCode ec = S2GeographyGeoArrowWKBReaderRead(
-      &geog_factory->wkb_reader, src, &parsed, &geog_factory->error);
+  GeoArrowErrorCode ec = GeoArrowWKBReaderRead(&geog_factory->wkb_reader, src,
+                                               &parsed, &geog_factory->error);
   if (ec != GEOARROW_OK) {
     S2GEOGRAPHY_SET_ERROR(err, geog_factory->error.message);
     return ec;

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -114,7 +114,7 @@ void S2GeogErrorDestroy(struct S2GeogError* err) {
 
 // Cell ID function
 
-uint64_t S2GeogLngLatToCellId(struct S2GeogVertex* v) {
+uint64_t S2GeogLngLatToCellId(const struct S2GeogVertex* v) {
   S2GEOGRAPHY_DCHECK(v != nullptr);
 
   if (std::isnan(v->v[0]) || std::isnan(v->v[1])) {
@@ -276,7 +276,7 @@ void S2GeogRectBounderClear(struct S2GeogRectBounder* rect_bounder) {
 }
 
 S2GeogErrorCode S2GeogRectBounderBound(struct S2GeogRectBounder* rect_bounder,
-                                       struct S2Geog* geog,
+                                       const struct S2Geog* geog,
                                        struct S2GeogError* err) {
   S2GEOGRAPHY_C_BEGIN(err);
 

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -1,0 +1,263 @@
+
+#include "s2geography_c.h"
+
+#include <openssl/opensslv.h>
+#include <s2geography/accessors-geog.h>
+#include <s2geography/accessors.h>
+#include <s2geography/build.h>
+#include <s2geography/coverings.h>
+#include <s2geography/distance.h>
+#include <s2geography/linear-referencing.h>
+#include <s2geography/predicates.h>
+#include <s2geography/sedona_udf/sedona_extension.h>
+
+#include <cstring>
+#include <string>
+
+#include "absl/base/config.h"
+#include "geoarrow/geoarrow.h"
+#include "nanoarrow/nanoarrow.h"
+#include "s2geography/geoarrow-geography.h"
+#include "s2geography/sedona_udf/sedona_extension.h"
+
+// Helper macros
+
+#define S2GEOGRAPHY_SET_ERROR(err, value) \
+  if ((err) != nullptr) {                 \
+    err->message = (value);               \
+  }
+
+#define S2GEOGRAPHY_C_BEGIN(err)  \
+  S2GEOGRAPHY_SET_ERROR(err, ""); \
+  try {
+#define S2GEOGRAPHY_C_END(err)                   \
+  }                                              \
+  catch (std::exception & e) {                   \
+    S2GEOGRAPHY_SET_ERROR(err, e.what());        \
+    return EINVAL;                               \
+  }                                              \
+  catch (...) {                                  \
+    S2GEOGRAPHY_SET_ERROR(err, "unknown error"); \
+    return EINVAL;                               \
+  }
+
+// Struct definitions
+
+struct S2GeogError {
+  std::string message;
+};
+
+struct S2Geog {
+  // The main object that is being wrapped
+  s2geography::GeoArrowGeography geog;
+
+  // Owns the GeoArrowGeometryView and possibly the coordinates
+  struct GeoArrowGeometry geom;
+
+  S2Geog() { GeoArrowGeometryInit(&geom); }
+  ~S2Geog() { GeoArrowGeometryReset(&geom); }
+
+  // Non-copyable
+  S2Geog(const S2Geog&) = delete;
+  S2Geog& operator=(const S2Geog&) = delete;
+};
+
+struct S2GeogFactory {
+  struct GeoArrowWKBReader wkb_reader;
+  struct GeoArrowError error;
+
+  S2GeogFactory() {
+    GeoArrowWKBReaderInit(&wkb_reader);
+    error.message[0] = '\0';
+  }
+  ~S2GeogFactory() { GeoArrowWKBReaderReset(&wkb_reader); }
+
+  // Non-copyable
+  S2GeogFactory(const S2GeogFactory&) = delete;
+  S2GeogFactory& operator=(const S2GeogFactory&) = delete;
+};
+
+// Error handling functions
+
+S2GeogErrorCode S2GeogErrorCreate(struct S2GeogError** err) {
+  if (err == nullptr) {
+    return -1;
+  }
+  *err = new S2GeogError();
+  return 0;
+}
+
+const char* S2GeogErrorGetMessage(struct S2GeogError* err) {
+  if (err == nullptr) {
+    return "";
+  }
+  return err->message.c_str();
+}
+
+void S2GeogErrorDestroy(struct S2GeogError* err) { delete err; }
+
+// Cell ID function
+
+uint64_t S2GeogLngLatToCellId(double lng, double lat) {
+  if (std::isnan(lng) || std::isnan(lat)) {
+    return S2CellId::Sentinel().id();
+  } else {
+    return S2CellId(S2LatLng::FromDegrees(lat, lng).Normalized().ToPoint())
+        .id();
+  }
+}
+
+// Kernel functions
+
+size_t S2GeogNumKernels(void) { return 27; }
+
+int S2GeogInitKernels(void* kernels_array, size_t kernels_array_size_bytes,
+                      int format) {
+  if (format != S2GEOGRAPHY_KERNEL_FORMAT_SEDONA_UDF) {
+    return ENOTSUP;
+  }
+
+  if (kernels_array_size_bytes !=
+      (sizeof(SedonaCScalarKernel) * S2GeogNumKernels())) {
+    return EINVAL;
+  }
+
+  auto* kernel_ptr =
+      reinterpret_cast<struct SedonaCScalarKernel*>(kernels_array);
+
+  s2geography::sedona_udf::AreaKernel(kernel_ptr++);
+  s2geography::sedona_udf::CentroidKernel(kernel_ptr++);
+  s2geography::sedona_udf::ClosestPointKernel(kernel_ptr++);
+  s2geography::sedona_udf::ContainsKernel(kernel_ptr++);
+  s2geography::sedona_udf::ConvexHullKernel(kernel_ptr++);
+  s2geography::sedona_udf::DifferenceKernel(kernel_ptr++);
+  s2geography::sedona_udf::DistanceKernel(kernel_ptr++);
+  s2geography::sedona_udf::EqualsKernel(kernel_ptr++);
+  s2geography::sedona_udf::IntersectionKernel(kernel_ptr++);
+  s2geography::sedona_udf::IntersectsKernel(kernel_ptr++);
+  s2geography::sedona_udf::LengthKernel(kernel_ptr++);
+  s2geography::sedona_udf::LineInterpolatePointKernel(kernel_ptr++);
+  s2geography::sedona_udf::LineLocatePointKernel(kernel_ptr++);
+  s2geography::sedona_udf::MaxDistanceKernel(kernel_ptr++);
+  s2geography::sedona_udf::PerimeterKernel(kernel_ptr++);
+  s2geography::sedona_udf::ShortestLineKernel(kernel_ptr++);
+  s2geography::sedona_udf::SymDifferenceKernel(kernel_ptr++);
+  s2geography::sedona_udf::UnionKernel(kernel_ptr++);
+  s2geography::sedona_udf::ReducePrecisionKernel(kernel_ptr++);
+  s2geography::sedona_udf::SimplifyKernel(kernel_ptr++);
+  s2geography::sedona_udf::BufferKernel(kernel_ptr++);
+  s2geography::sedona_udf::BufferQuadSegsKernel(kernel_ptr++);
+  s2geography::sedona_udf::BufferParamsKernel(kernel_ptr++);
+  s2geography::sedona_udf::DistanceWithinKernel(kernel_ptr++);
+  s2geography::sedona_udf::CellIdFromPointKernel(kernel_ptr++);
+  s2geography::sedona_udf::CoveringCellIdsKernel(kernel_ptr++);
+  s2geography::sedona_udf::LongestLineKernel(kernel_ptr++);
+
+  return 0;
+}
+
+// Geography functions
+
+S2GeogErrorCode S2GeogCreate(struct S2Geog** geog) {
+  if (geog == nullptr) {
+    return EINVAL;
+  }
+  *geog = new S2Geog();
+  return 0;
+}
+
+void S2GeogDestroy(struct S2Geog* geog) { delete geog; }
+
+// Factory functions
+
+S2GeogErrorCode S2GeogFactoryCreate(struct S2GeogFactory** geog_factory) {
+  if (geog_factory == nullptr) {
+    return EINVAL;
+  }
+
+  *geog_factory = new S2GeogFactory();
+  return 0;
+}
+
+S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
+    struct S2GeogFactory* geog_factory, const uint8_t* buf, size_t buf_size,
+    struct S2Geog* out, struct S2GeogError* err) {
+  S2GEOGRAPHY_C_BEGIN(err);
+
+  S2GEOGRAPHY_DCHECK(geog_factory != nullptr);
+  S2GEOGRAPHY_DCHECK(out != nullptr);
+  S2GEOGRAPHY_DCHECK(buf != nullptr || buf_size == 0);
+
+  // Reset the parse error
+  geog_factory->error.message[0] = '\0';
+
+  struct GeoArrowBufferView src;
+  src.data = buf;
+  src.size_bytes = static_cast<int64_t>(buf_size);
+
+  struct GeoArrowGeometryView parsed;
+  GeoArrowErrorCode ec = S2GeographyGeoArrowWKBReaderRead(
+      &geog_factory->wkb_reader, src, &parsed, &geog_factory->error);
+  if (ec != GEOARROW_OK) {
+    S2GEOGRAPHY_SET_ERROR(err, geog_factory->error.message);
+    return ec;
+  }
+
+  ec = GeoArrowGeometryShallowCopy(parsed, &out->geom);
+  if (ec != GEOARROW_OK) {
+    S2GEOGRAPHY_SET_ERROR(err, "error copying geometry nodes");
+  }
+
+  out->geog.Init(GeoArrowGeometryAsView(&out->geom));
+
+  return S2GEOGRAPHY_OK;
+  S2GEOGRAPHY_C_END(err);
+}
+
+void S2GeogFactoryDestroy(struct S2GeogFactory* geog_factory) {
+  delete geog_factory;
+}
+
+// Version functions
+
+const char* S2GeogNanoarrowVersion(void) {
+  static std::string version = std::string() +
+                               std::to_string(NANOARROW_VERSION_MAJOR) + "." +
+                               std::to_string(NANOARROW_VERSION_MINOR) + "." +
+                               std::to_string(NANOARROW_VERSION_PATCH);
+  return version.c_str();
+}
+
+const char* S2GeogGeoArrowVersion(void) {
+  static std::string version = std::string() +
+                               std::to_string(GEOARROW_VERSION_MAJOR) + "." +
+                               std::to_string(GEOARROW_VERSION_MINOR) + "." +
+                               std::to_string(GEOARROW_VERSION_PATCH);
+  return version.c_str();
+}
+
+const char* S2GeogOpenSSLVersion(void) {
+  static std::string version = std::string() +
+                               std::to_string(OPENSSL_VERSION_MAJOR) + "." +
+                               std::to_string(OPENSSL_VERSION_MINOR) + "." +
+                               std::to_string(OPENSSL_VERSION_PATCH);
+  return version.c_str();
+}
+
+const char* S2GeogS2GeometryVersion(void) {
+  static std::string version =
+      std::string() + std::to_string(S2_VERSION_MAJOR) + "." +
+      std::to_string(S2_VERSION_MINOR) + "." + std::to_string(S2_VERSION_PATCH);
+  return version.c_str();
+}
+
+const char* S2GeogAbseilVersion(void) {
+#if defined(ABSL_LTS_RELEASE_VERSION)
+  static std::string version = std::string() +
+                               std::to_string(ABSL_LTS_RELEASE_VERSION) + "." +
+                               std::to_string(ABSL_LTS_RELEASE_PATCH_LEVEL);
+  return version.c_str();
+#else
+  return "<live at head>";
+#endif
+}

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -77,6 +77,17 @@ struct S2GeogFactory {
   S2GeogFactory& operator=(const S2GeogFactory&) = delete;
 };
 
+struct S2GeogRectBounder {
+  s2geography::LatLngRectBounder bounder;
+
+  // Non-copyable
+  S2GeogRectBounder(const S2GeogRectBounder&) = delete;
+  S2GeogRectBounder& operator=(const S2GeogRectBounder&) = delete;
+
+  S2GeogRectBounder() = default;
+  ~S2GeogRectBounder() = default;
+};
+
 // Error handling functions
 
 S2GeogErrorCode S2GeogErrorCreate(struct S2GeogError** err) {
@@ -98,11 +109,12 @@ void S2GeogErrorDestroy(struct S2GeogError* err) { delete err; }
 
 // Cell ID function
 
-uint64_t S2GeogLngLatToCellId(double lng, double lat) {
-  if (std::isnan(lng) || std::isnan(lat)) {
+uint64_t S2GeogLngLatToCellId(struct S2GeogVertex* v) {
+  if (std::isnan(v->v[0]) || std::isnan(v->v[1])) {
     return S2CellId::Sentinel().id();
   } else {
-    return S2CellId(S2LatLng::FromDegrees(lat, lng).Normalized().ToPoint())
+    return S2CellId(
+               S2LatLng::FromDegrees(v->v[1], v->v[0]).Normalized().ToPoint())
         .id();
   }
 }
@@ -216,6 +228,71 @@ S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
 
 void S2GeogFactoryDestroy(struct S2GeogFactory* geog_factory) {
   delete geog_factory;
+}
+
+// Rectangle bounder functions
+
+S2GeogErrorCode S2GeogRectBounderCreate(
+    struct S2GeogRectBounder** rect_bounder) {
+  if (rect_bounder == nullptr) {
+    return EINVAL;
+  }
+  *rect_bounder = new S2GeogRectBounder();
+  return S2GEOGRAPHY_OK;
+}
+
+void S2GeogRectBounderClear(struct S2GeogRectBounder* rect_bounder) {
+  S2GEOGRAPHY_DCHECK(rect_bounder != nullptr);
+  rect_bounder->bounder.Clear();
+}
+
+S2GeogErrorCode S2GeogRectBounderBound(struct S2GeogRectBounder* rect_bounder,
+                                       struct S2Geog* geog,
+                                       struct S2GeogError* err) {
+  S2GEOGRAPHY_C_BEGIN(err);
+
+  S2GEOGRAPHY_DCHECK(rect_bounder != nullptr);
+  S2GEOGRAPHY_DCHECK(geog != nullptr);
+
+  rect_bounder->bounder.Update(geog->geog);
+
+  return S2GEOGRAPHY_OK;
+  S2GEOGRAPHY_C_END(err);
+}
+
+uint8_t S2GeogRectBounderIsEmpty(struct S2GeogRectBounder* rect_bounder) {
+  S2GEOGRAPHY_DCHECK(rect_bounder != nullptr);
+  return rect_bounder->bounder.Finish().is_empty() ? 1 : 0;
+}
+
+S2GeogErrorCode S2GeogRectBounderFinish(struct S2GeogRectBounder* rect_bounder,
+                                        struct S2GeogVertex* lo,
+                                        struct S2GeogVertex* hi,
+                                        struct S2GeogError* err) {
+  S2GEOGRAPHY_C_BEGIN(err);
+
+  S2GEOGRAPHY_DCHECK(rect_bounder != nullptr);
+  S2GEOGRAPHY_DCHECK(lo != nullptr);
+  S2GEOGRAPHY_DCHECK(hi != nullptr);
+
+  S2LatLngRect rect = rect_bounder->bounder.Finish();
+
+  lo->v[0] = rect.lng_lo().degrees();
+  lo->v[1] = rect.lat_lo().degrees();
+  lo->v[2] = 0;
+  lo->v[3] = 0;
+
+  hi->v[0] = rect.lng_hi().degrees();
+  hi->v[1] = rect.lat_hi().degrees();
+  hi->v[2] = 0;
+  hi->v[3] = 0;
+
+  return S2GEOGRAPHY_OK;
+  S2GEOGRAPHY_C_END(err);
+}
+
+void S2GeogRectBounderDestroy(struct S2GeogRectBounder* rect_bounder) {
+  delete rect_bounder;
 }
 
 // Version functions

--- a/src/capi/s2geography_c.h
+++ b/src/capi/s2geography_c.h
@@ -39,34 +39,16 @@ void S2GeogErrorDestroy(struct S2GeogError* err);
 
 /// \defgroup cell_functions Cell Functions
 /// Functions for working with S2 cell identifiers.
-/// @{
-
-/// \brief Convert longitude/latitude to an S2 cell ID
-uint64_t S2GeogLngLatToCellId(double lng, double lat);
-
-/// @}
-
-/// \defgroup sedona_udf Sedona UDF Interface
-///
-/// Interface for user-defined functions. These functions take Arrow as input
-/// and produce Arrow as output and are useful as a generic interface to avoid
-/// verbose wrappers around S2 functions. Consuming S2Geography in this way has
-/// the disadvantage that preparatory work (e.g., preparing a geography) is not
-/// effectively reused between calls.
 ///
 /// @{
 
-/// \brief Kernel format for Apache Sedona's scalar UDF extension
-#define S2GEOGRAPHY_KERNEL_FORMAT_SEDONA_UDF 1
+/// \brief Vertex used as common input/output for vertices
+struct S2GeogVertex {
+  double v[4];
+};
 
-/// \brief The number of user-defined functions to be exported
-size_t S2GeogNumKernels(void);
-
-/// \brief Export functions into an array of the appropriate type
-///
-/// The only currently supported format is S2GEOGRAPHY_KERNEL_FORMAT_SEDONA_UDF.
-S2GeogErrorCode S2GeogInitKernels(void* kernels_array,
-                                  size_t kernels_array_size_bytes, int format);
+/// \brief Convert vertex of longitude/latitude to an S2 cell ID
+uint64_t S2GeogLngLatToCellId(struct S2GeogVertex* vertex);
 
 /// @}
 
@@ -104,6 +86,66 @@ S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
 
 /// \brief Destroy a geography factory
 void S2GeogFactoryDestroy(struct S2GeogFactory* geog_factory);
+
+/// @}
+
+/// \defgroup bounding Rectangle bounding
+/// Functions for computing a rectangular bounding area
+///
+/// @{
+
+/// \brief Opaque rectangle bounder object
+struct S2GeogRectBounder;
+
+/// \brief Create a new rectangle bounder
+S2GeogErrorCode S2GeogRectBounderCreate(
+    struct S2GeogRectBounder** rect_bounder);
+
+/// \brief Clear accumulated bounds from the rectangle bounder
+void S2GeogRectBounderClear(struct S2GeogRectBounder* rect_bounder);
+
+/// \brief Add a geography's bounds to the rectangle bounder
+S2GeogErrorCode S2GeogRectBounderBound(struct S2GeogRectBounder* rect_bounder,
+                                       struct S2Geog* geog,
+                                       struct S2GeogError* err);
+
+/// \brief Return 1 if the rectangle that would be returned represents empty
+/// bounds or 0 otherwise
+uint8_t S2GeogRectBounderIsEmpty(struct S2GeogRectBounder* rect_bounder);
+
+/// \brief Finish bounding and retrieve the lo/hi corners of the bounding
+/// rectangle
+S2GeogErrorCode S2GeogRectBounderFinish(struct S2GeogRectBounder* rect_bounder,
+                                        struct S2GeogVertex* lo,
+                                        struct S2GeogVertex* hi,
+                                        struct S2GeogError* err);
+
+/// \brief Destroy a rectangle bounder
+void S2GeogRectBounderDestroy(struct S2GeogRectBounder* rect_bounder);
+
+/// @}
+
+/// \defgroup sedona_udf Sedona UDF Interface
+///
+/// Interface for user-defined functions. These functions take Arrow as input
+/// and produce Arrow as output and are useful as a generic interface to avoid
+/// verbose wrappers around S2 functions. Consuming S2Geography in this way has
+/// the disadvantage that preparatory work (e.g., preparing a geography) is not
+/// effectively reused between calls.
+///
+/// @{
+
+/// \brief Kernel format for Apache Sedona's scalar UDF extension
+#define S2GEOGRAPHY_KERNEL_FORMAT_SEDONA_UDF 1
+
+/// \brief The number of user-defined functions to be exported
+size_t S2GeogNumKernels(void);
+
+/// \brief Export functions into an array of the appropriate type
+///
+/// The only currently supported format is S2GEOGRAPHY_KERNEL_FORMAT_SEDONA_UDF.
+S2GeogErrorCode S2GeogInitKernels(void* kernels_array,
+                                  size_t kernels_array_size_bytes, int format);
 
 /// @}
 

--- a/src/capi/s2geography_c.h
+++ b/src/capi/s2geography_c.h
@@ -1,19 +1,3 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
 
 #include <stddef.h>
 #include <stdint.h>
@@ -28,50 +12,122 @@ extern "C" {
 /// s2geography from C or languages that provide C FFI infrastructure
 /// such as Rust or Julia.
 
+/// \defgroup error_handling Error Handling
+/// Functions for creating and managing error objects.
+///
+/// @{
+
+/// \brief An errno-compatible error code
 typedef int S2GeogErrorCode;
 
+/// \brief Value returned on success
+#define S2GEOGRAPHY_OK 0
+
+/// \brief Opaque error object containing error details
 struct S2GeogError;
 
+/// \brief Create a new error object
 S2GeogErrorCode S2GeogErrorCreate(struct S2GeogError** err);
 
+/// \brief Get the error message from an error object
 const char* S2GeogErrorGetMessage(struct S2GeogError* err);
 
+/// \brief Destroy an error object
 void S2GeogErrorDestroy(struct S2GeogError* err);
 
-const char* S2GeogNanoarrowVersion(void);
+/// @}
 
-const char* S2GeogGeoArrowVersion(void);
+/// \defgroup cell_functions Cell Functions
+/// Functions for working with S2 cell identifiers.
+/// @{
 
-const char* S2GeogOpenSSLVersion(void);
-
-const char* S2GeogS2GeometryVersion(void);
-
-const char* S2GeogAbseilVersion(void);
-
+/// \brief Convert longitude/latitude to an S2 cell ID
 uint64_t S2GeogLngLatToCellId(double lng, double lat);
 
+/// @}
+
+/// \defgroup sedona_udf Sedona UDF Interface
+///
+/// Interface for user-defined functions. These functions take Arrow as input
+/// and produce Arrow as output and are useful as a generic interface to avoid
+/// verbose wrappers around S2 functions. Consuming S2Geography in this way has
+/// the disadvantage that preparatory work (e.g., preparing a geography) is not
+/// effectively reused between calls.
+///
+/// @{
+
+/// \brief Kernel format for Apache Sedona's scalar UDF extension
 #define S2GEOGRAPHY_KERNEL_FORMAT_SEDONA_UDF 1
 
+/// \brief The number of user-defined functions to be exported
 size_t S2GeogNumKernels(void);
 
-int S2GeogInitKernels(void* kernels_array, size_t kernels_array_size_bytes,
-                      int format);
+/// \brief Export functions into an array of the appropriate type
+///
+/// The only currently supported format is S2GEOGRAPHY_KERNEL_FORMAT_SEDONA_UDF.
+S2GeogErrorCode S2GeogInitKernels(void* kernels_array,
+                                  size_t kernels_array_size_bytes, int format);
 
+/// @}
+
+/// \defgroup geography_accessors Geography Accessors
+/// Basic geography object creation and destruction.
+///
+/// @{
+
+/// \brief Opaque geography object
 struct S2Geog;
 
+/// \brief Create an empty geography object
 S2GeogErrorCode S2GeogCreate(struct S2Geog** geog);
 
+/// \brief Destroy a geography object
 void S2GeogDestroy(struct S2Geog* geog);
 
+/// @}
+
+/// \defgroup geography_factory Geography Factory
+/// Factory for creating geography objects from various formats.
+///
+/// @{
+
+/// \brief Opaque factory for creating geography objects
 struct S2GeogFactory;
 
+/// \brief Create a new geography factory
 S2GeogErrorCode S2GeogFactoryCreate(struct S2GeogFactory** geog_factory);
 
+/// \brief Create a geography from WKB without taking ownership of the buffer
 S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
     struct S2GeogFactory* geog_factory, const uint8_t* buf, size_t buf_size,
-    struct S2Geog** out, struct S2GeogError* err);
+    struct S2Geog* out, struct S2GeogError* err);
 
+/// \brief Destroy a geography factory
 void S2GeogFactoryDestroy(struct S2GeogFactory* geog_factory);
+
+/// @}
+
+/// \defgroup versions Version Information
+/// Functions for retrieving version information of dependencies.
+///
+/// @{
+
+/// \brief Get the nanoarrow library version
+const char* S2GeogNanoarrowVersion(void);
+
+/// \brief Get the GeoArrow library version
+const char* S2GeogGeoArrowVersion(void);
+
+/// \brief Get the OpenSSL library version
+const char* S2GeogOpenSSLVersion(void);
+
+/// \brief Get the S2Geometry library version
+const char* S2GeogS2GeometryVersion(void);
+
+/// \brief Get the Abseil library version
+const char* S2GeogAbseilVersion(void);
+
+/// @}
 
 #ifdef __cplusplus
 }

--- a/src/capi/s2geography_c.h
+++ b/src/capi/s2geography_c.h
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// \file geography_glue.h
+///
+/// This file exposes C functions and/or data structures used to call
+/// s2geography from C or languages that provide C FFI infrastructure
+/// such as Rust or Julia.
+
+typedef int S2GeogErrorCode;
+
+struct S2GeogError;
+
+S2GeogErrorCode S2GeogErrorCreate(struct S2GeogError** err);
+
+const char* S2GeogErrorGetMessage(struct S2GeogError* err);
+
+void S2GeogErrorDestroy(struct S2GeogError* err);
+
+const char* S2GeogNanoarrowVersion(void);
+
+const char* S2GeogGeoArrowVersion(void);
+
+const char* S2GeogOpenSSLVersion(void);
+
+const char* S2GeogS2GeometryVersion(void);
+
+const char* S2GeogAbseilVersion(void);
+
+uint64_t S2GeogLngLatToCellId(double lng, double lat);
+
+#define S2GEOGRAPHY_KERNEL_FORMAT_SEDONA_UDF 1
+
+size_t S2GeogNumKernels(void);
+
+int S2GeogInitKernels(void* kernels_array, size_t kernels_array_size_bytes,
+                      int format);
+
+struct S2Geog;
+
+S2GeogErrorCode S2GeogCreate(struct S2Geog** geog);
+
+void S2GeogDestroy(struct S2Geog* geog);
+
+struct S2GeogFactory;
+
+S2GeogErrorCode S2GeogFactoryCreate(struct S2GeogFactory** geog_factory);
+
+S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
+    struct S2GeogFactory* geog_factory, const uint8_t* buf, size_t buf_size,
+    struct S2Geog** out, struct S2GeogError* err);
+
+void S2GeogFactoryDestroy(struct S2GeogFactory* geog_factory);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -20,16 +20,9 @@
 
 TEST(S2GeographyC, ErrorCreate) {
   struct S2GeogError* err = nullptr;
-  S2GeogErrorCode code = S2GeogErrorCreate(&err);
-  ASSERT_EQ(code, S2GEOGRAPHY_OK);
+  ASSERT_EQ(S2GeogErrorCreate(&err), S2GEOGRAPHY_OK);
   ASSERT_NE(err, nullptr);
   S2GeogErrorDestroy(err);
-}
-
-TEST(S2GeographyC, ErrorCreateNull) {
-  // Creating with null pointer should return error
-  S2GeogErrorCode code = S2GeogErrorCreate(nullptr);
-  EXPECT_NE(code, S2GEOGRAPHY_OK);
 }
 
 TEST(S2GeographyC, ErrorGetMessage) {
@@ -42,13 +35,6 @@ TEST(S2GeographyC, ErrorGetMessage) {
   EXPECT_EQ(strlen(msg), 0);
 
   S2GeogErrorDestroy(err);
-}
-
-TEST(S2GeographyC, ErrorGetMessageNull) {
-  // Getting message from null error should return empty string
-  const char* msg = S2GeogErrorGetMessage(nullptr);
-  ASSERT_NE(msg, nullptr);
-  EXPECT_EQ(strlen(msg), 0);
 }
 
 // ============================================================================
@@ -98,11 +84,6 @@ TEST(S2GeographyC, GeogCreate) {
   S2GeogDestroy(geog);
 }
 
-TEST(S2GeographyC, GeogCreateNull) {
-  S2GeogErrorCode code = S2GeogCreate(nullptr);
-  EXPECT_NE(code, S2GEOGRAPHY_OK);
-}
-
 // ============================================================================
 // Geography Factory Tests
 // ============================================================================
@@ -113,11 +94,6 @@ TEST(S2GeographyC, FactoryCreate) {
   ASSERT_EQ(code, S2GEOGRAPHY_OK);
   ASSERT_NE(factory, nullptr);
   S2GeogFactoryDestroy(factory);
-}
-
-TEST(S2GeographyC, FactoryCreateNull) {
-  S2GeogErrorCode code = S2GeogFactoryCreate(nullptr);
-  EXPECT_NE(code, S2GEOGRAPHY_OK);
 }
 
 TEST(S2GeographyC, FactoryInitFromWkbPoint) {

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -27,7 +27,7 @@ TEST(S2GeographyC, ErrorCreate) {
 
 TEST(S2GeographyC, ErrorGetMessage) {
   struct S2GeogError* err = nullptr;
-  S2GeogErrorCreate(&err);
+  ASSERT_EQ(S2GeogErrorCreate(&err), S2GEOGRAPHY_OK);
 
   // Fresh error should have empty message
   const char* msg = S2GeogErrorGetMessage(err);
@@ -90,8 +90,7 @@ TEST(S2GeographyC, GeogCreate) {
 
 TEST(S2GeographyC, FactoryCreate) {
   struct S2GeogFactory* factory = nullptr;
-  S2GeogErrorCode code = S2GeogFactoryCreate(&factory);
-  ASSERT_EQ(code, S2GEOGRAPHY_OK);
+  ASSERT_EQ(S2GeogFactoryCreate(&factory), S2GEOGRAPHY_OK);
   ASSERT_NE(factory, nullptr);
   S2GeogFactoryDestroy(factory);
 }
@@ -106,13 +105,13 @@ TEST(S2GeographyC, FactoryInitFromWkbPoint) {
   };
 
   struct S2GeogFactory* factory = nullptr;
-  S2GeogFactoryCreate(&factory);
+  ASSERT_EQ(S2GeogFactoryCreate(&factory), S2GEOGRAPHY_OK);
 
   struct S2Geog* geog = nullptr;
-  S2GeogCreate(&geog);
+  ASSERT_EQ(S2GeogCreate(&geog), S2GEOGRAPHY_OK);
 
   struct S2GeogError* err = nullptr;
-  S2GeogErrorCreate(&err);
+  ASSERT_EQ(S2GeogErrorCreate(&err), S2GEOGRAPHY_OK);
 
   S2GeogErrorCode code = S2GeogFactoryInitFromWkbNonOwning(
       factory, wkb_point, sizeof(wkb_point), geog, err);
@@ -137,19 +136,19 @@ TEST(S2GeographyC, RectBounderBound) {
   };
 
   struct S2GeogFactory* factory = nullptr;
-  S2GeogFactoryCreate(&factory);
+  ASSERT_EQ(S2GeogFactoryCreate(&factory), S2GEOGRAPHY_OK);
 
   struct S2Geog* geog = nullptr;
-  S2GeogCreate(&geog);
+  ASSERT_EQ(S2GeogCreate(&geog), S2GEOGRAPHY_OK);
 
   struct S2GeogError* err = nullptr;
-  S2GeogErrorCreate(&err);
+  ASSERT_EQ(S2GeogErrorCreate(&err), S2GEOGRAPHY_OK);
 
   S2GeogFactoryInitFromWkbNonOwning(factory, wkb_point, sizeof(wkb_point), geog,
                                     err);
 
   struct S2GeogRectBounder* bounder = nullptr;
-  S2GeogRectBounderCreate(&bounder);
+  ASSERT_EQ(S2GeogRectBounderCreate(&bounder), S2GEOGRAPHY_OK);
 
   // Fresh bounder should be empty
   EXPECT_EQ(S2GeogRectBounderIsEmpty(bounder), 1);

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -2,6 +2,7 @@
 #include "capi/s2geography_c.h"
 
 #include <gtest/gtest.h>
+#include <s2/s2cell_id.h>
 
 #include <limits>
 
@@ -63,8 +64,7 @@ TEST(S2GeographyC, LngLatToCellId) {
   uint64_t cell_id = S2GeogLngLatToCellId(&vertex);
 
   // Should return a valid (non-sentinel) cell ID
-  // S2CellId::Sentinel().id() is 0
-  EXPECT_NE(cell_id, 0);
+  EXPECT_NE(cell_id, S2CellId::Sentinel().id());
 }
 
 TEST(S2GeographyC, LngLatToCellIdNaN) {
@@ -73,7 +73,7 @@ TEST(S2GeographyC, LngLatToCellIdNaN) {
   vertex.v[0] = std::numeric_limits<double>::quiet_NaN();
   vertex.v[1] = 40.0;
 
-  uint64_t cell_id = S2GeogLngLatToCellId(&vertex);
+  EXPECT_EQ(S2GeogLngLatToCellId(&vertex), S2CellId::Sentinel().id());
 
   // Should return sentinel cell ID for NaN input
   // S2CellId::Sentinel().id() is expected here
@@ -81,11 +81,7 @@ TEST(S2GeographyC, LngLatToCellIdNaN) {
   struct S2GeogVertex vertex2;
   vertex2.v[0] = 0.0;
   vertex2.v[1] = std::numeric_limits<double>::quiet_NaN();
-  ;
-  uint64_t cell_id2 = S2GeogLngLatToCellId(&vertex2);
-
-  // Both NaN cases should return the same sentinel
-  EXPECT_EQ(cell_id, cell_id2);
+  EXPECT_EQ(S2GeogLngLatToCellId(&vertex2), S2CellId::Sentinel().id());
 }
 
 // ============================================================================
@@ -153,40 +149,6 @@ TEST(S2GeographyC, FactoryInitFromWkbPoint) {
 // Rectangle Bounder Tests
 // ============================================================================
 
-TEST(S2GeographyC, RectBounderCreate) {
-  struct S2GeogRectBounder* bounder = nullptr;
-  S2GeogErrorCode code = S2GeogRectBounderCreate(&bounder);
-  ASSERT_EQ(code, S2GEOGRAPHY_OK);
-  ASSERT_NE(bounder, nullptr);
-  S2GeogRectBounderDestroy(bounder);
-}
-
-TEST(S2GeographyC, RectBounderCreateNull) {
-  S2GeogErrorCode code = S2GeogRectBounderCreate(nullptr);
-  EXPECT_NE(code, S2GEOGRAPHY_OK);
-}
-
-TEST(S2GeographyC, RectBounderClear) {
-  struct S2GeogRectBounder* bounder = nullptr;
-  S2GeogRectBounderCreate(&bounder);
-
-  // Just verify it doesn't crash
-  S2GeogRectBounderClear(bounder);
-
-  S2GeogRectBounderDestroy(bounder);
-}
-
-TEST(S2GeographyC, RectBounderIsEmpty) {
-  struct S2GeogRectBounder* bounder = nullptr;
-  S2GeogRectBounderCreate(&bounder);
-
-  // Fresh bounder should be empty
-  uint8_t is_empty = S2GeogRectBounderIsEmpty(bounder);
-  EXPECT_EQ(is_empty, 1);
-
-  S2GeogRectBounderDestroy(bounder);
-}
-
 TEST(S2GeographyC, RectBounderBound) {
   // WKB for POINT(10 20)
   const uint8_t wkb_point[] = {
@@ -211,52 +173,25 @@ TEST(S2GeographyC, RectBounderBound) {
   struct S2GeogRectBounder* bounder = nullptr;
   S2GeogRectBounderCreate(&bounder);
 
-  S2GeogErrorCode code = S2GeogRectBounderBound(bounder, geog, err);
-  EXPECT_EQ(code, S2GEOGRAPHY_OK);
+  // Fresh bounder should be empty
+  EXPECT_EQ(S2GeogRectBounderIsEmpty(bounder), 1);
 
-  // After bounding a point, should no longer be empty
-  uint8_t is_empty = S2GeogRectBounderIsEmpty(bounder);
-  EXPECT_EQ(is_empty, 0);
-
-  S2GeogRectBounderDestroy(bounder);
-  S2GeogErrorDestroy(err);
-  S2GeogDestroy(geog);
-  S2GeogFactoryDestroy(factory);
-}
-
-TEST(S2GeographyC, RectBounderFinish) {
-  // WKB for POINT(10 20)
-  const uint8_t wkb_point[] = {
-      0x01,                    // byte order: little endian
-      0x01, 0x00, 0x00, 0x00,  // type: Point (1)
-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x24, 0x40,  // x: 10.0
-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x40   // y: 20.0
-  };
-
-  struct S2GeogFactory* factory = nullptr;
-  S2GeogFactoryCreate(&factory);
-
-  struct S2Geog* geog = nullptr;
-  S2GeogCreate(&geog);
-
-  struct S2GeogError* err = nullptr;
-  S2GeogErrorCreate(&err);
-
-  S2GeogFactoryInitFromWkbNonOwning(factory, wkb_point, sizeof(wkb_point), geog,
-                                    err);
-
-  struct S2GeogRectBounder* bounder = nullptr;
-  S2GeogRectBounderCreate(&bounder);
-
+  // Bound a point
   S2GeogRectBounderBound(bounder, geog, err);
 
-  struct S2GeogVertex lo, hi;
-  S2GeogErrorCode code = S2GeogRectBounderFinish(bounder, &lo, &hi, err);
-  EXPECT_EQ(code, S2GEOGRAPHY_OK);
+  // Should no longer be empty
+  EXPECT_EQ(S2GeogRectBounderIsEmpty(bounder), 0);
 
-  // For a single point, lo and hi should be very close
-  EXPECT_NEAR(lo.v[0], hi.v[0], 1e-6);  // longitude
-  EXPECT_NEAR(lo.v[1], hi.v[1], 1e-6);  // latitude
+  struct S2GeogVertex lo, hi;
+  EXPECT_EQ(S2GeogRectBounderFinish(bounder, &lo, &hi, err), S2GEOGRAPHY_OK);
+  EXPECT_LE(lo.v[0], 10);
+  EXPECT_GE(hi.v[0], 10);
+  EXPECT_LE(lo.v[1], 20);
+  EXPECT_GE(hi.v[1], 20);
+
+  // If we clear, the bounder should be empty again
+  S2GeogRectBounderClear(bounder);
+  EXPECT_EQ(S2GeogRectBounderIsEmpty(bounder), 1);
 
   S2GeogRectBounderDestroy(bounder);
   S2GeogErrorDestroy(err);

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -113,9 +113,29 @@ TEST(S2GeographyC, FactoryInitFromWkbPoint) {
   struct S2GeogError* err = nullptr;
   ASSERT_EQ(S2GeogErrorCreate(&err), S2GEOGRAPHY_OK);
 
-  S2GeogErrorCode code = S2GeogFactoryInitFromWkbNonOwning(
-      factory, wkb_point, sizeof(wkb_point), geog, err);
-  EXPECT_EQ(code, S2GEOGRAPHY_OK);
+  EXPECT_EQ(S2GeogFactoryInitFromWkbNonOwning(factory, wkb_point,
+                                              sizeof(wkb_point), geog, err),
+            S2GEOGRAPHY_OK);
+
+  S2GeogErrorDestroy(err);
+  S2GeogDestroy(geog);
+  S2GeogFactoryDestroy(factory);
+}
+
+TEST(S2GeographyC, FactoryInitFromInvalidWkb) {
+  struct S2GeogFactory* factory = nullptr;
+  ASSERT_EQ(S2GeogFactoryCreate(&factory), S2GEOGRAPHY_OK);
+
+  struct S2Geog* geog = nullptr;
+  ASSERT_EQ(S2GeogCreate(&geog), S2GEOGRAPHY_OK);
+
+  struct S2GeogError* err = nullptr;
+  ASSERT_EQ(S2GeogErrorCreate(&err), S2GEOGRAPHY_OK);
+
+  ASSERT_EQ(S2GeogFactoryInitFromWkbNonOwning(factory, nullptr, 0, geog, err),
+            EINVAL);
+  EXPECT_STREQ(S2GeogErrorGetMessage(err),
+               "Expected endian byte but found end of buffer at byte 0");
 
   S2GeogErrorDestroy(err);
   S2GeogDestroy(geog);
@@ -144,8 +164,9 @@ TEST(S2GeographyC, RectBounderBound) {
   struct S2GeogError* err = nullptr;
   ASSERT_EQ(S2GeogErrorCreate(&err), S2GEOGRAPHY_OK);
 
-  S2GeogFactoryInitFromWkbNonOwning(factory, wkb_point, sizeof(wkb_point), geog,
-                                    err);
+  ASSERT_EQ(S2GeogFactoryInitFromWkbNonOwning(factory, wkb_point,
+                                              sizeof(wkb_point), geog, err),
+            S2GEOGRAPHY_OK);
 
   struct S2GeogRectBounder* bounder = nullptr;
   ASSERT_EQ(S2GeogRectBounderCreate(&bounder), S2GEOGRAPHY_OK);

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -180,13 +180,7 @@ TEST(S2GeographyC, RectBounderBound) {
 // Sedona UDF Interface Tests
 // ============================================================================
 
-TEST(S2GeographyC, NumKernels) {
-  size_t num_kernels = S2GeogNumKernels();
-  // Should have at least some kernels
-  EXPECT_GT(num_kernels, 0);
-  // Current implementation has 27 kernels
-  EXPECT_EQ(num_kernels, 27);
-}
+TEST(S2GeographyC, NumKernels) { EXPECT_EQ(S2GeogNumKernels(), 27); }
 
 TEST(S2GeographyC, InitKernelsInvalidFormat) {
   // Test with invalid format

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -4,7 +4,9 @@
 #include <gtest/gtest.h>
 #include <s2/s2cell_id.h>
 
+#include <cstring>
 #include <limits>
+#include <vector>
 
 // This test file performs "is it plugged in" level checks for all C API
 // functions. The goal is to ensure that:

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -1,5 +1,5 @@
 
-#include "capi/s2geography_c.h"
+#include "s2geography_c.h"
 
 #include <gtest/gtest.h>
 #include <s2/s2cell_id.h>

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -1,0 +1,325 @@
+
+#include "capi/s2geography_c.h"
+
+#include <gtest/gtest.h>
+
+// This test file performs "is it plugged in" level checks for all C API
+// functions. The goal is to ensure that:
+// 1. All functions are exported and linkable
+// 2. Basic happy-path usage works
+// 3. Functions return expected values for simple cases
+
+// ============================================================================
+// Error Handling Tests
+// ============================================================================
+
+TEST(S2GeographyC, ErrorCreate) {
+  struct S2GeogError* err = nullptr;
+  S2GeogErrorCode code = S2GeogErrorCreate(&err);
+  ASSERT_EQ(code, S2GEOGRAPHY_OK);
+  ASSERT_NE(err, nullptr);
+  S2GeogErrorDestroy(err);
+}
+
+TEST(S2GeographyC, ErrorCreateNull) {
+  // Creating with null pointer should return error
+  S2GeogErrorCode code = S2GeogErrorCreate(nullptr);
+  EXPECT_NE(code, S2GEOGRAPHY_OK);
+}
+
+TEST(S2GeographyC, ErrorGetMessage) {
+  struct S2GeogError* err = nullptr;
+  S2GeogErrorCreate(&err);
+
+  // Fresh error should have empty message
+  const char* msg = S2GeogErrorGetMessage(err);
+  ASSERT_NE(msg, nullptr);
+  EXPECT_EQ(strlen(msg), 0);
+
+  S2GeogErrorDestroy(err);
+}
+
+TEST(S2GeographyC, ErrorGetMessageNull) {
+  // Getting message from null error should return empty string
+  const char* msg = S2GeogErrorGetMessage(nullptr);
+  ASSERT_NE(msg, nullptr);
+  EXPECT_EQ(strlen(msg), 0);
+}
+
+// ============================================================================
+// Cell Functions Tests
+// ============================================================================
+
+TEST(S2GeographyC, LngLatToCellId) {
+  // Test with a valid coordinate (New York City area)
+  struct S2GeogVertex vertex;
+  vertex.v[0] = -73.9857;  // longitude
+  vertex.v[1] = 40.7484;   // latitude
+  vertex.v[2] = 0;
+  vertex.v[3] = 0;
+
+  uint64_t cell_id = S2GeogLngLatToCellId(&vertex);
+
+  // Should return a valid (non-sentinel) cell ID
+  // S2CellId::Sentinel().id() is 0
+  EXPECT_NE(cell_id, 0);
+}
+
+TEST(S2GeographyC, LngLatToCellIdNaN) {
+  // Test with NaN coordinates - should return sentinel
+  struct S2GeogVertex vertex;
+  vertex.v[0] = NAN;
+  vertex.v[1] = 40.0;
+
+  uint64_t cell_id = S2GeogLngLatToCellId(&vertex);
+
+  // Should return sentinel cell ID for NaN input
+  // S2CellId::Sentinel().id() is expected here
+  // The actual sentinel value - just verify it's consistent
+  struct S2GeogVertex vertex2;
+  vertex2.v[0] = 0.0;
+  vertex2.v[1] = NAN;
+  uint64_t cell_id2 = S2GeogLngLatToCellId(&vertex2);
+
+  // Both NaN cases should return the same sentinel
+  EXPECT_EQ(cell_id, cell_id2);
+}
+
+// ============================================================================
+// Geography Accessors Tests
+// ============================================================================
+
+TEST(S2GeographyC, GeogCreate) {
+  struct S2Geog* geog = nullptr;
+  S2GeogErrorCode code = S2GeogCreate(&geog);
+  ASSERT_EQ(code, S2GEOGRAPHY_OK);
+  ASSERT_NE(geog, nullptr);
+  S2GeogDestroy(geog);
+}
+
+TEST(S2GeographyC, GeogCreateNull) {
+  S2GeogErrorCode code = S2GeogCreate(nullptr);
+  EXPECT_NE(code, S2GEOGRAPHY_OK);
+}
+
+// ============================================================================
+// Geography Factory Tests
+// ============================================================================
+
+TEST(S2GeographyC, FactoryCreate) {
+  struct S2GeogFactory* factory = nullptr;
+  S2GeogErrorCode code = S2GeogFactoryCreate(&factory);
+  ASSERT_EQ(code, S2GEOGRAPHY_OK);
+  ASSERT_NE(factory, nullptr);
+  S2GeogFactoryDestroy(factory);
+}
+
+TEST(S2GeographyC, FactoryCreateNull) {
+  S2GeogErrorCode code = S2GeogFactoryCreate(nullptr);
+  EXPECT_NE(code, S2GEOGRAPHY_OK);
+}
+
+TEST(S2GeographyC, FactoryInitFromWkbPoint) {
+  // WKB for POINT(0 0) - little endian
+  const uint8_t wkb_point[] = {
+      0x01,                    // byte order: little endian
+      0x01, 0x00, 0x00, 0x00,  // type: Point (1)
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // x: 0.0
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00   // y: 0.0
+  };
+
+  struct S2GeogFactory* factory = nullptr;
+  S2GeogFactoryCreate(&factory);
+
+  struct S2Geog* geog = nullptr;
+  S2GeogCreate(&geog);
+
+  struct S2GeogError* err = nullptr;
+  S2GeogErrorCreate(&err);
+
+  S2GeogErrorCode code = S2GeogFactoryInitFromWkbNonOwning(
+      factory, wkb_point, sizeof(wkb_point), geog, err);
+  EXPECT_EQ(code, S2GEOGRAPHY_OK);
+
+  S2GeogErrorDestroy(err);
+  S2GeogDestroy(geog);
+  S2GeogFactoryDestroy(factory);
+}
+
+// ============================================================================
+// Rectangle Bounder Tests
+// ============================================================================
+
+TEST(S2GeographyC, RectBounderCreate) {
+  struct S2GeogRectBounder* bounder = nullptr;
+  S2GeogErrorCode code = S2GeogRectBounderCreate(&bounder);
+  ASSERT_EQ(code, S2GEOGRAPHY_OK);
+  ASSERT_NE(bounder, nullptr);
+  S2GeogRectBounderDestroy(bounder);
+}
+
+TEST(S2GeographyC, RectBounderCreateNull) {
+  S2GeogErrorCode code = S2GeogRectBounderCreate(nullptr);
+  EXPECT_NE(code, S2GEOGRAPHY_OK);
+}
+
+TEST(S2GeographyC, RectBounderClear) {
+  struct S2GeogRectBounder* bounder = nullptr;
+  S2GeogRectBounderCreate(&bounder);
+
+  // Just verify it doesn't crash
+  S2GeogRectBounderClear(bounder);
+
+  S2GeogRectBounderDestroy(bounder);
+}
+
+TEST(S2GeographyC, RectBounderIsEmpty) {
+  struct S2GeogRectBounder* bounder = nullptr;
+  S2GeogRectBounderCreate(&bounder);
+
+  // Fresh bounder should be empty
+  uint8_t is_empty = S2GeogRectBounderIsEmpty(bounder);
+  EXPECT_EQ(is_empty, 1);
+
+  S2GeogRectBounderDestroy(bounder);
+}
+
+TEST(S2GeographyC, RectBounderBound) {
+  // WKB for POINT(10 20)
+  const uint8_t wkb_point[] = {
+      0x01,                    // byte order: little endian
+      0x01, 0x00, 0x00, 0x00,  // type: Point (1)
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x24, 0x40,  // x: 10.0
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x40   // y: 20.0
+  };
+
+  struct S2GeogFactory* factory = nullptr;
+  S2GeogFactoryCreate(&factory);
+
+  struct S2Geog* geog = nullptr;
+  S2GeogCreate(&geog);
+
+  struct S2GeogError* err = nullptr;
+  S2GeogErrorCreate(&err);
+
+  S2GeogFactoryInitFromWkbNonOwning(factory, wkb_point, sizeof(wkb_point), geog,
+                                    err);
+
+  struct S2GeogRectBounder* bounder = nullptr;
+  S2GeogRectBounderCreate(&bounder);
+
+  S2GeogErrorCode code = S2GeogRectBounderBound(bounder, geog, err);
+  EXPECT_EQ(code, S2GEOGRAPHY_OK);
+
+  // After bounding a point, should no longer be empty
+  uint8_t is_empty = S2GeogRectBounderIsEmpty(bounder);
+  EXPECT_EQ(is_empty, 0);
+
+  S2GeogRectBounderDestroy(bounder);
+  S2GeogErrorDestroy(err);
+  S2GeogDestroy(geog);
+  S2GeogFactoryDestroy(factory);
+}
+
+TEST(S2GeographyC, RectBounderFinish) {
+  // WKB for POINT(10 20)
+  const uint8_t wkb_point[] = {
+      0x01,                    // byte order: little endian
+      0x01, 0x00, 0x00, 0x00,  // type: Point (1)
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x24, 0x40,  // x: 10.0
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x40   // y: 20.0
+  };
+
+  struct S2GeogFactory* factory = nullptr;
+  S2GeogFactoryCreate(&factory);
+
+  struct S2Geog* geog = nullptr;
+  S2GeogCreate(&geog);
+
+  struct S2GeogError* err = nullptr;
+  S2GeogErrorCreate(&err);
+
+  S2GeogFactoryInitFromWkbNonOwning(factory, wkb_point, sizeof(wkb_point), geog,
+                                    err);
+
+  struct S2GeogRectBounder* bounder = nullptr;
+  S2GeogRectBounderCreate(&bounder);
+
+  S2GeogRectBounderBound(bounder, geog, err);
+
+  struct S2GeogVertex lo, hi;
+  S2GeogErrorCode code = S2GeogRectBounderFinish(bounder, &lo, &hi, err);
+  EXPECT_EQ(code, S2GEOGRAPHY_OK);
+
+  // For a single point, lo and hi should be very close
+  EXPECT_NEAR(lo.v[0], hi.v[0], 1e-6);  // longitude
+  EXPECT_NEAR(lo.v[1], hi.v[1], 1e-6);  // latitude
+
+  S2GeogRectBounderDestroy(bounder);
+  S2GeogErrorDestroy(err);
+  S2GeogDestroy(geog);
+  S2GeogFactoryDestroy(factory);
+}
+
+// ============================================================================
+// Sedona UDF Interface Tests
+// ============================================================================
+
+TEST(S2GeographyC, NumKernels) {
+  size_t num_kernels = S2GeogNumKernels();
+  // Should have at least some kernels
+  EXPECT_GT(num_kernels, 0);
+  // Current implementation has 27 kernels
+  EXPECT_EQ(num_kernels, 27);
+}
+
+TEST(S2GeographyC, InitKernelsInvalidFormat) {
+  // Test with invalid format
+  size_t num_kernels = S2GeogNumKernels();
+  std::vector<char> buffer(num_kernels * 256);  // Oversized buffer
+
+  // Invalid format (not S2GEOGRAPHY_KERNEL_FORMAT_SEDONA_UDF)
+  S2GeogErrorCode code = S2GeogInitKernels(buffer.data(), buffer.size(), 999);
+  EXPECT_NE(code, S2GEOGRAPHY_OK);
+}
+
+// ============================================================================
+// Version Functions Tests
+// ============================================================================
+
+TEST(S2GeographyC, NanoarrowVersion) {
+  const char* version = S2GeogNanoarrowVersion();
+  ASSERT_NE(version, nullptr);
+  // Should be a non-empty version string
+  EXPECT_GT(strlen(version), 0);
+  // Should contain at least one dot (like "0.5.0")
+  EXPECT_NE(strchr(version, '.'), nullptr);
+}
+
+TEST(S2GeographyC, GeoArrowVersion) {
+  const char* version = S2GeogGeoArrowVersion();
+  ASSERT_NE(version, nullptr);
+  EXPECT_GT(strlen(version), 0);
+  EXPECT_NE(strchr(version, '.'), nullptr);
+}
+
+TEST(S2GeographyC, OpenSSLVersion) {
+  const char* version = S2GeogOpenSSLVersion();
+  ASSERT_NE(version, nullptr);
+  EXPECT_GT(strlen(version), 0);
+  EXPECT_NE(strchr(version, '.'), nullptr);
+}
+
+TEST(S2GeographyC, S2GeometryVersion) {
+  const char* version = S2GeogS2GeometryVersion();
+  ASSERT_NE(version, nullptr);
+  EXPECT_GT(strlen(version), 0);
+  EXPECT_NE(strchr(version, '.'), nullptr);
+}
+
+TEST(S2GeographyC, AbseilVersion) {
+  const char* version = S2GeogAbseilVersion();
+  ASSERT_NE(version, nullptr);
+  // Could be a version string or "<live at head>"
+  EXPECT_GT(strlen(version), 0);
+}

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -3,6 +3,8 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+
 // This test file performs "is it plugged in" level checks for all C API
 // functions. The goal is to ensure that:
 // 1. All functions are exported and linkable
@@ -68,7 +70,7 @@ TEST(S2GeographyC, LngLatToCellId) {
 TEST(S2GeographyC, LngLatToCellIdNaN) {
   // Test with NaN coordinates - should return sentinel
   struct S2GeogVertex vertex;
-  vertex.v[0] = NAN;
+  vertex.v[0] = std::numeric_limits<double>::quiet_NaN();
   vertex.v[1] = 40.0;
 
   uint64_t cell_id = S2GeogLngLatToCellId(&vertex);
@@ -78,7 +80,8 @@ TEST(S2GeographyC, LngLatToCellIdNaN) {
   // The actual sentinel value - just verify it's consistent
   struct S2GeogVertex vertex2;
   vertex2.v[0] = 0.0;
-  vertex2.v[1] = NAN;
+  vertex2.v[1] = std::numeric_limits<double>::quiet_NaN();
+  ;
   uint64_t cell_id2 = S2GeogLngLatToCellId(&vertex2);
 
   // Both NaN cases should return the same sentinel

--- a/src/s2geography/coverings.h
+++ b/src/s2geography/coverings.h
@@ -15,13 +15,14 @@ class LatLngRectBounder {
   void Clear();
   S2LatLngRect Finish() const;
   void Update(const GeoArrowGeography& value);
+  bool is_empty() { return bounds_.is_empty(); }
 
  private:
   S2LatLngRect BoundPoints(const GeoArrowGeography& value);
   S2LatLngRect BoundLines(const GeoArrowGeography& value);
   S2LatLngRect BoundLoops(const GeoArrowGeography& value);
 
-  S2LatLngRect bounds_;
+  S2LatLngRect bounds_{S2LatLngRect::Empty()};
   std::vector<S2Point> scratch_;
 };
 

--- a/src/s2geography/coverings.h
+++ b/src/s2geography/coverings.h
@@ -15,7 +15,7 @@ class LatLngRectBounder {
   void Clear();
   S2LatLngRect Finish() const;
   void Update(const GeoArrowGeography& value);
-  bool is_empty() { return bounds_.is_empty(); }
+  bool is_empty() const { return bounds_.is_empty(); }
 
  private:
   S2LatLngRect BoundPoints(const GeoArrowGeography& value);

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -54,7 +54,7 @@ S2GeogErrorCode S2GeogErrorCreate(struct S2GeogError** err);
 ///
 /// This message is always guaranteed to be a null-terminated
 /// string (usually the empty string).
-const char* S2GeogErrorGetMessage(struct S2GeogError* err);
+const char* S2GeogErrorGetMessage(const struct S2GeogError* err);
 
 /// \brief Destroy an error object
 ///
@@ -117,9 +117,10 @@ S2GeogErrorCode S2GeogFactoryCreate(struct S2GeogFactory** geog_factory);
 
 /// \brief Create a geography from WKB without taking ownership of the buffer
 ///
-/// The output S2Geog must have been created before this call with S2GeogCreate().
-/// This S2Geog can and should be reused for multiple calls to this or other
-/// factory functions (geographies have internal scratch space that can be reused).
+/// The output S2Geog must have been created before this call with
+/// S2GeogCreate(). This S2Geog can and should be reused for multiple calls to
+/// this or other factory functions (geographies have internal scratch space
+/// that can be reused).
 ///
 /// \pre geog_factory != NULL
 /// \pre out != NULL

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -13,9 +13,26 @@ extern "C" {
 /// This file exposes C functions and/or data structures used to call
 /// s2geography from C or languages that provide C FFI infrastructure
 /// such as Rust or Julia.
+///
+/// The functions here are designed to have some common properties:
+///
+/// - Preconditions are only checked in debug mode (i.e., users are
+///   responsible for checking that C API functions are passed
+///   non-NULL inputs where required). This includes destructors.
+/// - Output arguments of functions are only modified on success
+/// - Pointers that are const (e.g., const S2Geog*) may be shared
+///   between threads, like const std::vector (which is generally the
+///   model also used for all S2 C++ objects).
 
 /// \defgroup error_handling Error Handling
 /// Functions for creating and managing error objects.
+///
+/// Most functions in this C API return an errno-compatible error code
+/// (usually EINVAL or ENOTSUP) and optionally accept an err parameter
+/// into which more detailed message is placed when given a non-NULL
+/// value by the caller. This error object can and should be reused
+/// between calls (e.g., users may wish to allocate a thread-local error
+/// and reuse it).
 ///
 /// @{
 
@@ -34,6 +51,9 @@ struct S2GeogError;
 S2GeogErrorCode S2GeogErrorCreate(struct S2GeogError** err);
 
 /// \brief Get the error message from an error object
+///
+/// This message is always guaranteed to be a null-terminated
+/// string (usually the empty string).
 const char* S2GeogErrorGetMessage(struct S2GeogError* err);
 
 /// \brief Destroy an error object
@@ -56,7 +76,7 @@ struct S2GeogVertex {
 /// \brief Convert vertex of longitude/latitude to an S2 cell ID
 ///
 /// \pre vertex != NULL
-uint64_t S2GeogLngLatToCellId(struct S2GeogVertex* vertex);
+uint64_t S2GeogLngLatToCellId(const struct S2GeogVertex* vertex);
 
 /// @}
 
@@ -83,6 +103,8 @@ void S2GeogDestroy(struct S2Geog* geog);
 /// \defgroup geography_factory Geography Factory
 /// Factory for creating geography objects from various formats.
 ///
+/// The factory is fairly lightweight but should be reused when creating
+/// many geographies in a batch.
 /// @{
 
 /// \brief Opaque factory for creating geography objects
@@ -94,6 +116,10 @@ struct S2GeogFactory;
 S2GeogErrorCode S2GeogFactoryCreate(struct S2GeogFactory** geog_factory);
 
 /// \brief Create a geography from WKB without taking ownership of the buffer
+///
+/// The output S2Geog must have been created before this call with S2GeogCreate().
+/// This S2Geog can and should be reused for multiple calls to this or other
+/// factory functions (geographies have internal scratch space that can be reused).
 ///
 /// \pre geog_factory != NULL
 /// \pre out != NULL
@@ -133,7 +159,7 @@ void S2GeogRectBounderClear(struct S2GeogRectBounder* rect_bounder);
 /// \pre rect_bounder != NULL
 /// \pre geog != NULL
 S2GeogErrorCode S2GeogRectBounderBound(struct S2GeogRectBounder* rect_bounder,
-                                       struct S2Geog* geog,
+                                       const struct S2Geog* geog,
                                        struct S2GeogError* err);
 
 /// \brief Return 1 if the rectangle that would be returned represents empty

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -29,12 +29,16 @@ typedef int S2GeogErrorCode;
 struct S2GeogError;
 
 /// \brief Create a new error object
+///
+/// \pre err != NULL
 S2GeogErrorCode S2GeogErrorCreate(struct S2GeogError** err);
 
 /// \brief Get the error message from an error object
 const char* S2GeogErrorGetMessage(struct S2GeogError* err);
 
 /// \brief Destroy an error object
+///
+/// \pre err != NULL
 void S2GeogErrorDestroy(struct S2GeogError* err);
 
 /// @}
@@ -50,6 +54,8 @@ struct S2GeogVertex {
 };
 
 /// \brief Convert vertex of longitude/latitude to an S2 cell ID
+///
+/// \pre vertex != NULL
 uint64_t S2GeogLngLatToCellId(struct S2GeogVertex* vertex);
 
 /// @}
@@ -63,9 +69,13 @@ uint64_t S2GeogLngLatToCellId(struct S2GeogVertex* vertex);
 struct S2Geog;
 
 /// \brief Create an empty geography object
+///
+/// \pre geog != NULL
 S2GeogErrorCode S2GeogCreate(struct S2Geog** geog);
 
 /// \brief Destroy a geography object
+///
+/// \pre geog != NULL
 void S2GeogDestroy(struct S2Geog* geog);
 
 /// @}
@@ -79,14 +89,22 @@ void S2GeogDestroy(struct S2Geog* geog);
 struct S2GeogFactory;
 
 /// \brief Create a new geography factory
+///
+/// \pre geog_factory != NULL
 S2GeogErrorCode S2GeogFactoryCreate(struct S2GeogFactory** geog_factory);
 
 /// \brief Create a geography from WKB without taking ownership of the buffer
+///
+/// \pre geog_factory != NULL
+/// \pre out != NULL
+/// \pre buf != NULL || buf_size == 0
 S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
     struct S2GeogFactory* geog_factory, const uint8_t* buf, size_t buf_size,
     struct S2Geog* out, struct S2GeogError* err);
 
 /// \brief Destroy a geography factory
+///
+/// \pre geog_factory != NULL
 void S2GeogFactoryDestroy(struct S2GeogFactory* geog_factory);
 
 /// @}
@@ -100,29 +118,44 @@ void S2GeogFactoryDestroy(struct S2GeogFactory* geog_factory);
 struct S2GeogRectBounder;
 
 /// \brief Create a new rectangle bounder
+///
+/// \pre rect_bounder != NULL
 S2GeogErrorCode S2GeogRectBounderCreate(
     struct S2GeogRectBounder** rect_bounder);
 
 /// \brief Clear accumulated bounds from the rectangle bounder
+///
+/// \pre rect_bounder != NULL
 void S2GeogRectBounderClear(struct S2GeogRectBounder* rect_bounder);
 
 /// \brief Add a geography's bounds to the rectangle bounder
+///
+/// \pre rect_bounder != NULL
+/// \pre geog != NULL
 S2GeogErrorCode S2GeogRectBounderBound(struct S2GeogRectBounder* rect_bounder,
                                        struct S2Geog* geog,
                                        struct S2GeogError* err);
 
 /// \brief Return 1 if the rectangle that would be returned represents empty
 /// bounds or 0 otherwise
+///
+/// \pre rect_bounder != NULL
 uint8_t S2GeogRectBounderIsEmpty(struct S2GeogRectBounder* rect_bounder);
 
 /// \brief Finish bounding and retrieve the lo/hi corners of the bounding
 /// rectangle
+///
+/// \pre rect_bounder != NULL
+/// \pre lo != NULL
+/// \pre hi != NULL
 S2GeogErrorCode S2GeogRectBounderFinish(struct S2GeogRectBounder* rect_bounder,
                                         struct S2GeogVertex* lo,
                                         struct S2GeogVertex* hi,
                                         struct S2GeogError* err);
 
 /// \brief Destroy a rectangle bounder
+///
+/// \pre rect_bounder != NULL
 void S2GeogRectBounderDestroy(struct S2GeogRectBounder* rect_bounder);
 
 /// @}

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -1,4 +1,6 @@
 
+#pragma once
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-/// \file geography_glue.h
+/// \file s2geography_c.h
 ///
 /// This file exposes C functions and/or data structures used to call
 /// s2geography from C or languages that provide C FFI infrastructure


### PR DESCRIPTION
I need two specific things for spatial joins in SedonaDB: rectangle bounding and "prepared" geometries for predicate evaluation. This PR sets up the first one (which is more brief) and moves some C stuff that had previously been handled in the depths of a rust crate to live here (where we have the appropriate CI to check it)