### PR TITLE
feat: Add predicates to C API

### DIFF
--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -341,6 +341,8 @@ S2GeogErrorCode S2GeogFactoryInitFromWkt(struct S2GeogFactory* geog_factory,
   // Reset the output geometry to receive the parsed result
   // Ideally we could rewind this to keep the internal coord buffer
   GeoArrowGeometryReset(&out->geom);
+  out->geog.Init({nullptr, 0});
+
   ec = GeoArrowGeometryInit(&out->geom);
   if (ec != GEOARROW_OK) {
     S2GEOGRAPHY_SET_ERROR(err, "error initializing GeoArrowGeometry");

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -470,16 +470,16 @@ int S2GeogOpOutputType(const struct S2GeogOp* op) {
   }
 }
 
-S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* lhs,
-                                     const S2Geog* rhs,
+S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* arg0,
+                                     const S2Geog* arg1,
                                      struct S2GeogError* err) {
   S2GEOGRAPHY_C_BEGIN(err);
   S2GEOGRAPHY_DCHECK(op != nullptr);
   S2GEOGRAPHY_DCHECK(op->op != nullptr);
-  S2GEOGRAPHY_DCHECK(lhs != nullptr);
-  S2GEOGRAPHY_DCHECK(rhs != nullptr);
+  S2GEOGRAPHY_DCHECK(arg0 != nullptr);
+  S2GEOGRAPHY_DCHECK(arg1 != nullptr);
 
-  op->op->ExecGeogGeog(lhs->geog, rhs->geog);
+  op->op->ExecGeogGeog(arg0->geog, arg1->geog);
   return S2GEOGRAPHY_OK;
   S2GEOGRAPHY_C_END(err);
 }

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -90,6 +90,17 @@ struct S2GeogRectBounder {
   ~S2GeogRectBounder() = default;
 };
 
+struct S2GeogPredicate {
+  // TODO: Add predicate state
+
+  // Non-copyable
+  S2GeogPredicate(const S2GeogPredicate&) = delete;
+  S2GeogPredicate& operator=(const S2GeogPredicate&) = delete;
+
+  S2GeogPredicate() = default;
+  ~S2GeogPredicate() = default;
+};
+
 // Error handling functions
 
 S2GeogErrorCode S2GeogErrorCreate(struct S2GeogError** err) {
@@ -323,6 +334,26 @@ S2GeogErrorCode S2GeogRectBounderFinish(struct S2GeogRectBounder* rect_bounder,
 void S2GeogRectBounderDestroy(struct S2GeogRectBounder* rect_bounder) {
   S2GEOGRAPHY_DCHECK(rect_bounder != nullptr);
   delete rect_bounder;
+}
+
+// Predicate functions
+
+S2GeogErrorCode S2GeogPredicateCreate(struct S2GeogPredicate* predicate,
+                                      int op) {
+  // TODO: Implement
+  return ENOTSUP;
+}
+
+S2GeogErrorCode S2GeogPredicateEval(struct S2GeogPredicate* predicate,
+                                    const S2Geog* lhs, const S2Geog* rhs,
+                                    uint8_t* out, struct S2GeogError* err) {
+  // TODO: Implement
+  return ENOTSUP;
+}
+
+void S2GeogPredicateDestroy(struct S2GeogPredicate* predicate) {
+  S2GEOGRAPHY_DCHECK(predicate != nullptr);
+  delete predicate;
 }
 
 // Version functions

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -365,7 +365,11 @@ S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* lhs,
 }
 
 /// \brief Get integer or boolean output for this operation
-int64_t S2GeogOpGetInt(struct S2GeogOp* op) { return 0; }
+int64_t S2GeogOpGetInt(struct S2GeogOp* op) {
+  S2GEOGRAPHY_DCHECK(op != nullptr);
+  S2GEOGRAPHY_DCHECK(op->op != nullptr);
+  return op->op->GetInt();
+}
 
 /// \brief Destroy a op object
 void S2GeogOpDestroy(struct S2GeogOp* op) {

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -16,6 +16,7 @@
 #include "s2geography/distance.h"
 #include "s2geography/geoarrow-geography.h"
 #include "s2geography/linear-referencing.h"
+#include "s2geography/operation.h"
 #include "s2geography/predicates.h"
 #include "s2geography/sedona_udf/sedona_extension.h"
 
@@ -90,15 +91,15 @@ struct S2GeogRectBounder {
   ~S2GeogRectBounder() = default;
 };
 
-struct S2GeogPredicate {
-  // TODO: Add predicate state
+struct S2GeogOp {
+  std::unique_ptr<s2geography::Operation> op;
 
   // Non-copyable
-  S2GeogPredicate(const S2GeogPredicate&) = delete;
-  S2GeogPredicate& operator=(const S2GeogPredicate&) = delete;
+  S2GeogOp(const S2GeogOp&) = delete;
+  S2GeogOp& operator=(const S2GeogOp&) = delete;
 
-  S2GeogPredicate() = default;
-  ~S2GeogPredicate() = default;
+  S2GeogOp() = default;
+  ~S2GeogOp() = default;
 };
 
 // Error handling functions
@@ -336,24 +337,40 @@ void S2GeogRectBounderDestroy(struct S2GeogRectBounder* rect_bounder) {
   delete rect_bounder;
 }
 
-// Predicate functions
+// Operator functions
 
-S2GeogErrorCode S2GeogPredicateCreate(struct S2GeogPredicate* predicate,
-                                      int op) {
-  // TODO: Implement
-  return ENOTSUP;
+S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp* op, int op_id) {
+  switch (op_id) {
+    case S2GEOGRAPHY_OP_INTERSECTS:
+    case S2GEOGRAPHY_OP_CONTAINS:
+    case S2GEOGRAPHY_OP_WITHIN:
+    case S2GEOGRAPHY_OP_EQUALS:
+    default:
+      return ENOTSUP;
+  }
 }
 
-S2GeogErrorCode S2GeogPredicateEval(struct S2GeogPredicate* predicate,
-                                    const S2Geog* lhs, const S2Geog* rhs,
-                                    uint8_t* out, struct S2GeogError* err) {
-  // TODO: Implement
-  return ENOTSUP;
+/// \brief Evaluate an operation with two geographies as input
+S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* lhs,
+                                     const S2Geog* rhs,
+                                     struct S2GeogError* err) {
+  S2GEOGRAPHY_C_BEGIN(err);
+  S2GEOGRAPHY_DCHECK(op != nullptr);
+  S2GEOGRAPHY_DCHECK(lhs != nullptr);
+  S2GEOGRAPHY_DCHECK(rhs != nullptr);
+
+  op->op->ExecGeogGeog(lhs->geog, rhs->geog);
+  return S2GEOGRAPHY_OK;
+  S2GEOGRAPHY_C_END(err);
 }
 
-void S2GeogPredicateDestroy(struct S2GeogPredicate* predicate) {
-  S2GEOGRAPHY_DCHECK(predicate != nullptr);
-  delete predicate;
+/// \brief Get integer or boolean output for this operation
+int64_t S2GeogOpGetInt(struct S2GeogOp* op) { return 0; }
+
+/// \brief Destroy a op object
+void S2GeogOpDestroy(struct S2GeogOp* op) {
+  S2GEOGRAPHY_DCHECK(op != nullptr);
+  delete op;
 }
 
 // Version functions

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -453,12 +453,29 @@ S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp** op, int op_id) {
   S2GEOGRAPHY_C_END(nullptr);
 }
 
-/// \brief Evaluate an operation with two geographies as input
+const char* S2GeogOpName(const struct S2GeogOp* op) {
+  S2GEOGRAPHY_DCHECK(op != nullptr);
+  S2GEOGRAPHY_DCHECK(op->op != nullptr);
+  return op->op->name().c_str();
+}
+
+int S2GeogOpOutputType(const struct S2GeogOp* op) {
+  S2GEOGRAPHY_DCHECK(op != nullptr);
+  S2GEOGRAPHY_DCHECK(op->op != nullptr);
+  switch (op->op->output_type()) {
+    case s2geography::Operation::OutputType::kBool:
+      return S2GEOGRAPHY_OUTPUT_TYPE_BOOL;
+    default:
+      return 0;
+  }
+}
+
 S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* lhs,
                                      const S2Geog* rhs,
                                      struct S2GeogError* err) {
   S2GEOGRAPHY_C_BEGIN(err);
   S2GEOGRAPHY_DCHECK(op != nullptr);
+  S2GEOGRAPHY_DCHECK(op->op != nullptr);
   S2GEOGRAPHY_DCHECK(lhs != nullptr);
   S2GEOGRAPHY_DCHECK(rhs != nullptr);
 
@@ -467,14 +484,12 @@ S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* lhs,
   S2GEOGRAPHY_C_END(err);
 }
 
-/// \brief Get integer or boolean output for this operation
 int64_t S2GeogOpGetInt(struct S2GeogOp* op) {
   S2GEOGRAPHY_DCHECK(op != nullptr);
   S2GEOGRAPHY_DCHECK(op->op != nullptr);
   return op->op->GetInt();
 }
 
-/// \brief Destroy a op object
 void S2GeogOpDestroy(struct S2GeogOp* op) {
   S2GEOGRAPHY_DCHECK(op != nullptr);
   delete op;

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -67,13 +67,46 @@ struct S2Geog {
 
 struct S2GeogFactory {
   struct GeoArrowWKBReader wkb_reader;
+  struct GeoArrowWKTReader wkt_reader;
   struct GeoArrowError error;
+  bool wkb_reader_initialized;
+  bool wkt_reader_initialized;
 
-  S2GeogFactory() {
-    GeoArrowWKBReaderInit(&wkb_reader);
+  S2GeogFactory()
+      : wkb_reader_initialized(false), wkt_reader_initialized(false) {
     error.message[0] = '\0';
   }
-  ~S2GeogFactory() { GeoArrowWKBReaderReset(&wkb_reader); }
+
+  ~S2GeogFactory() {
+    if (wkb_reader_initialized) {
+      GeoArrowWKBReaderReset(&wkb_reader);
+    }
+    if (wkt_reader_initialized) {
+      GeoArrowWKTReaderReset(&wkt_reader);
+    }
+  }
+
+  GeoArrowErrorCode EnsureWkbReader() {
+    if (!wkb_reader_initialized) {
+      GeoArrowErrorCode ec = GeoArrowWKBReaderInit(&wkb_reader);
+      if (ec == GEOARROW_OK) {
+        wkb_reader_initialized = true;
+      }
+      return ec;
+    }
+    return GEOARROW_OK;
+  }
+
+  GeoArrowErrorCode EnsureWktReader() {
+    if (!wkt_reader_initialized) {
+      GeoArrowErrorCode ec = GeoArrowWKTReaderInit(&wkt_reader);
+      if (ec == GEOARROW_OK) {
+        wkt_reader_initialized = true;
+      }
+      return ec;
+    }
+    return GEOARROW_OK;
+  }
 
   // Non-copyable
   S2GeogFactory(const S2GeogFactory&) = delete;
@@ -242,13 +275,20 @@ S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
   // Reset the parse error
   geog_factory->error.message[0] = '\0';
 
+  // Lazily initialize the WKB reader
+  GeoArrowErrorCode ec = geog_factory->EnsureWkbReader();
+  if (ec != GEOARROW_OK) {
+    S2GEOGRAPHY_SET_ERROR(err, "error initializing WKB reader");
+    return ec;
+  }
+
   struct GeoArrowBufferView src;
   src.data = buf;
   src.size_bytes = static_cast<int64_t>(buf_size);
 
   struct GeoArrowGeometryView parsed;
-  GeoArrowErrorCode ec = GeoArrowWKBReaderRead(&geog_factory->wkb_reader, src,
-                                               &parsed, &geog_factory->error);
+  ec = GeoArrowWKBReaderRead(&geog_factory->wkb_reader, src, &parsed,
+                             &geog_factory->error);
   if (ec != GEOARROW_OK) {
     S2GEOGRAPHY_SET_ERROR(err, geog_factory->error.message);
     return ec;
@@ -257,6 +297,55 @@ S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
   ec = GeoArrowGeometryShallowCopy(parsed, &out->geom);
   if (ec != GEOARROW_OK) {
     S2GEOGRAPHY_SET_ERROR(err, "error copying geometry nodes");
+    return ec;
+  }
+
+  out->geog.Init(GeoArrowGeometryAsView(&out->geom));
+
+  return S2GEOGRAPHY_OK;
+  S2GEOGRAPHY_C_END(err);
+}
+
+S2GeogErrorCode S2GeogFactoryInitFromWkt(struct S2GeogFactory* geog_factory,
+                                         const char* buf, size_t buf_size,
+                                         struct S2Geog* out,
+                                         struct S2GeogError* err) {
+  S2GEOGRAPHY_C_BEGIN(err);
+
+  S2GEOGRAPHY_DCHECK(geog_factory != nullptr);
+  S2GEOGRAPHY_DCHECK(out != nullptr);
+  S2GEOGRAPHY_DCHECK(buf != nullptr || buf_size == 0);
+
+  // Reset the parse error
+  geog_factory->error.message[0] = '\0';
+
+  // Lazily initialize the WKT reader
+  GeoArrowErrorCode ec = geog_factory->EnsureWktReader();
+  if (ec != GEOARROW_OK) {
+    S2GEOGRAPHY_SET_ERROR(err, "error initializing WKT reader");
+    return ec;
+  }
+
+  // Reset the output geometry to receive the parsed result
+  // Ideally we could rewind this to keep the internal coord buffer
+  GeoArrowGeometryReset(&out->geom);
+  ec = GeoArrowGeometryInit(&out->geom);
+  if (ec != GEOARROW_OK) {
+    S2GEOGRAPHY_SET_ERROR(err, "error initializing GeoArrowGeometry");
+    return ec;
+  }
+
+  struct GeoArrowStringView src;
+  src.data = buf;
+  src.size_bytes = static_cast<int64_t>(buf_size);
+
+  // Initialize a visitor that builds into the output geometry
+  struct GeoArrowVisitor v{};
+  GeoArrowGeometryInitVisitor(&out->geom, &v);
+
+  ec = GeoArrowWKTReaderVisit(&geog_factory->wkt_reader, src, &v);
+  if (ec != GEOARROW_OK) {
+    S2GEOGRAPHY_SET_ERROR(err, "error parsing WKT");
     return ec;
   }
 

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -248,6 +248,15 @@ S2GeogErrorCode S2GeogCreate(struct S2Geog** geog) {
   S2GEOGRAPHY_C_END(nullptr)
 }
 
+S2GeogErrorCode S2GeogForcePrepare(struct S2Geog* geog,
+                                   struct S2GeogError* err) {
+  S2GEOGRAPHY_C_BEGIN(err)
+  S2GEOGRAPHY_DCHECK(geog != nullptr);
+  geog->geog.ForceBuildIndex();
+  return S2GEOGRAPHY_OK;
+  S2GEOGRAPHY_C_END(err);
+}
+
 void S2GeogDestroy(struct S2Geog* geog) {
   S2GEOGRAPHY_DCHECK(geog != nullptr);
   delete geog;

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -125,6 +125,9 @@ struct S2GeogRectBounder {
 };
 
 struct S2GeogOp {
+  explicit S2GeogOp(std::unique_ptr<s2geography::Operation> op_in)
+      : op(std::move(op_in)) {}
+
   std::unique_ptr<s2geography::Operation> op;
 
   // Non-copyable
@@ -439,6 +442,8 @@ void S2GeogRectBounderDestroy(struct S2GeogRectBounder* rect_bounder) {
 
 S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp** op, int op_id) {
   S2GEOGRAPHY_C_BEGIN(nullptr);
+  S2GEOGRAPHY_DCHECK(op != nullptr);
+
   std::unique_ptr<s2geography::Operation> inner;
   switch (op_id) {
     case S2GEOGRAPHY_OP_INTERSECTS:
@@ -457,7 +462,7 @@ S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp** op, int op_id) {
       return ENOTSUP;
   }
 
-  *op = new S2GeogOp{std::move(inner)};
+  *op = new S2GeogOp(std::move(inner));
   return S2GEOGRAPHY_OK;
   S2GEOGRAPHY_C_END(nullptr);
 }

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -339,15 +339,29 @@ void S2GeogRectBounderDestroy(struct S2GeogRectBounder* rect_bounder) {
 
 // Operator functions
 
-S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp* op, int op_id) {
+S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp** op, int op_id) {
+  S2GEOGRAPHY_C_BEGIN(nullptr);
+  std::unique_ptr<s2geography::Operation> inner;
   switch (op_id) {
     case S2GEOGRAPHY_OP_INTERSECTS:
+      inner = s2geography::Intersects();
+      break;
     case S2GEOGRAPHY_OP_CONTAINS:
+      inner = s2geography::Contains();
+      break;
     case S2GEOGRAPHY_OP_WITHIN:
+      inner = s2geography::Within();
+      break;
     case S2GEOGRAPHY_OP_EQUALS:
+      inner = s2geography::Equals();
+      break;
     default:
       return ENOTSUP;
   }
+
+  *op = new S2GeogOp{std::move(inner)};
+  return S2GEOGRAPHY_OK;
+  S2GEOGRAPHY_C_END(nullptr);
 }
 
 /// \brief Evaluate an operation with two geographies as input

--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -460,6 +460,9 @@ S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp** op, int op_id) {
     case S2GEOGRAPHY_OP_EQUALS:
       inner = s2geography::Equals();
       break;
+    case S2GEOGRAPHY_OP_DISTANCE_WITHIN:
+      inner = s2geography::DistanceWithin();
+      break;
     default:
       return ENOTSUP;
   }
@@ -496,6 +499,21 @@ S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* arg0,
   S2GEOGRAPHY_DCHECK(arg1 != nullptr);
 
   op->op->ExecGeogGeog(arg0->geog, arg1->geog);
+  return S2GEOGRAPHY_OK;
+  S2GEOGRAPHY_C_END(err);
+}
+
+S2GeogErrorCode S2GeogOpEvalGeogGeogDouble(struct S2GeogOp* op,
+                                           const S2Geog* arg0,
+                                           const S2Geog* arg1, double arg2,
+                                           struct S2GeogError* err) {
+  S2GEOGRAPHY_C_BEGIN(err);
+  S2GEOGRAPHY_DCHECK(op != nullptr);
+  S2GEOGRAPHY_DCHECK(op->op != nullptr);
+  S2GEOGRAPHY_DCHECK(arg0 != nullptr);
+  S2GEOGRAPHY_DCHECK(arg1 != nullptr);
+
+  op->op->ExecGeogGeogDouble(arg0->geog, arg1->geog, arg2);
   return S2GEOGRAPHY_OK;
   S2GEOGRAPHY_C_END(err);
 }

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -142,18 +142,8 @@ TEST(S2GeographyC, FactoryInitFromInvalidWkb) {
   S2GeogFactoryDestroy(factory);
 }
 
-// ============================================================================
-// Rectangle Bounder Tests
-// ============================================================================
-
-TEST(S2GeographyC, RectBounderBound) {
-  // WKB for POINT(10 20)
-  const uint8_t wkb_point[] = {
-      0x01,                    // byte order: little endian
-      0x01, 0x00, 0x00, 0x00,  // type: Point (1)
-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x24, 0x40,  // x: 10.0
-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x40   // y: 20.0
-  };
+TEST(S2GeographyC, FactoryInitFromWktPoint) {
+  const char* wkt_point = "POINT (0 0)";
 
   struct S2GeogFactory* factory = nullptr;
   ASSERT_EQ(S2GeogFactoryCreate(&factory), S2GEOGRAPHY_OK);
@@ -164,8 +154,52 @@ TEST(S2GeographyC, RectBounderBound) {
   struct S2GeogError* err = nullptr;
   ASSERT_EQ(S2GeogErrorCreate(&err), S2GEOGRAPHY_OK);
 
-  ASSERT_EQ(S2GeogFactoryInitFromWkbNonOwning(factory, wkb_point,
-                                              sizeof(wkb_point), geog, err),
+  EXPECT_EQ(S2GeogFactoryInitFromWkt(factory, wkt_point, strlen(wkt_point),
+                                     geog, err),
+            S2GEOGRAPHY_OK);
+
+  S2GeogErrorDestroy(err);
+  S2GeogDestroy(geog);
+  S2GeogFactoryDestroy(factory);
+}
+
+TEST(S2GeographyC, FactoryInitFromInvalidWkt) {
+  const char* invalid_wkt = "NOT VALID WKT";
+
+  struct S2GeogFactory* factory = nullptr;
+  ASSERT_EQ(S2GeogFactoryCreate(&factory), S2GEOGRAPHY_OK);
+
+  struct S2Geog* geog = nullptr;
+  ASSERT_EQ(S2GeogCreate(&geog), S2GEOGRAPHY_OK);
+
+  struct S2GeogError* err = nullptr;
+  ASSERT_EQ(S2GeogErrorCreate(&err), S2GEOGRAPHY_OK);
+
+  EXPECT_NE(S2GeogFactoryInitFromWkt(factory, invalid_wkt, strlen(invalid_wkt),
+                                     geog, err),
+            S2GEOGRAPHY_OK);
+
+  S2GeogErrorDestroy(err);
+  S2GeogDestroy(geog);
+  S2GeogFactoryDestroy(factory);
+}
+
+// ============================================================================
+// Rectangle Bounder Tests
+// ============================================================================
+
+TEST(S2GeographyC, RectBounderBound) {
+  struct S2GeogFactory* factory = nullptr;
+  ASSERT_EQ(S2GeogFactoryCreate(&factory), S2GEOGRAPHY_OK);
+
+  struct S2Geog* geog = nullptr;
+  ASSERT_EQ(S2GeogCreate(&geog), S2GEOGRAPHY_OK);
+
+  struct S2GeogError* err = nullptr;
+  ASSERT_EQ(S2GeogErrorCreate(&err), S2GEOGRAPHY_OK);
+
+  const char* wkt = "POINT (10 20)";
+  ASSERT_EQ(S2GeogFactoryInitFromWkt(factory, wkt, strlen(wkt), geog, err),
             S2GEOGRAPHY_OK);
 
   struct S2GeogRectBounder* bounder = nullptr;

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -287,3 +287,72 @@ TEST(S2GeographyC, AbseilVersion) {
   // Could be a version string or "<live at head>"
   EXPECT_GT(strlen(version), 0);
 }
+
+// ============================================================================
+// Binary Predicate Operations Tests (Parameterized)
+// ============================================================================
+
+struct BinaryPredicateParam {
+  const char* name;
+  int op_id;
+  const char* lhs_wkt;
+  const char* rhs_wkt;
+  int64_t expected;
+};
+
+class BinaryPredicateTest
+    : public ::testing::TestWithParam<BinaryPredicateParam> {};
+
+TEST_P(BinaryPredicateTest, EvalGeogGeog) {
+  const auto& p = GetParam();
+
+  struct S2GeogFactory* factory = nullptr;
+  ASSERT_EQ(S2GeogFactoryCreate(&factory), S2GEOGRAPHY_OK);
+
+  struct S2Geog* lhs = nullptr;
+  struct S2Geog* rhs = nullptr;
+  ASSERT_EQ(S2GeogCreate(&lhs), S2GEOGRAPHY_OK);
+  ASSERT_EQ(S2GeogCreate(&rhs), S2GEOGRAPHY_OK);
+
+  struct S2GeogError* err = nullptr;
+  ASSERT_EQ(S2GeogErrorCreate(&err), S2GEOGRAPHY_OK);
+
+  ASSERT_EQ(
+      S2GeogFactoryInitFromWkt(factory, p.lhs_wkt, strlen(p.lhs_wkt), lhs, err),
+      S2GEOGRAPHY_OK);
+  ASSERT_EQ(
+      S2GeogFactoryInitFromWkt(factory, p.rhs_wkt, strlen(p.rhs_wkt), rhs, err),
+      S2GEOGRAPHY_OK);
+
+  struct S2GeogOp* op = nullptr;
+  ASSERT_EQ(S2GeogOpCreate(&op, p.op_id), S2GEOGRAPHY_OK);
+
+  ASSERT_EQ(S2GeogOpEvalGeogGeog(op, lhs, rhs, err), S2GEOGRAPHY_OK);
+  EXPECT_EQ(S2GeogOpGetInt(op), p.expected);
+
+  S2GeogOpDestroy(op);
+  S2GeogErrorDestroy(err);
+  S2GeogDestroy(rhs);
+  S2GeogDestroy(lhs);
+  S2GeogFactoryDestroy(factory);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    S2GeographyC, BinaryPredicateTest,
+    ::testing::Values(BinaryPredicateParam{"intersects",
+                                           S2GEOGRAPHY_OP_INTERSECTS,
+                                           "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+                                           "POINT (0.25 0.25)", 1},
+                      BinaryPredicateParam{"contains", S2GEOGRAPHY_OP_CONTAINS,
+                                           "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+                                           "POINT (0.25 0.25)", 1},
+                      BinaryPredicateParam{"within", S2GEOGRAPHY_OP_WITHIN,
+                                           "POINT (0.25 0.25)",
+                                           "POLYGON ((0 0, 2 0, 0 2, 0 0))", 1},
+                      BinaryPredicateParam{"equals", S2GEOGRAPHY_OP_EQUALS,
+                                           "POLYGON ((0 0, 1 0, 0 1, 0 0))",
+                                           "POLYGON ((1 0, 0 1, 0 0, 1 0))",
+                                           1}),
+    [](const ::testing::TestParamInfo<BinaryPredicateParam>& info) {
+      return info.param.name;
+    });

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -78,9 +78,12 @@ TEST(S2GeographyC, LngLatToCellIdNaN) {
 
 TEST(S2GeographyC, GeogCreate) {
   struct S2Geog* geog = nullptr;
-  S2GeogErrorCode code = S2GeogCreate(&geog);
-  ASSERT_EQ(code, S2GEOGRAPHY_OK);
+  ASSERT_EQ(S2GeogCreate(&geog), S2GEOGRAPHY_OK);
   ASSERT_NE(geog, nullptr);
+
+  // Should be able to force prepare a fresh geography
+  ASSERT_EQ(S2GeogForcePrepare(geog, nullptr), S2GEOGRAPHY_OK);
+
   S2GeogDestroy(geog);
 }
 

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -327,6 +327,9 @@ TEST_P(BinaryPredicateTest, EvalGeogGeog) {
   struct S2GeogOp* op = nullptr;
   ASSERT_EQ(S2GeogOpCreate(&op, p.op_id), S2GEOGRAPHY_OK);
 
+  ASSERT_STREQ(S2GeogOpName(op), p.name);
+  ASSERT_EQ(S2GeogOpOutputType(op), S2GEOGRAPHY_OUTPUT_TYPE_BOOL);
+
   ASSERT_EQ(S2GeogOpEvalGeogGeog(op, lhs, rhs, err), S2GEOGRAPHY_OK);
   EXPECT_EQ(S2GeogOpGetInt(op), p.expected);
 

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -362,3 +362,53 @@ INSTANTIATE_TEST_SUITE_P(
     [](const ::testing::TestParamInfo<BinaryPredicateParam>& info) {
       return info.param.name;
     });
+
+// ============================================================================
+// DistanceWithin Operation Test
+// ============================================================================
+
+TEST(S2GeographyC, DistanceWithinOperation) {
+  struct S2GeogFactory* factory = nullptr;
+  ASSERT_EQ(S2GeogFactoryCreate(&factory), S2GEOGRAPHY_OK);
+
+  struct S2Geog* lhs = nullptr;
+  struct S2Geog* rhs = nullptr;
+  ASSERT_EQ(S2GeogCreate(&lhs), S2GEOGRAPHY_OK);
+  ASSERT_EQ(S2GeogCreate(&rhs), S2GEOGRAPHY_OK);
+
+  struct S2GeogError* err = nullptr;
+  ASSERT_EQ(S2GeogErrorCreate(&err), S2GEOGRAPHY_OK);
+
+  // Points ~111km apart (1 degree latitude)
+  const char* lhs_wkt = "POINT (0 0)";
+  const char* rhs_wkt = "POINT (0 1)";
+  ASSERT_EQ(
+      S2GeogFactoryInitFromWkt(factory, lhs_wkt, strlen(lhs_wkt), lhs, err),
+      S2GEOGRAPHY_OK);
+  ASSERT_EQ(
+      S2GeogFactoryInitFromWkt(factory, rhs_wkt, strlen(rhs_wkt), rhs, err),
+      S2GEOGRAPHY_OK);
+
+  struct S2GeogOp* op = nullptr;
+  ASSERT_EQ(S2GeogOpCreate(&op, S2GEOGRAPHY_OP_DISTANCE_WITHIN),
+            S2GEOGRAPHY_OK);
+
+  ASSERT_STREQ(S2GeogOpName(op), "distance_within");
+  ASSERT_EQ(S2GeogOpOutputType(op), S2GEOGRAPHY_OUTPUT_TYPE_BOOL);
+
+  // Distance is ~111195 meters, so 200000 meters should return true
+  ASSERT_EQ(S2GeogOpEvalGeogGeogDouble(op, lhs, rhs, 200000.0, err),
+            S2GEOGRAPHY_OK);
+  EXPECT_EQ(S2GeogOpGetInt(op), 1);
+
+  // 50000 meters should return false
+  ASSERT_EQ(S2GeogOpEvalGeogGeogDouble(op, lhs, rhs, 50000.0, err),
+            S2GEOGRAPHY_OK);
+  EXPECT_EQ(S2GeogOpGetInt(op), 0);
+
+  S2GeogOpDestroy(op);
+  S2GeogErrorDestroy(err);
+  S2GeogDestroy(rhs);
+  S2GeogDestroy(lhs);
+  S2GeogFactoryDestroy(factory);
+}

--- a/src/s2geography/accessors-geog.cc
+++ b/src/s2geography/accessors-geog.cc
@@ -241,7 +241,7 @@ struct Centroid {
 
 namespace {
 std::optional<internal::GeoArrowVertex> CentroidVertex(
-    GeoArrowGeography& value, std::vector<S2Point>* scratch) {
+    const GeoArrowGeography& value, std::vector<S2Point>* scratch) {
   // Compute in decreasing dimensionality and return early, because
   // centroids of lower dimension do not count towards the final value
   // if the geography has mixed dimension.

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -12,6 +12,7 @@
 #include <type_traits>
 
 #include "s2geography/geography.h"
+#include "s2geography/operation.h"
 #include "s2geography/sedona_udf/sedona_udf_internal.h"
 
 namespace s2geography {
@@ -742,11 +743,12 @@ struct S2LongestLineExec {
   EdgePair edge_pair_;
 };
 
+template <typename Output>
 struct S2DistanceWithinExec {
   using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = GeoArrowGeographyInputView;
   using arg2_t = DoubleInputView;
-  using out_t = BoolOutputBuilder;
+  using out_t = Output;
 
   void Exec(arg0_t::c_type value0, arg1_t::c_type value1, arg2_t::c_type value2,
             out_t* out) {
@@ -783,7 +785,7 @@ void DistanceKernel(struct SedonaCScalarKernel* out, bool prepare_arg0_scalar,
 
 void DistanceWithinKernel(struct SedonaCScalarKernel* out,
                           bool prepare_arg0_scalar, bool prepare_arg1_scalar) {
-  InitTernaryKernel<S2DistanceWithinExec>(
+  InitTernaryKernel<S2DistanceWithinExec<BoolOutputBuilder>>(
       out, "st_dwithin", prepare_arg0_scalar, prepare_arg1_scalar);
 }
 
@@ -806,5 +808,38 @@ void ShortestLineKernel(struct SedonaCScalarKernel* out,
 }
 
 }  // namespace sedona_udf
+
+struct StashedBoolOutput {
+  void Append(bool value) { *out_ = value; }
+  bool* out_;
+};
+
+class DistanceWithinOperation : public Operation {
+ public:
+  DistanceWithinOperation() : name_("distance_within") {}
+
+  const std::string& name() const override { return name_; }
+
+  OutputType output_type() const override {
+    return Operation::OutputType::kBool;
+  }
+
+  void ExecGeogGeogDouble(const GeoArrowGeography& arg0,
+                          const GeoArrowGeography& arg1,
+                          double distance_meters) override {
+    StashedBoolOutput out{&result_};
+    exec_.Exec(arg0, arg1, distance_meters, &out);
+    int_result_ = result_ ? 1 : 0;
+  }
+
+ private:
+  std::string name_;
+  bool result_{};
+  sedona_udf::S2DistanceWithinExec<StashedBoolOutput> exec_;
+};
+
+std::unique_ptr<Operation> DistanceWithin() {
+  return std::make_unique<DistanceWithinOperation>();
+}
 
 }  // namespace s2geography

--- a/src/s2geography/distance.cc
+++ b/src/s2geography/distance.cc
@@ -540,8 +540,8 @@ bool BothSmallWithoutPolygons(const GeoArrowGeography& value0,
 }
 
 template <typename Traits>
-void DistanceLine(GeoArrowGeography& value0, GeoArrowGeography& value1,
-                  EdgePair* out, int flags,
+void DistanceLine(const GeoArrowGeography& value0,
+                  const GeoArrowGeography& value1, EdgePair* out, int flags,
                   S1ChordAngle max_distance = S1ChordAngle::Infinity()) {
   if (value0.is_empty() || value1.is_empty()) {
     *out = {};

--- a/src/s2geography/distance.h
+++ b/src/s2geography/distance.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "s2geography/geography.h"
+#include "s2geography/operation.h"
 #include "s2geography/sedona_udf/sedona_extension.h"
 
 namespace s2geography {
@@ -43,5 +44,7 @@ void LongestLineKernel(struct SedonaCScalarKernel* out,
 void ClosestPointKernel(struct SedonaCScalarKernel* out);
 
 }  // namespace sedona_udf
+
+std::unique_ptr<Operation> DistanceWithin();
 
 }  // namespace s2geography

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -282,6 +282,76 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
   }
 }
 
+TEST_P(DistanceScalarScalarTest, DistanceOperation) {
+  const auto& p = GetParam();
+
+  // Skip null tests for Operation (it doesn't handle nulls directly)
+  if (!p.lhs.has_value() || !p.rhs.has_value()) {
+    return;
+  }
+
+  // Create the DistanceWithin operation
+  std::unique_ptr<s2geography::Operation> distance_within =
+      s2geography::DistanceWithin();
+
+  // Check with all combinations of forcing an index build on arguments.
+  for (bool prepare_arg0 : {true, false}) {
+    for (bool prepare_arg1 : {true, false}) {
+      SCOPED_TRACE("prepare_arg0: " + std::to_string(prepare_arg0) +
+                   ", prepare_arg1: " + std::to_string(prepare_arg1));
+
+      // Create fresh geographies for each iteration
+      auto lhs_geom = TestGeometry::FromWKT(*p.lhs);
+      auto rhs_geom = TestGeometry::FromWKT(*p.rhs);
+
+      s2geography::GeoArrowGeography lhs_geog;
+      s2geography::GeoArrowGeography rhs_geog;
+      lhs_geog.Init(lhs_geom.geom());
+      rhs_geog.Init(rhs_geom.geom());
+
+      // Force index build if preparing
+      if (prepare_arg0) {
+        lhs_geog.ForceBuildIndex();
+      } else {
+        ASSERT_TRUE(lhs_geog.is_unindexed())
+            << "lhs geography should be unindexed when not preparing";
+      }
+
+      if (prepare_arg1) {
+        rhs_geog.ForceBuildIndex();
+      } else {
+        ASSERT_TRUE(rhs_geog.is_unindexed())
+            << "rhs geography should be unindexed when not preparing";
+      }
+
+      // Test with exact distance threshold (should return true for non-empty)
+      {
+        SCOPED_TRACE("DistanceWithin(exact_distance)");
+        double distance_threshold = p.expected.value_or(0.0);
+        distance_within->ExecGeogGeogDouble(lhs_geog, rhs_geog,
+                                            distance_threshold);
+        bool result = distance_within->GetInt() != 0;
+        // Expected: true if we have a non-null expected distance, false
+        // otherwise (e.g., distance between empties)
+        bool expected = p.expected.has_value();
+        EXPECT_EQ(result, expected);
+      }
+
+      // Test with distance slightly less than exact (should return false)
+      if (p.expected.has_value()) {
+        SCOPED_TRACE("DistanceWithin(exact_distance - eps)");
+        double distance_threshold = *p.expected;
+        double eps = std::max(1.0e-15, distance_threshold * 1e-15);
+        distance_threshold -= eps;
+        distance_within->ExecGeogGeogDouble(lhs_geog, rhs_geog,
+                                            distance_threshold);
+        bool result = distance_within->GetInt() != 0;
+        EXPECT_FALSE(result);
+      }
+    }
+  }
+}
+
 INSTANTIATE_TEST_SUITE_P(
     Distance, DistanceScalarScalarTest,
     ::testing::Values(

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -15,6 +15,7 @@
 
 #include "geoarrow/geoarrow.h"
 #include "s2/s2point_region.h"
+#include "s2/s2region_coverer.h"
 #include "s2geography/geography_interface.h"
 
 namespace s2geography {
@@ -523,14 +524,12 @@ void GeoArrowGeography::GetCellUnionBound(
       break;
   }
 
-  Region()->GetCellUnionBound(cell_ids);
+  S2RegionCoverer coverer;
+  coverer.GetFastCovering(*Region(), cell_ids);
 }
 
 const std::vector<S2CellId>& GeoArrowGeography::Covering() const {
-  if (covering_.empty()) {
-    GetCellUnionBound(&covering_);
-  }
-
+  InitIndex();
   return covering_;
 }
 
@@ -757,6 +756,29 @@ void GeoArrowGeography::InitIndex() const {
       throw Exception(
           "Can't create index from geometry type " +
           std::string(GeometryTypeString(geom_.root->geometry_type)));
+  }
+
+  // Compute covering while we hold the lock (avoid calling Region() which
+  // would re-enter InitIndex())
+  if (!is_empty()) {
+    switch (geom_.root->geometry_type) {
+      case GEOARROW_GEOMETRY_TYPE_POINT:
+      case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
+        if (points_.num_vertices() <= 32) {
+          points_.geom().VisitVertices([&](S2Point v) {
+            covering_.push_back(S2CellId(v));
+            return true;
+          });
+          break;
+        }
+        [[fallthrough]];
+      default: {
+        S2RegionCoverer coverer;
+        S2ShapeIndexRegion<MutableS2ShapeIndex> region(&index_);
+        coverer.GetFastCovering(region, &covering_);
+        break;
+      }
+    }
   }
 
   indexed_.store(true, std::memory_order_release);

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -444,7 +444,7 @@ GeoArrowGeography::GeoArrowGeography(GeoArrowGeography&& other)
       covering_(std::move(other.covering_)) {
   // index_ needs to be rebuilt
   index_.Clear();
-  indexed_ = false;
+  indexed_.store(false, std::memory_order_relaxed);
 }
 
 GeoArrowGeography& GeoArrowGeography::operator=(GeoArrowGeography&& other) {
@@ -456,7 +456,7 @@ GeoArrowGeography& GeoArrowGeography::operator=(GeoArrowGeography&& other) {
     covering_ = std::move(other.covering_);
     // index_ needs to be rebuilt
     index_.Clear();
-    indexed_ = false;
+    indexed_.store(false, std::memory_order_relaxed);
   }
   return *this;
 }
@@ -472,7 +472,7 @@ void GeoArrowGeography::InitOriented(struct GeoArrowGeometryView geom) {
   polygons_.Clear();
   index_.Clear();
   covering_.clear();
-  indexed_ = false;
+  indexed_.store(false, std::memory_order_relaxed);
   geom_ = geom;
 
   if (geom.size_nodes == 0) {
@@ -502,7 +502,7 @@ void GeoArrowGeography::InitOriented(struct GeoArrowGeometryView geom) {
   }
 }
 
-void GeoArrowGeography::GetCellUnionBound(std::vector<S2CellId>* cell_ids) {
+void GeoArrowGeography::GetCellUnionBound(std::vector<S2CellId>* cell_ids) const {
   if (geom_.size_nodes == 0 || is_empty()) {
     return;
   }
@@ -525,7 +525,7 @@ void GeoArrowGeography::GetCellUnionBound(std::vector<S2CellId>* cell_ids) {
   Region()->GetCellUnionBound(cell_ids);
 }
 
-const std::vector<S2CellId>& GeoArrowGeography::Covering() {
+const std::vector<S2CellId>& GeoArrowGeography::Covering() const {
   if (covering_.empty()) {
     GetCellUnionBound(&covering_);
   }
@@ -533,7 +533,7 @@ const std::vector<S2CellId>& GeoArrowGeography::Covering() {
   return covering_;
 }
 
-const S2ShapeIndex& GeoArrowGeography::ShapeIndex() {
+const S2ShapeIndex& GeoArrowGeography::ShapeIndex() const {
   InitIndex();
   return index_;
 }
@@ -712,7 +712,7 @@ const S2Shape* GeoArrowGeography::Shape(int id) const {
   }
 }
 
-std::unique_ptr<S2Region> GeoArrowGeography::Region() {
+std::unique_ptr<S2Region> GeoArrowGeography::Region() const {
   auto maybe_point = Point();
   if (maybe_point) {
     return std::make_unique<S2PointRegion>(*maybe_point);
@@ -722,8 +722,17 @@ std::unique_ptr<S2Region> GeoArrowGeography::Region() {
   return std::make_unique<S2ShapeIndexRegion<MutableS2ShapeIndex>>(&index_);
 }
 
-void GeoArrowGeography::InitIndex() {
-  if (indexed_ || geom_.size_nodes == 0) {
+void GeoArrowGeography::InitIndex() const {
+  // Fast path: already indexed or empty geometry
+  if (indexed_.load(std::memory_order_acquire) || geom_.size_nodes == 0) {
+    return;
+  }
+
+  // Slow path: acquire lock and add shapes (double-checked locking)
+  std::lock_guard<std::mutex> lock(index_mutex_);
+
+  // Double-check after acquiring lock
+  if (indexed_.load(std::memory_order_relaxed)) {
     return;
   }
 
@@ -749,7 +758,7 @@ void GeoArrowGeography::InitIndex() {
           std::string(GeometryTypeString(geom_.root->geometry_type)));
   }
 
-  indexed_ = true;
+  indexed_.store(true, std::memory_order_release);
 }
 
 std::pair<int, int> GeoArrowGeography::ResolveGlobalEdgeId(

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -502,7 +502,8 @@ void GeoArrowGeography::InitOriented(struct GeoArrowGeometryView geom) {
   }
 }
 
-void GeoArrowGeography::GetCellUnionBound(std::vector<S2CellId>* cell_ids) const {
+void GeoArrowGeography::GetCellUnionBound(
+    std::vector<S2CellId>* cell_ids) const {
   if (geom_.size_nodes == 0 || is_empty()) {
     return;
   }

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -503,31 +503,6 @@ void GeoArrowGeography::InitOriented(struct GeoArrowGeometryView geom) {
   }
 }
 
-void GeoArrowGeography::GetCellUnionBound(
-    std::vector<S2CellId>* cell_ids) const {
-  if (geom_.size_nodes == 0 || is_empty()) {
-    return;
-  }
-
-  switch (geom_.root->geometry_type) {
-    case GEOARROW_GEOMETRY_TYPE_POINT:
-    case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
-      if (points_.num_vertices() <= 32) {
-        points_.geom().VisitVertices([&](S2Point v) {
-          cell_ids->push_back(S2CellId(v));
-          return true;
-        });
-        return;
-      }
-      break;
-    default:
-      break;
-  }
-
-  S2RegionCoverer coverer;
-  coverer.GetFastCovering(*Region(), cell_ids);
-}
-
 const std::vector<S2CellId>& GeoArrowGeography::Covering() const {
   InitIndex();
   return covering_;

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -5,6 +5,8 @@
 #include <s2/s2shape.h>
 #include <s2/s2shape_index.h>
 
+#include <atomic>
+#include <mutex>
 #include <vector>
 
 #include "s2geography/geoarrow-geography_util.h"
@@ -300,7 +302,7 @@ class GeoArrowGeography {
   /// containment. This is lazily computed and may incur building an index. For
   /// Small point or multipoint geographies this will not incur the cost of
   /// building an index.
-  const std::vector<S2CellId>& Covering();
+  const std::vector<S2CellId>& Covering() const;
 
   /// \brief Return a S2ShapeIndex representation of this geography
   ///
@@ -308,18 +310,18 @@ class GeoArrowGeography {
   /// and will not be built until it is queried (see MutableS2ShapeIndex). Note
   /// that building an index of a small geography is comparatively very costly
   /// to brute force iteration if that is an option for a given algorithm.
-  const S2ShapeIndex& ShapeIndex();
+  const S2ShapeIndex& ShapeIndex() const;
 
   /// \brief Return a Region representation of this geography
   ///
   /// This region is lazy: it will not be created until potentially this call.
   /// For (single) point geographies the implementation avoids creating or
   /// building an index.
-  std::unique_ptr<S2Region> Region();
+  std::unique_ptr<S2Region> Region() const;
 
   /// \brief Return true if the internal index has not yet been built
   bool is_unindexed() const {
-    if (indexed_) {
+    if (indexed_.load(std::memory_order_acquire)) {
       return !index_.is_fresh();
     } else {
       return true;
@@ -327,7 +329,7 @@ class GeoArrowGeography {
   }
 
   /// \brief Force building the internal index
-  void ForceBuildIndex() {
+  void ForceBuildIndex() const {
     InitIndex();
     index_.ForceBuild();
   }
@@ -466,12 +468,13 @@ class GeoArrowGeography {
   GeoArrowPointShape points_;
   GeoArrowLaxPolylineShape lines_;
   GeoArrowLaxPolygonShape polygons_;
-  MutableS2ShapeIndex index_;
-  std::vector<S2CellId> covering_;
-  bool indexed_{};
+  mutable MutableS2ShapeIndex index_;
+  mutable std::vector<S2CellId> covering_;
+  mutable std::mutex index_mutex_;
+  mutable std::atomic<bool> indexed_{false};
 
-  void InitIndex();
-  void GetCellUnionBound(std::vector<S2CellId>* cell_ids);
+  void InitIndex() const;
+  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
 };
 
 /// @}

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -329,7 +329,7 @@ class GeoArrowGeography {
   }
 
   /// \brief Force building the internal index
-  void ForceBuildIndex() const {
+  void ForceBuildIndex() {
     InitIndex();
     index_.ForceBuild();
   }

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -406,7 +406,7 @@ class GeoArrowGeography {
 
   /// \brief Visit all vertices in this geography
   template <typename Visit>
-  bool VisitVertices(Visit&& visit) {
+  bool VisitVertices(Visit&& visit) const {
     if (!points()->geom().VisitChains(
             [&](GeoArrowChain chain) { return chain.VisitVertices(visit); }))
       return false;

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -474,7 +474,6 @@ class GeoArrowGeography {
   mutable std::atomic<bool> indexed_{false};
 
   void InitIndex() const;
-  void GetCellUnionBound(std::vector<S2CellId>* cell_ids) const;
 };
 
 /// @}

--- a/src/s2geography/operation.h
+++ b/src/s2geography/operation.h
@@ -28,7 +28,7 @@ namespace s2geography {
 class Operation {
  public:
   /// \brief Output type enumerator
-  enum class OutputType { kBool, kDouble, kWkb };
+  enum class OutputType { kBool, kInt, kDouble, kWkb };
 
   Operation() = default;
   virtual ~Operation() = default;
@@ -56,6 +56,7 @@ class Operation {
   bool has_result() const { return has_result_; }
 
   /// \brief Return the integer result for operations whose output type is kInt
+  /// or kBool
   ///
   /// The result before a call to an Exec or for a function with a different
   /// output type is not defined.

--- a/src/s2geography/operation.h
+++ b/src/s2geography/operation.h
@@ -13,16 +13,19 @@ namespace s2geography {
 
 class Operation {
  public:
+  enum class OutputType { kBool, kDouble, kWkb };
+
   Operation() = default;
   virtual ~Operation() = default;
 
   virtual const std::string& name() const = 0;
+  virtual OutputType output_type() const = 0;
 
-  void ExecGeogGeog(const GeoArrowGeography& arg0,
-                    const GeoArrowGeography& arg1) {
+  virtual void ExecGeogGeog(const GeoArrowGeography& arg0,
+                            const GeoArrowGeography& arg1) {
     S2GEOGRAPHY_UNUSED(arg0);
     S2GEOGRAPHY_UNUSED(arg1);
-    throw Exception("Can't call " + name() + "with geog + geog");
+    throw Exception("Can't call " + name() + " with geog + geog");
   }
 
   bool has_result() const { return has_result_; }

--- a/src/s2geography/operation.h
+++ b/src/s2geography/operation.h
@@ -49,6 +49,15 @@ class Operation {
     throw Exception("Can't call " + name() + " with geog + geog");
   }
 
+  /// \brief Execute a function with two geographies and a double as input
+  virtual void ExecGeogGeogDouble(const GeoArrowGeography& arg0,
+                                  const GeoArrowGeography& arg1, double arg2) {
+    S2GEOGRAPHY_UNUSED(arg0);
+    S2GEOGRAPHY_UNUSED(arg1);
+    S2GEOGRAPHY_UNUSED(arg2);
+    throw Exception("Can't call " + name() + " with geog + geog + double");
+  }
+
   /// \brief Return true if the output of the last Exec call is non-null
   ///
   /// This is needed for functions that can return null even for non-null

--- a/src/s2geography/operation.h
+++ b/src/s2geography/operation.h
@@ -1,0 +1,40 @@
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "s2geography/geoarrow-geography.h"
+#include "s2geography/geography_interface.h"
+#include "s2geography/macros.h"
+
+namespace s2geography {
+
+class Operation {
+ public:
+  Operation() = default;
+  virtual ~Operation() = default;
+
+  virtual const std::string& name() const = 0;
+
+  void ExecGeogGeog(const GeoArrowGeography& arg0,
+                    const GeoArrowGeography& arg1) {
+    S2GEOGRAPHY_UNUSED(arg0);
+    S2GEOGRAPHY_UNUSED(arg1);
+    throw Exception("Can't call " + name() + "with geog + geog");
+  }
+
+  bool has_result() const { return has_result_; }
+  int64_t GetInt() const { return int_result_; }
+  double GetDouble() const { return double_result_; }
+  std::string_view GetStringView() const { return string_result_; }
+
+ protected:
+  bool has_result_{true};
+  int64_t int_result_{};
+  double double_result_{};
+  std::string_view string_result_{};
+};
+
+}  // namespace s2geography

--- a/src/s2geography/operation.h
+++ b/src/s2geography/operation.h
@@ -11,16 +11,37 @@
 
 namespace s2geography {
 
+/// \brief Generic abstract operator
+///
+/// This class is an abstract base for non-trivial operations (i.e., those
+/// expensive enough that the cost of the abstract dispatch is trivial compared
+/// to the operation in question). This is intended to (1) make it easier to
+/// wrap operations of s2geography and (2) ensure that operations that benefit
+/// from a cache of scratch space or heavy object initialization can amortize
+/// that overhead over many evaluations of a single function. Operations that
+/// are more sensitive to this type of overhead should expose the functionality
+/// directly or use the SedonaUDF interface.
+///
+/// Note that this operation does not participate in the propagation of nulls
+/// from inputs but can represent null outputs for operations that can return
+/// null even for some non-null inputs.
 class Operation {
  public:
+  /// \brief Output type enumerator
   enum class OutputType { kBool, kDouble, kWkb };
 
   Operation() = default;
   virtual ~Operation() = default;
 
+  /// \brief The name of this operation (e.g., for errors, debugging, or generic
+  /// wrapping)
   virtual const std::string& name() const = 0;
+
+  /// \brief The output type of this operation (e.g., for generic wrapping when
+  /// an output object type must be chosen)
   virtual OutputType output_type() const = 0;
 
+  /// \brief Execute a function with two geographies as input
   virtual void ExecGeogGeog(const GeoArrowGeography& arg0,
                             const GeoArrowGeography& arg1) {
     S2GEOGRAPHY_UNUSED(arg0);
@@ -28,9 +49,30 @@ class Operation {
     throw Exception("Can't call " + name() + " with geog + geog");
   }
 
+  /// \brief Return true if the output of the last Exec call is non-null
+  ///
+  /// This is needed for functions that can return null even for non-null
+  /// inputs.
   bool has_result() const { return has_result_; }
+
+  /// \brief Return the integer result for operations whose output type is kInt
+  ///
+  /// The result before a call to an Exec or for a function with a different
+  /// output type is not defined.
   int64_t GetInt() const { return int_result_; }
+
+  /// \brief Return the double result for operations whose output type is
+  /// kDouble
+  ///
+  /// The result before a call to an Exec or for a function with a different
+  /// output type is not defined.
   double GetDouble() const { return double_result_; }
+
+  /// \brief Return the byte array result for operations whose output type is
+  /// kWkb
+  ///
+  /// The result before a call to an Exec or for a function with a different
+  /// output type is not defined.
   std::string_view GetStringView() const { return string_result_; }
 
  protected:

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -185,7 +185,8 @@ struct S2Intersects {
     out->Append(ExecUsingShapeIndex(value0, value1));
   }
 
-  bool BruteForceExec(GeoArrowGeography& geog0, GeoArrowGeography& geog1) {
+  bool BruteForceExec(const GeoArrowGeography& geog0,
+                      const GeoArrowGeography& geog1) {
     // Collect non-point edges from both geometries upfront
     edges0_.clear();
     geog0.VisitNonPointEdges([&](const S2Shape::Edge& e) {
@@ -288,10 +289,11 @@ struct S2Intersects {
   std::vector<S2Shape::Edge> edges1_;
 };
 
+template <typename Output>
 struct S2Contains {
   using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = GeoArrowGeographyInputView;
-  using out_t = BoolOutputBuilder;
+  using out_t = Output;
 
   void Exec(arg0_t::c_type value0, arg1_t::c_type value1, out_t* out) {
     // If either argument is EMPTY, the result is FALSE
@@ -347,7 +349,8 @@ struct S2Contains {
     out->Append(ExecUsingShapeIndex(value0, value1));
   }
 
-  bool BruteForceExec(GeoArrowGeography& geog0, GeoArrowGeography& geog1) {
+  bool BruteForceExec(const GeoArrowGeography& geog0,
+                      const GeoArrowGeography& geog1) {
     // All vertices of geog1 must be inside geog0's polygons
     auto ref = geog0.polygons()->GetReferencePoint();
     if (!geog1.VisitVertices([&](const S2Point& pt) {
@@ -381,7 +384,7 @@ struct S2Contains {
   // Container (value0) is indexed, value1 is small and unindexed.
   // Use index queries to check all vertices/edges of value1 against value0.
   bool SemiBruteForceIndexedContains(const S2ShapeIndex& indexed,
-                                     GeoArrowGeography& fresh_geog) {
+                                     const GeoArrowGeography& fresh_geog) {
     // All vertices of the fresh geometry must be contained by the index.
     auto contains_query = MakeS2ContainsPointQuery(
         &indexed, S2ContainsPointQueryOptions(S2VertexModel::SEMI_OPEN));
@@ -414,10 +417,11 @@ struct S2Contains {
   std::vector<s2shapeutil::ShapeEdge> crossing_edges_;
 };
 
+template <typename Output>
 struct S2Equals {
   using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = GeoArrowGeographyInputView;
-  using out_t = BoolOutputBuilder;
+  using out_t = Output;
 
   S2Equals() {
     options_.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
@@ -445,8 +449,8 @@ struct S2Equals {
     out->Append(s2_equals(value0.ShapeIndex(), value1.ShapeIndex(), options_));
   }
 
-  bool GeographyIdentical(GeoArrowGeography& value0,
-                          GeoArrowGeography& value1) {
+  bool GeographyIdentical(const GeoArrowGeography& value0,
+                          const GeoArrowGeography& value1) {
     if (value0.num_shapes() != value1.num_shapes()) {
       return false;
     }
@@ -523,14 +527,14 @@ void IntersectsKernel(struct SedonaCScalarKernel* out, bool prepare_arg0_scalar,
 
 void ContainsKernel(struct SedonaCScalarKernel* out, bool prepare_arg0_scalar,
                     bool prepare_arg1_scalar) {
-  InitBinaryKernel<S2Contains>(out, "st_contains", prepare_arg0_scalar,
-                               prepare_arg1_scalar);
+  InitBinaryKernel<S2Contains<BoolOutputBuilder>>(
+      out, "st_contains", prepare_arg0_scalar, prepare_arg1_scalar);
 }
 
 void EqualsKernel(struct SedonaCScalarKernel* out, bool prepare_arg0_scalar,
                   bool prepare_arg1_scalar) {
-  InitBinaryKernel<S2Equals>(out, "st_equals", prepare_arg0_scalar,
-                             prepare_arg1_scalar);
+  InitBinaryKernel<S2Equals<BoolOutputBuilder>>(
+      out, "st_equals", prepare_arg0_scalar, prepare_arg1_scalar);
 }
 
 }  // namespace sedona_udf
@@ -540,70 +544,42 @@ struct StashedBoolOutput {
   bool* out_;
 };
 
-class IntersectsPredicate : public BinaryPredicate {
+template <typename Exec>
+class PredicateImpl : public BinaryPredicate {
  public:
-  IntersectsPredicate() : out_(StashedBoolOutput{&result_}) {}
+  PredicateImpl() : out_(StashedBoolOutput{&result_}) {}
 
   bool Evaluate(const GeoArrowGeography& lhs,
                 const GeoArrowGeography& rhs) override {
-    S2GEOGRAPHY_UNUSED(lhs);
-    S2GEOGRAPHY_UNUSED(rhs);
-    S2GEOGRAPHY_UNUSED(out_);
-    // exec_.Exec(lhs, rhs, &out_);
-    return false;
+    exec_.Exec(lhs, rhs, &out_);
+    return result_;
   }
 
  private:
   bool result_{};
   StashedBoolOutput out_;
-  sedona_udf::S2Intersects<StashedBoolOutput> exec_;
-};
-
-class ContainsPredicate : public BinaryPredicate {
- public:
-  bool Evaluate(const GeoArrowGeography& lhs,
-                const GeoArrowGeography& rhs) override {
-    S2GEOGRAPHY_UNUSED(lhs);
-    S2GEOGRAPHY_UNUSED(rhs);
-    // Const-correctness
-    // p_.Exec(lhs, rhs, nullptr);
-
-    return result_;
-  }
-
- private:
-  sedona_udf::S2Contains p_;
-  bool result_{};
+  Exec exec_;
 };
 
 class WithinPredicate : public BinaryPredicate {
  public:
   bool Evaluate(const GeoArrowGeography& lhs,
                 const GeoArrowGeography& rhs) override {
-    S2GEOGRAPHY_UNUSED(lhs);
-    S2GEOGRAPHY_UNUSED(rhs);
-    // TODO: implement
-    return false;
+    return contains_.Evaluate(rhs, lhs);
   }
-};
 
-class EqualsPredicate : public BinaryPredicate {
- public:
-  bool Evaluate(const GeoArrowGeography& lhs,
-                const GeoArrowGeography& rhs) override {
-    S2GEOGRAPHY_UNUSED(lhs);
-    S2GEOGRAPHY_UNUSED(rhs);
-    // TODO: implement
-    return false;
-  }
+ private:
+  PredicateImpl<sedona_udf::S2Contains<StashedBoolOutput>> contains_;
 };
 
 std::unique_ptr<BinaryPredicate> BinaryPredicate::Intersects() {
-  return std::make_unique<IntersectsPredicate>();
+  return std::make_unique<
+      PredicateImpl<sedona_udf::S2Intersects<StashedBoolOutput>>>();
 }
 
 std::unique_ptr<BinaryPredicate> BinaryPredicate::Contains() {
-  return std::make_unique<ContainsPredicate>();
+  return std::make_unique<
+      PredicateImpl<sedona_udf::S2Contains<StashedBoolOutput>>>();
 }
 
 std::unique_ptr<BinaryPredicate> BinaryPredicate::Within() {
@@ -611,7 +587,8 @@ std::unique_ptr<BinaryPredicate> BinaryPredicate::Within() {
 }
 
 std::unique_ptr<BinaryPredicate> BinaryPredicate::Equals() {
-  return std::make_unique<EqualsPredicate>();
+  return std::make_unique<
+      PredicateImpl<sedona_udf::S2Equals<StashedBoolOutput>>>();
 }
 
 }  // namespace s2geography

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -9,6 +9,7 @@
 #include <s2/s2edge_tessellator.h>
 #include <s2/s2lax_loop_shape.h>
 
+#include "s2geography/operation.h"
 #include "s2geography/sedona_udf/sedona_udf_internal.h"
 
 namespace s2geography {
@@ -545,50 +546,72 @@ struct StashedBoolOutput {
 };
 
 template <typename Exec>
-class PredicateImpl : public BinaryPredicate {
+class PredicateOperation : public Operation {
  public:
-  PredicateImpl() : out_(StashedBoolOutput{&result_}) {}
+  PredicateOperation(std::string name)
+      : name_(std::move(name)), out_(StashedBoolOutput{&result_}) {}
 
-  bool Evaluate(const GeoArrowGeography& lhs,
-                const GeoArrowGeography& rhs) override {
-    exec_.Exec(lhs, rhs, &out_);
-    return result_;
+  const std::string& name() const override { return name_; }
+
+  OutputType output_type() const override {
+    return Operation::OutputType::kBool;
+  }
+
+  void ExecGeogGeog(const GeoArrowGeography& arg0,
+                    const GeoArrowGeography& arg1) override {
+    exec_.Exec(arg0, arg1, &out_);
+    int_result_ = result_ ? 1 : 0;
   }
 
  private:
+  std::string name_;
   bool result_{};
   StashedBoolOutput out_;
   Exec exec_;
 };
 
-class WithinPredicate : public BinaryPredicate {
+class WithinOperation : public Operation {
  public:
-  bool Evaluate(const GeoArrowGeography& lhs,
-                const GeoArrowGeography& rhs) override {
-    return contains_.Evaluate(rhs, lhs);
+  WithinOperation() : name_("within") {}
+
+  const std::string& name() const override { return name_; }
+
+  OutputType output_type() const override {
+    return Operation::OutputType::kBool;
+  }
+
+  void ExecGeogGeog(const GeoArrowGeography& arg0,
+                    const GeoArrowGeography& arg1) override {
+    // Within(A, B) is Contains(B, A)
+    contains_.ExecGeogGeog(arg1, arg0);
+    int_result_ = contains_.GetInt();
   }
 
  private:
-  PredicateImpl<sedona_udf::S2Contains<StashedBoolOutput>> contains_;
+  std::string name_;
+  PredicateOperation<sedona_udf::S2Contains<StashedBoolOutput>> contains_{
+      "contains"};
 };
 
-std::unique_ptr<BinaryPredicate> BinaryPredicate::Intersects() {
+std::unique_ptr<Operation> Intersects() {
   return std::make_unique<
-      PredicateImpl<sedona_udf::S2Intersects<StashedBoolOutput>>>();
+      PredicateOperation<sedona_udf::S2Intersects<StashedBoolOutput>>>(
+      "intersects");
 }
 
-std::unique_ptr<BinaryPredicate> BinaryPredicate::Contains() {
+std::unique_ptr<Operation> Contains() {
   return std::make_unique<
-      PredicateImpl<sedona_udf::S2Contains<StashedBoolOutput>>>();
+      PredicateOperation<sedona_udf::S2Contains<StashedBoolOutput>>>(
+      "contains");
 }
 
-std::unique_ptr<BinaryPredicate> BinaryPredicate::Within() {
-  return std::make_unique<WithinPredicate>();
+std::unique_ptr<Operation> Within() {
+  return std::make_unique<WithinOperation>();
 }
 
-std::unique_ptr<BinaryPredicate> BinaryPredicate::Equals() {
+std::unique_ptr<Operation> Equals() {
   return std::make_unique<
-      PredicateImpl<sedona_udf::S2Equals<StashedBoolOutput>>>();
+      PredicateOperation<sedona_udf::S2Equals<StashedBoolOutput>>>("equals");
 }
 
 }  // namespace s2geography

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -113,10 +113,11 @@ namespace sedona_udf {
 
 static const int kMaxBruteForceEdges = 32;
 
+template <typename Output>
 struct S2Intersects {
   using arg0_t = GeoArrowGeographyInputView;
   using arg1_t = GeoArrowGeographyInputView;
-  using out_t = BoolOutputBuilder;
+  using out_t = Output;
 
   S2Intersects() {
     options_.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
@@ -516,8 +517,8 @@ struct S2Equals {
 
 void IntersectsKernel(struct SedonaCScalarKernel* out, bool prepare_arg0_scalar,
                       bool prepare_arg1_scalar) {
-  InitBinaryKernel<S2Intersects>(out, "st_intersects", prepare_arg0_scalar,
-                                 prepare_arg1_scalar);
+  InitBinaryKernel<S2Intersects<BoolOutputBuilder>>(
+      out, "st_intersects", prepare_arg0_scalar, prepare_arg1_scalar);
 }
 
 void ContainsKernel(struct SedonaCScalarKernel* out, bool prepare_arg0_scalar,
@@ -533,5 +534,84 @@ void EqualsKernel(struct SedonaCScalarKernel* out, bool prepare_arg0_scalar,
 }
 
 }  // namespace sedona_udf
+
+struct StashedBoolOutput {
+  void Append(bool value) { *out_ = value; }
+  bool* out_;
+};
+
+class IntersectsPredicate : public BinaryPredicate {
+ public:
+  IntersectsPredicate() : out_(StashedBoolOutput{&result_}) {}
+
+  bool Evaluate(const GeoArrowGeography& lhs,
+                const GeoArrowGeography& rhs) override {
+    S2GEOGRAPHY_UNUSED(lhs);
+    S2GEOGRAPHY_UNUSED(rhs);
+    S2GEOGRAPHY_UNUSED(out_);
+    // exec_.Exec(lhs, rhs, &out_);
+    return false;
+  }
+
+ private:
+  bool result_{};
+  StashedBoolOutput out_;
+  sedona_udf::S2Intersects<StashedBoolOutput> exec_;
+};
+
+class ContainsPredicate : public BinaryPredicate {
+ public:
+  bool Evaluate(const GeoArrowGeography& lhs,
+                const GeoArrowGeography& rhs) override {
+    S2GEOGRAPHY_UNUSED(lhs);
+    S2GEOGRAPHY_UNUSED(rhs);
+    // Const-correctness
+    // p_.Exec(lhs, rhs, nullptr);
+
+    return result_;
+  }
+
+ private:
+  sedona_udf::S2Contains p_;
+  bool result_{};
+};
+
+class WithinPredicate : public BinaryPredicate {
+ public:
+  bool Evaluate(const GeoArrowGeography& lhs,
+                const GeoArrowGeography& rhs) override {
+    S2GEOGRAPHY_UNUSED(lhs);
+    S2GEOGRAPHY_UNUSED(rhs);
+    // TODO: implement
+    return false;
+  }
+};
+
+class EqualsPredicate : public BinaryPredicate {
+ public:
+  bool Evaluate(const GeoArrowGeography& lhs,
+                const GeoArrowGeography& rhs) override {
+    S2GEOGRAPHY_UNUSED(lhs);
+    S2GEOGRAPHY_UNUSED(rhs);
+    // TODO: implement
+    return false;
+  }
+};
+
+std::unique_ptr<BinaryPredicate> BinaryPredicate::Intersects() {
+  return std::make_unique<IntersectsPredicate>();
+}
+
+std::unique_ptr<BinaryPredicate> BinaryPredicate::Contains() {
+  return std::make_unique<ContainsPredicate>();
+}
+
+std::unique_ptr<BinaryPredicate> BinaryPredicate::Within() {
+  return std::make_unique<WithinPredicate>();
+}
+
+std::unique_ptr<BinaryPredicate> BinaryPredicate::Equals() {
+  return std::make_unique<EqualsPredicate>();
+}
 
 }  // namespace s2geography

--- a/src/s2geography/predicates.h
+++ b/src/s2geography/predicates.h
@@ -3,6 +3,7 @@
 
 #include <s2/s2boolean_operation.h>
 
+#include "s2geography/geoarrow-geography.h"
 #include "s2geography/geography.h"
 #include "s2geography/sedona_udf/sedona_extension.h"
 
@@ -41,6 +42,20 @@ bool s2_intersects_box(const ShapeIndexGeography& geog1,
 bool s2_intersects_box(const S2ShapeIndex& geog1, const S2LatLngRect& rect,
                        const S2BooleanOperation::Options& options,
                        double tolerance);
+
+class BinaryPredicate {
+ public:
+  BinaryPredicate() = default;
+  virtual ~BinaryPredicate() = default;
+
+  virtual bool Evaluate(const GeoArrowGeography& lhs,
+                        const GeoArrowGeography& rhs) = 0;
+
+  std::unique_ptr<BinaryPredicate> Intersects();
+  std::unique_ptr<BinaryPredicate> Contains();
+  std::unique_ptr<BinaryPredicate> Within();
+  std::unique_ptr<BinaryPredicate> Equals();
+};
 
 namespace sedona_udf {
 

--- a/src/s2geography/predicates.h
+++ b/src/s2geography/predicates.h
@@ -3,8 +3,8 @@
 
 #include <s2/s2boolean_operation.h>
 
-#include "s2geography/geoarrow-geography.h"
 #include "s2geography/geography.h"
+#include "s2geography/operation.h"
 #include "s2geography/sedona_udf/sedona_extension.h"
 
 namespace s2geography {
@@ -43,19 +43,10 @@ bool s2_intersects_box(const S2ShapeIndex& geog1, const S2LatLngRect& rect,
                        const S2BooleanOperation::Options& options,
                        double tolerance);
 
-class BinaryPredicate {
- public:
-  BinaryPredicate() = default;
-  virtual ~BinaryPredicate() = default;
-
-  virtual bool Evaluate(const GeoArrowGeography& lhs,
-                        const GeoArrowGeography& rhs) = 0;
-
-  static std::unique_ptr<BinaryPredicate> Intersects();
-  static std::unique_ptr<BinaryPredicate> Contains();
-  static std::unique_ptr<BinaryPredicate> Within();
-  static std::unique_ptr<BinaryPredicate> Equals();
-};
+std::unique_ptr<Operation> Intersects();
+std::unique_ptr<Operation> Contains();
+std::unique_ptr<Operation> Within();
+std::unique_ptr<Operation> Equals();
 
 namespace sedona_udf {
 

--- a/src/s2geography/predicates.h
+++ b/src/s2geography/predicates.h
@@ -51,10 +51,10 @@ class BinaryPredicate {
   virtual bool Evaluate(const GeoArrowGeography& lhs,
                         const GeoArrowGeography& rhs) = 0;
 
-  std::unique_ptr<BinaryPredicate> Intersects();
-  std::unique_ptr<BinaryPredicate> Contains();
-  std::unique_ptr<BinaryPredicate> Within();
-  std::unique_ptr<BinaryPredicate> Equals();
+  static std::unique_ptr<BinaryPredicate> Intersects();
+  static std::unique_ptr<BinaryPredicate> Contains();
+  static std::unique_ptr<BinaryPredicate> Within();
+  static std::unique_ptr<BinaryPredicate> Equals();
 };
 
 namespace sedona_udf {

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "nanoarrow/nanoarrow.hpp"
+#include "s2geography/geoarrow-geography.h"
 #include "s2geography/sedona_udf/sedona_udf_test_internal.h"
 
 TEST(Predicates, SedonaUdfIntersectsScalarArray) {
@@ -282,6 +283,67 @@ TEST_P(PredicatesScalarScalarTest, SedonaUdf) {
 
       ASSERT_NO_FATAL_FAILURE(
           TestResultArrow(out_array.get(), NANOARROW_TYPE_BOOL, {p.expected}));
+    }
+  }
+}
+
+TEST_P(PredicatesScalarScalarTest, BinaryPredicate) {
+  const auto& p = GetParam();
+
+  // Skip null tests for BinaryPredicate (it doesn't handle nulls directly)
+  if (!p.lhs.has_value() || !p.rhs.has_value()) {
+    return;
+  }
+
+  // Create the appropriate predicate
+  std::unique_ptr<s2geography::BinaryPredicate> predicate;
+  if (p.op == "intersects") {
+    predicate = s2geography::BinaryPredicate::Intersects();
+  } else if (p.op == "contains") {
+    predicate = s2geography::BinaryPredicate::Contains();
+  } else if (p.op == "equals") {
+    predicate = s2geography::BinaryPredicate::Equals();
+  } else {
+    FAIL() << "Unknown predicate: " << p.op;
+  }
+
+  // Check with all combinations of forcing an index build on arguments.
+  // This ensures we test both prepared (indexed) and unprepared (fresh)
+  // geographies.
+  for (bool prepare_arg0 : {true, false}) {
+    for (bool prepare_arg1 : {true, false}) {
+      SCOPED_TRACE("prepare_arg0: " + std::to_string(prepare_arg0) +
+                   ", prepare_arg1: " + std::to_string(prepare_arg1));
+
+      // Create fresh geographies for each iteration to ensure unindexed state
+      // when not preparing
+      auto lhs_geom = TestGeometry::FromWKT(*p.lhs);
+      auto rhs_geom = TestGeometry::FromWKT(*p.rhs);
+
+      s2geography::GeoArrowGeography lhs_geog;
+      s2geography::GeoArrowGeography rhs_geog;
+      lhs_geog.Init(lhs_geom.geom());
+      rhs_geog.Init(rhs_geom.geom());
+
+      // Force index build if preparing, otherwise verify geography is unindexed
+      if (prepare_arg0) {
+        lhs_geog.ForceBuildIndex();
+      } else {
+        ASSERT_TRUE(lhs_geog.is_unindexed())
+            << "lhs geography should be unindexed when not preparing";
+      }
+
+      if (prepare_arg1) {
+        rhs_geog.ForceBuildIndex();
+      } else {
+        ASSERT_TRUE(rhs_geog.is_unindexed())
+            << "rhs geography should be unindexed when not preparing";
+      }
+
+      bool result = predicate->Evaluate(lhs_geog, rhs_geog);
+      ASSERT_TRUE(p.expected.has_value())
+          << "Expected value should not be null";
+      EXPECT_EQ(result, *p.expected);
     }
   }
 }

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -287,22 +287,22 @@ TEST_P(PredicatesScalarScalarTest, SedonaUdf) {
   }
 }
 
-TEST_P(PredicatesScalarScalarTest, BinaryPredicate) {
+TEST_P(PredicatesScalarScalarTest, PredicateOperation) {
   const auto& p = GetParam();
 
-  // Skip null tests for BinaryPredicate (it doesn't handle nulls directly)
+  // Skip null tests for Operation (it doesn't handle nulls directly)
   if (!p.lhs.has_value() || !p.rhs.has_value()) {
     return;
   }
 
-  // Create the appropriate predicate
-  std::unique_ptr<s2geography::BinaryPredicate> predicate;
+  // Create the appropriate predicate operation
+  std::unique_ptr<s2geography::Operation> predicate;
   if (p.op == "intersects") {
-    predicate = s2geography::BinaryPredicate::Intersects();
+    predicate = s2geography::Intersects();
   } else if (p.op == "contains") {
-    predicate = s2geography::BinaryPredicate::Contains();
+    predicate = s2geography::Contains();
   } else if (p.op == "equals") {
-    predicate = s2geography::BinaryPredicate::Equals();
+    predicate = s2geography::Equals();
   } else {
     FAIL() << "Unknown predicate: " << p.op;
   }
@@ -340,7 +340,8 @@ TEST_P(PredicatesScalarScalarTest, BinaryPredicate) {
             << "rhs geography should be unindexed when not preparing";
       }
 
-      bool result = predicate->Evaluate(lhs_geog, rhs_geog);
+      predicate->ExecGeogGeog(lhs_geog, rhs_geog);
+      bool result = predicate->GetInt() != 0;
       ASSERT_TRUE(p.expected.has_value())
           << "Expected value should not be null";
       EXPECT_EQ(result, *p.expected);

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -776,7 +776,7 @@ using StringInputView = ArrowInputView<std::string_view>;
 /// represent any GeoArrow type when supported by geoarrow-c.
 class GeoArrowGeographyInputView {
  public:
-  using c_type = GeoArrowGeography&;
+  using c_type = const GeoArrowGeography&;
 
   static bool Matches(const struct ArrowSchema* type) {
     struct GeoArrowSchemaView schema_view;

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -217,19 +217,33 @@ S2GeogErrorCode S2GeogInitKernels(void* kernels_array,
 /// \defgroup operations Operators
 /// Generic interface for function operations
 ///
+/// This interface exposes functions in a generic way that (1) allows for
+/// operation-specific scratch space or expensive object construction to be
+/// amortized over many calls and (2) reduces the number of functions required
+/// in this C API. In general, only non-trivial functions are exposed in this
+/// way because there is some overhead associated with this wrapping. Trivial
+/// functions should be exposed directly in this C API or called via the Arrow
+/// interface where these overheads can be more effectively amortized over
+/// elements in a loop.
+///
 /// @{
 
 /// \brief Opaque operator object
 struct S2GeogOp;
 
-/// \brief
 #define S2GEOGRAPHY_OP_INTERSECTS 1
 #define S2GEOGRAPHY_OP_CONTAINS 2
 #define S2GEOGRAPHY_OP_WITHIN 3
 #define S2GEOGRAPHY_OP_EQUALS 4
 
+#define S2GEOGRAPHY_OP_OUTPUT_BOOL 1
+
 /// \brief Create a new operator object
 S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp* op, int op_id);
+
+const char* S2GeogOpName(struct S2GeogOp* op);
+
+int S2GeogOutputType(struct S2GeogOp* op);
 
 /// \brief Evaluate a operation with two geographies as input
 S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* lhs,

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -239,7 +239,7 @@ struct S2GeogOp;
 #define S2GEOGRAPHY_OP_OUTPUT_BOOL 1
 
 /// \brief Create a new operator object
-S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp* op, int op_id);
+S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp** op, int op_id);
 
 const char* S2GeogOpName(struct S2GeogOp* op);
 

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -214,31 +214,33 @@ S2GeogErrorCode S2GeogInitKernels(void* kernels_array,
 
 /// @}
 
-/// \defgroup predicates Predicates
-/// Functions for evaluating spatial predicates between geographies.
+/// \defgroup operations Operators
+/// Generic interface for function operations
 ///
 /// @{
 
-/// \brief Opaque predicate object
-struct S2GeogPredicate;
+/// \brief Opaque operator object
+struct S2GeogOp;
 
 /// \brief
-#define S2GEOGRAPHY_PREDICATE_INTERSECTS 1
-#define S2GEOGRAPHY_PREDICATE_CONTAINS 2
-#define S2GEOGRAPHY_PREDICATE_WITHIN 3
-#define S2GEOGRAPHY_PREDICATE_EQUALS 4
+#define S2GEOGRAPHY_OP_INTERSECTS 1
+#define S2GEOGRAPHY_OP_CONTAINS 2
+#define S2GEOGRAPHY_OP_WITHIN 3
+#define S2GEOGRAPHY_OP_EQUALS 4
 
-/// \brief Create a new predicate object
-S2GeogErrorCode S2GeogPredicateCreate(struct S2GeogPredicate* predicate,
-                                      int predicate_id);
+/// \brief Create a new operator object
+S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp* op, int op_id);
 
-/// \brief Evaluate a predicate between two geographies
-S2GeogErrorCode S2GeogPredicateEval(struct S2GeogPredicate* predicate,
-                                    const S2Geog* lhs, const S2Geog* rhs,
-                                    uint8_t* out, struct S2GeogError* err);
+/// \brief Evaluate a operation with two geographies as input
+S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* lhs,
+                                     const S2Geog* rhs,
+                                     struct S2GeogError* err);
 
-/// \brief Destroy a predicate object
-void S2GeogPredicateDestroy(struct S2GeogPredicate* predicate);
+/// \brief Get integer or boolean output for this operation
+int64_t S2GeogOpGetInt(struct S2GeogOp* op);
+
+/// \brief Destroy a op object
+void S2GeogOpDestroy(struct S2GeogOp* op);
 
 /// @}
 

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -96,6 +96,21 @@ struct S2Geog;
 /// \pre geog != NULL
 S2GeogErrorCode S2GeogCreate(struct S2Geog** geog);
 
+/// \brief Force building the internal shape index for this geography
+///
+/// Most operations attempt to avoid building the internal ShapeIndex
+/// attached to this geography because doing so can be slow; however, for
+/// repeated calls to the same function (e.g., predicates), it can be faster to
+/// force the creation of an index. For example, internal S2 logic generally
+/// avoids building an index for loops with less than 32 vertices unless there
+/// have been 20 or more point containment queries on the same loop. In
+/// S2Geography, we leave the choice of whether or not to eagerly build an index
+/// to the user.
+///
+/// \pre geog != NULL
+S2GeogErrorCode S2GeogForcePrepare(struct S2Geog* geog,
+                                   struct S2GeogError* err);
+
 /// \brief Destroy a geography object
 ///
 /// \pre geog != NULL

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -34,6 +34,9 @@ extern "C" {
 /// between calls (e.g., users may wish to allocate a thread-local error
 /// and reuse it).
 ///
+/// Functions that can't fail do not return error codes or accept error
+/// arguments and return their values directly.
+///
 /// @{
 
 /// \brief An errno-compatible error code
@@ -208,6 +211,34 @@ size_t S2GeogNumKernels(void);
 /// The only currently supported format is S2GEOGRAPHY_KERNEL_FORMAT_SEDONA_UDF.
 S2GeogErrorCode S2GeogInitKernels(void* kernels_array,
                                   size_t kernels_array_size_bytes, int format);
+
+/// @}
+
+/// \defgroup predicates Predicates
+/// Functions for evaluating spatial predicates between geographies.
+///
+/// @{
+
+/// \brief Opaque predicate object
+struct S2GeogPredicate;
+
+/// \brief
+#define S2GEOGRAPHY_PREDICATE_INTERSECTS 1
+#define S2GEOGRAPHY_PREDICATE_CONTAINS 2
+#define S2GEOGRAPHY_PREDICATE_WITHIN 3
+#define S2GEOGRAPHY_PREDICATE_EQUALS 4
+
+/// \brief Create a new predicate object
+S2GeogErrorCode S2GeogPredicateCreate(struct S2GeogPredicate* predicate,
+                                      int predicate_id);
+
+/// \brief Evaluate a predicate between two geographies
+S2GeogErrorCode S2GeogPredicateEval(struct S2GeogPredicate* predicate,
+                                    const S2Geog* lhs, const S2Geog* rhs,
+                                    uint8_t* out, struct S2GeogError* err);
+
+/// \brief Destroy a predicate object
+void S2GeogPredicateDestroy(struct S2GeogPredicate* predicate);
 
 /// @}
 

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -132,6 +132,21 @@ S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
     struct S2GeogFactory* geog_factory, const uint8_t* buf, size_t buf_size,
     struct S2Geog* out, struct S2GeogError* err);
 
+/// \brief Create a geography from WKT
+///
+/// The output S2Geog must have been created before this call with
+/// S2GeogCreate(). The resulting geography owns its coordinates and
+/// is not tied to the lifecycle of the input text. This is primarily
+/// useful for testing.
+///
+/// \pre geog_factory != NULL
+/// \pre out != NULL
+/// \pre buf != NULL || buf_size == 0
+S2GeogErrorCode S2GeogFactoryInitFromWkt(struct S2GeogFactory* geog_factory,
+                                         const char* buf, size_t buf_size,
+                                         struct S2Geog* out,
+                                         struct S2GeogError* err);
+
 /// \brief Destroy a geography factory
 ///
 /// \pre geog_factory != NULL

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -154,6 +154,9 @@ S2GeogErrorCode S2GeogFactoryInitFromWkbNonOwning(
 /// is not tied to the lifecycle of the input text. This is primarily
 /// useful for testing.
 ///
+/// This function may modify out in the case of error; however, is left in
+/// a valid state and may be reused in another call to a factory method.
+///
 /// \pre geog_factory != NULL
 /// \pre out != NULL
 /// \pre buf != NULL || buf_size == 0
@@ -308,7 +311,7 @@ S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* arg0,
 /// \pre op != NULL
 int64_t S2GeogOpGetInt(struct S2GeogOp* op);
 
-/// \brief Destroy a op object
+/// \brief Destroy an op object
 ///
 /// \pre op != NULL
 void S2GeogOpDestroy(struct S2GeogOp* op);

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -294,7 +294,7 @@ const char* S2GeogOpName(const struct S2GeogOp* op);
 /// \pre op != NULL
 int S2GeogOpOutputType(const struct S2GeogOp* op);
 
-/// \brief Evaluate a operation with two geographies as input
+/// \brief Evaluate an operation with two geographies as input
 ///
 /// \pre op != NULL
 /// \pre arg0 != NULL

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -246,31 +246,56 @@ S2GeogErrorCode S2GeogInitKernels(void* kernels_array,
 /// \brief Opaque operator object
 struct S2GeogOp;
 
+/// \brief Compute the intersects predicate between two geographies, returning a
+/// boolean
 #define S2GEOGRAPHY_OP_INTERSECTS 1
+
+/// \brief Compute the contains predicate between two geographies, returning a
+/// boolean
 #define S2GEOGRAPHY_OP_CONTAINS 2
+
+/// \brief Compute the within predicate between two geographies, returning a
+/// boolean
 #define S2GEOGRAPHY_OP_WITHIN 3
+
+/// \brief Compute the equals predicate between two geographies, returning a
+/// boolean
 #define S2GEOGRAPHY_OP_EQUALS 4
 
 #define S2GEOGRAPHY_OUTPUT_TYPE_BOOL 1
 
 /// \brief Create a new operator object
+///
+/// \pre op != NULL
 S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp** op, int op_id);
 
 /// \brief Get the name of the operator
+///
+/// \pre op != NULL
 const char* S2GeogOpName(const struct S2GeogOp* op);
 
 /// \brief Get the output type of the operator
+///
+/// \pre op != NULL
 int S2GeogOpOutputType(const struct S2GeogOp* op);
 
 /// \brief Evaluate a operation with two geographies as input
-S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* lhs,
-                                     const S2Geog* rhs,
+///
+/// \pre op != NULL
+/// \pre arg0 != NULL
+/// \pre arg1 != NULL
+S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* arg0,
+                                     const S2Geog* arg1,
                                      struct S2GeogError* err);
 
 /// \brief Get integer or boolean output for this operation
+///
+/// \pre op != NULL
 int64_t S2GeogOpGetInt(struct S2GeogOp* op);
 
 /// \brief Destroy a op object
+///
+/// \pre op != NULL
 void S2GeogOpDestroy(struct S2GeogOp* op);
 
 /// @}

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -251,14 +251,16 @@ struct S2GeogOp;
 #define S2GEOGRAPHY_OP_WITHIN 3
 #define S2GEOGRAPHY_OP_EQUALS 4
 
-#define S2GEOGRAPHY_OP_OUTPUT_BOOL 1
+#define S2GEOGRAPHY_OUTPUT_TYPE_BOOL 1
 
 /// \brief Create a new operator object
 S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp** op, int op_id);
 
-const char* S2GeogOpName(struct S2GeogOp* op);
+/// \brief Get the name of the operator
+const char* S2GeogOpName(const struct S2GeogOp* op);
 
-int S2GeogOutputType(struct S2GeogOp* op);
+/// \brief Get the output type of the operator
+int S2GeogOpOutputType(const struct S2GeogOp* op);
 
 /// \brief Evaluate a operation with two geographies as input
 S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* lhs,

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -280,6 +280,10 @@ struct S2GeogOp;
 /// boolean
 #define S2GEOGRAPHY_OP_EQUALS 4
 
+/// \brief Compute the distance-within predicate between two geographies with a
+/// distance threshold, returning a boolean
+#define S2GEOGRAPHY_OP_DISTANCE_WITHIN 5
+
 #define S2GEOGRAPHY_OUTPUT_TYPE_BOOL 1
 
 /// \brief Create a new operator object
@@ -305,6 +309,16 @@ int S2GeogOpOutputType(const struct S2GeogOp* op);
 S2GeogErrorCode S2GeogOpEvalGeogGeog(struct S2GeogOp* op, const S2Geog* arg0,
                                      const S2Geog* arg1,
                                      struct S2GeogError* err);
+
+/// \brief Evaluate an operation with two geographies and a double as input
+///
+/// \pre op != NULL
+/// \pre arg0 != NULL
+/// \pre arg1 != NULL
+S2GeogErrorCode S2GeogOpEvalGeogGeogDouble(struct S2GeogOp* op,
+                                           const S2Geog* arg0,
+                                           const S2Geog* arg1, double arg2,
+                                           struct S2GeogError* err);
 
 /// \brief Get integer or boolean output for this operation
 ///


### PR DESCRIPTION
This PR adds predicates to the C API, which is strictly speaking the minimum I need to implement spatial joins for geography in SedonaDB (hopefully). The key change here is that a `const GeoArrowGeography` has a thread-safe prepared state (because querying these objects in parallel is a key driver of the performance we have in our join, and the reason why GEOS is so bad that we can't use it there).

I ran the benchmarks in SedonaDB to make sure the mutex wasn't slowing down the single threaded case and it doesn't seem to have.

The route for exposing these is via an `Operation` wrapper, which is basically a way to avoid me having to expose too many different object types in the C API (or C++ API) while retaining the scratch space / heavy object amortization that we get for having every "operation" be reused. I'm open to other ways to do this...I'll give this a go from Rust to see if it does what we need it to.