### PR TITLE
feat: Add GEOMETRYCOLLECTION to GeoArrowGeometry

### DIFF
--- a/src/s2geography/accessors-geog_test.cc
+++ b/src/s2geography/accessors-geog_test.cc
@@ -192,7 +192,14 @@ INSTANTIATE_TEST_SUITE_P(
             "polygon_with_hole",
             "POLYGON ((0 0, 0 2, 2 0, 0 0), (0.1 0.1, 0.1 0.5, 0.5 "
             "0.1, 0.1 0.1))",
-            23744568445.094166}
+            23744568445.094166},
+
+        // GeometryCollection (area from polygon only)
+        UnaryDoubleScalarParam{
+            "geometrycollection",
+            "GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (0 0, 0 1), "
+            "POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+            6182489130.9071951}
 
         ),
     [](const ::testing::TestParamInfo<UnaryDoubleScalarParam>& info) {
@@ -236,7 +243,14 @@ INSTANTIATE_TEST_SUITE_P(
         UnaryDoubleScalarParam{"triangle", "POLYGON ((0 0, 0 1, 1 0, 0 0))",
                                0.0},
         UnaryDoubleScalarParam{"square", "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
-                               0.0}
+                               0.0},
+
+        // GeometryCollection (length from linestring only)
+        UnaryDoubleScalarParam{
+            "geometrycollection",
+            "GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (0 0, 0 1), "
+            "POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+            111195.10117748393}
 
         ),
     [](const ::testing::TestParamInfo<UnaryDoubleScalarParam>& info) {
@@ -286,7 +300,14 @@ INSTANTIATE_TEST_SUITE_P(
             "polygon_with_hole",
             "POLYGON ((0 0, 0 2, 2 0, 0 0), (0.1 0.1, 0.1 0.5, 0.5 0.1, 0.1 "
             "0.1))",
-            911112.66968130425}
+            911112.66968130425},
+
+        // GeometryCollection (perimeter from polygon only)
+        UnaryDoubleScalarParam{
+            "geometrycollection",
+            "GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (0 0, 0 1), "
+            "POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+            379639.83044747578}
 
         ),
     [](const ::testing::TestParamInfo<UnaryDoubleScalarParam>& info) {
@@ -451,7 +472,14 @@ INSTANTIATE_TEST_SUITE_P(
             "POLYGON ZM ((0 0 10 20, 0 2 10 20, 2 0 10 20, 0 0 "
             "10 20), (0.1 0.1 11 21, 0.1 0.5 11 21, 0.5 "
             "0.1 11 21, 0.1 0.1 11 21))",
-            "POINT ZM (0.684859 0.68481 10.038454 20.038454)"}
+            "POINT ZM (0.684859 0.68481 10.038454 20.038454)"},
+
+        // GeometryCollection (centroid weighted by all components)
+        UnaryGeographyScalarParam{
+            "geometrycollection",
+            "GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (0 0, 0 1), "
+            "POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+            "POINT (0.33335 0.333344)"}
 
         ),
     [](const ::testing::TestParamInfo<UnaryGeographyScalarParam>& info) {
@@ -511,7 +539,14 @@ INSTANTIATE_TEST_SUITE_P(
             "multipolygon_with_hole",
             "MULTIPOLYGON (((0 0, 0 2, 2 0, 0 0), (0.1 0.1, 0.1 0.5, "
             "0.5 0.1, 0.1 0.1)), ((10 10, 10 11, 11 10, 10 10)))",
-            "POLYGON ((0 0, 2 0, 11 10, 10 11, 0 2, 0 0))"}
+            "POLYGON ((0 0, 2 0, 11 10, 10 11, 0 2, 0 0))"},
+
+        // GeometryCollection (convex hull of all vertices)
+        UnaryGeographyScalarParam{
+            "geometrycollection",
+            "GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (0 0, 0 1), "
+            "POLYGON ((0 0, 0 1, 1 0, 0 0)))",
+            "POLYGON ((0 0, 1 0, 5 5, 0 1, 0 0))"}
 
         ),
     [](const ::testing::TestParamInfo<UnaryGeographyScalarParam>& info) {
@@ -580,6 +615,13 @@ INSTANTIATE_TEST_SUITE_P(
             "multipolygon",
             "MULTIPOLYGON (((0 0, 0 1, 1 0, 0 0)), ((10 10, 10 11, "
             "11 10, 10 10)))",
+            "POINT (0.224466 0.224464)"},
+
+        // GeometryCollection (point on one of the surfaces)
+        UnaryGeographyScalarParam{
+            "geometrycollection",
+            "GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (0 0, 0 1), "
+            "POLYGON ((0 0, 0 1, 1 0, 0 0)))",
             "POINT (0.224466 0.224464)"}
 
         ),

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -118,7 +118,14 @@ INSTANTIATE_TEST_SUITE_P(
                                -180.0, 80.0, 180.0, 90.0},
         LatLngRectBounderParam{"triangle_south_pole",
                                "POLYGON ((0 -80, -120 -80, 120 -80, 0 -80))",
-                               -180.0, -90.0, 180.0, -80.0}
+                               -180.0, -90.0, 180.0, -80.0},
+
+        // GeometryCollection (bounds span all component geometries)
+        LatLngRectBounderParam{
+            "geometrycollection",
+            "GEOMETRYCOLLECTION (POINT (50 50), LINESTRING (0 0, 10 0), "
+            "POLYGON ((0 0, 10 0, 5 10, 0 0)))",
+            0.0, -4.1493099444912135e-14, 50.000000000000028, 50.0}
 
         ));
 

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -949,7 +949,8 @@ INSTANTIATE_TEST_SUITE_P(
             // GC (with polygon) x point outside
             // Uses index path due to polygon
             "gc_with_polygon_distance_point_outside",
-            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 "
+            "0)))",
             "POINT (-1 0)",
             // Distance: same as polygon_not_contains_close_point
             111195.10117748393,
@@ -984,7 +985,8 @@ INSTANTIATE_TEST_SUITE_P(
             // GC (with polygon) x linestring inside
             // Uses index due to polygon; linestring fully inside polygon
             "gc_with_polygon_distance_linestring_inside",
-            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 "
+            "0)))",
             "LINESTRING (0.25 0.25, 0.5 0.5)",
             // Distance: linestring inside polygon
             0.0,
@@ -1001,7 +1003,8 @@ INSTANTIATE_TEST_SUITE_P(
             // Reversed: linestring fully outside polygon
             "linestring_distance_gc_with_polygon_outside",
             "LINESTRING (3 3, 4 4)",
-            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 "
+            "0)))",
             // Distance: same as linestring_distance_polygon_outside
             314367.35908786188,
             // Max distance: from LINESTRING(3 3) to POINT(30 30)

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -891,7 +891,163 @@ INSTANTIATE_TEST_SUITE_P(
             // Longest line
             "LINESTRING (0 -90, 0 90)",
             // Closest Point
-            "POINT (0 -90)"}
+            "POINT (0 -90)"},
+
+        // GEOMETRYCOLLECTION tests
+        // These test cases exercise different fast paths in the distance
+        // implementation based on geometry type composition.
+
+        DistanceScalarScalarParam{
+            // GC (point + linestring, no polygon) x point
+            // Exercises brute force path for small geometries without polygons
+            "gc_no_polygon_distance_point",
+            "GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (0 0, 0 1))",
+            "POINT (0 0)",
+            // Distance: point at (0,0) touches the linestring
+            0.0,
+            // Max distance: from POINT(5 5) to POINT(0 0)
+            785768.45419216133,
+            // Shortest line
+            "LINESTRING (0 0, 0 0)",
+            // Longest line
+            "LINESTRING (5 5, 0 0)",
+            // Closest Point
+            "POINT (0 0)"},
+        DistanceScalarScalarParam{
+            // Point x GC (point + linestring, no polygon)
+            // Exercises brute force path (reversed)
+            "point_distance_gc_no_polygon", "POINT (0 0)",
+            "GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (0 0, 0 1))",
+            // Distance
+            0.0,
+            // Max distance
+            785768.45419216133,
+            // Shortest line
+            "LINESTRING (0 0, 0 0)",
+            // Longest line
+            "LINESTRING (0 0, 5 5)",
+            // Closest Point
+            "POINT (0 0)"},
+
+        DistanceScalarScalarParam{
+            // GC (with polygon) x point inside
+            // Exercises DistanceLineUsingShapeIndexAndPoint due to polygon
+            "gc_with_polygon_distance_point_inside",
+            "GEOMETRYCOLLECTION (POINT (5 5), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            "POINT (0.25 0.25)",
+            // Distance: point is inside polygon
+            0.0,
+            // Max distance: from POINT(5 5) to POINT(0.25 0.25)
+            746455.18632442318,
+            // Shortest line
+            "LINESTRING (0.25 0.25, 0.25 0.25)",
+            // Longest line
+            "LINESTRING (5 5, 0.25 0.25)",
+            // Closest Point
+            "POINT (0.25 0.25)"},
+        DistanceScalarScalarParam{
+            // GC (with polygon) x point outside
+            // Uses index path due to polygon
+            "gc_with_polygon_distance_point_outside",
+            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            "POINT (-1 0)",
+            // Distance: same as polygon_not_contains_close_point
+            111195.10117748393,
+            // Max distance: from POINT(30 30) to POINT(-1 0) (including polygon
+            // vertices)
+            4677959.9936393471,
+            // Shortest line
+            "LINESTRING (0 0, -1 0)",
+            // Longest line
+            "LINESTRING (30 30, -1 0)",
+            // Closest Point
+            "POINT (0 0)"},
+
+        DistanceScalarScalarParam{
+            // GC (point + linestring, no polygon) x linestring
+            // Exercises BothSmallWithoutPolygons brute force path
+            "gc_no_polygon_distance_linestring",
+            "GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (0 0, 0 1))",
+            "LINESTRING (0 0.5, 1 0.5)",
+            // Distance: linestrings cross at (0, 0.5)
+            0.0,
+            // Max distance: from POINT(5 5) to linestring vertex (0 0.5)
+            747405.65220515686,
+            // Shortest line
+            "LINESTRING (0 0.5, 0 0.5)",
+            // Longest line
+            "LINESTRING (5 5, 0 0.5)",
+            // Closest Point
+            "POINT (0 0.5)"},
+
+        DistanceScalarScalarParam{
+            // GC (with polygon) x linestring inside
+            // Uses index due to polygon; linestring fully inside polygon
+            "gc_with_polygon_distance_linestring_inside",
+            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            "LINESTRING (0.25 0.25, 0.5 0.5)",
+            // Distance: linestring inside polygon
+            0.0,
+            // Max distance: from POINT(30 30) to linestring vertex
+            4565335.4112626193,
+            // Shortest line
+            "LINESTRING (0.25 0.25, 0.25 0.25)",
+            // Longest line
+            "LINESTRING (30 30, 0.25 0.25)",
+            // Closest Point
+            "POINT (0.25 0.25)"},
+        DistanceScalarScalarParam{
+            // Linestring x GC (with polygon)
+            // Reversed: linestring fully outside polygon
+            "linestring_distance_gc_with_polygon_outside",
+            "LINESTRING (3 3, 4 4)",
+            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            // Distance: same as linestring_distance_polygon_outside
+            314367.35908786188,
+            // Max distance: from LINESTRING(3 3) to POINT(30 30)
+            4134193.266520442,
+            // Shortest line
+            "LINESTRING (3 3, 0.998247 1.00221)",
+            // Longest line
+            "LINESTRING (3 3, 30 30)",
+            // Closest Point
+            "POINT (3 3)"},
+
+        DistanceScalarScalarParam{
+            // GC x GC (both with polygons, overlapping)
+            // Exercises full DistanceLineUsingShapeIndex path
+            "gc_distance_gc_overlapping",
+            "GEOMETRYCOLLECTION (POINT (5 5), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            "GEOMETRYCOLLECTION (POINT (6 6), POLYGON ((0.5 0.5, 1.5 0.5, 0.5 "
+            "1.5, 0.5 0.5)))",
+            // Distance: polygons overlap
+            0.0,
+            // Max distance: from polygon vertex (0 0) to POINT(6 6)
+            942657.82524783083,
+            // Shortest line: interior touch point (reported at vertex from
+            // second GC point)
+            "LINESTRING (6 6, 6 6)",
+            // Longest line
+            "LINESTRING (0 0, 6 6)",
+            // Closest Point
+            "POINT (6 6)"},
+        DistanceScalarScalarParam{
+            // GC x GC (both with polygons, disjoint)
+            // Full index path with non-zero distance
+            "gc_distance_gc_disjoint",
+            "GEOMETRYCOLLECTION (POINT (0 0), POLYGON ((0 0, 1 0, 0 1, 0 0)))",
+            "GEOMETRYCOLLECTION (POINT (40 40), POLYGON ((30 30, 31 30, 30 31, "
+            "30 30)))",
+            // Distance: same as polygon_distance_polygon_outside
+            4520972.0955287321,
+            // Max distance: between POINT(0 0) and POINT(40 40)
+            6012101.3650370687,
+            // Shortest line
+            "LINESTRING (0 1, 30 30)",
+            // Longest line
+            "LINESTRING (0 0, 40 40)",
+            // Closest Point
+            "POINT (0 1)"}
 
         ),
     [](const ::testing::TestParamInfo<DistanceScalarScalarParam>& info) {

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -441,6 +441,7 @@ GeoArrowGeography::GeoArrowGeography(GeoArrowGeography&& other)
       points_(std::move(other.points_)),
       lines_(std::move(other.lines_)),
       polygons_(std::move(other.polygons_)),
+      collection_nodes_(std::move(other.collection_nodes_)),
       index_(),
       covering_(std::move(other.covering_)) {
   // index_ needs to be rebuilt
@@ -454,6 +455,7 @@ GeoArrowGeography& GeoArrowGeography::operator=(GeoArrowGeography&& other) {
     points_ = std::move(other.points_);
     lines_ = std::move(other.lines_);
     polygons_ = std::move(other.polygons_);
+    collection_nodes_ = std::move(other.collection_nodes_);
     covering_ = std::move(other.covering_);
     // index_ needs to be rebuilt
     index_.Clear();
@@ -485,17 +487,93 @@ void GeoArrowGeography::InitOriented(struct GeoArrowGeometryView geom) {
     case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
       points_.Init(geom);
       break;
+
     case GEOARROW_GEOMETRY_TYPE_LINESTRING:
     case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
       lines_.Init(geom);
       break;
+
     case GEOARROW_GEOMETRY_TYPE_POLYGON:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
       polygons_.Init(geom);
       break;
-    // GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION:
-    // Can be supported by walking the list and separating geometry types
-    // but not yet.
+
+    case GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION: {
+      // We support geometry collections by splitting them up consistently into
+      // a multipoint, followed by a multilinestring, followed by a
+      // multipolygon. This does not maintain the nesting structure of the
+      // original (however, that is available from the original geom in a
+      // pinch). In some cases this may copy nodes unnecessarily (e.g., for
+      // polygon, where they're copied already, or if there was already only a
+      // single multipoint or multilinestring with non-empty members) but we
+      // keep it this way for simplicity.
+
+      std::vector<struct GeoArrowGeometryNode> points;
+      std::vector<struct GeoArrowGeometryNode> lines;
+      std::vector<struct GeoArrowGeometryNode> polygons;
+
+      int64_t remaining_loops = 0;
+      GeoArrowGeom(geom).VisitNodes(
+          [&](const struct GeoArrowGeometryNode* node) {
+            switch (node->geometry_type) {
+              case GEOARROW_GEOMETRY_TYPE_POINT:
+                if (node->size > 0) {
+                  points.push_back(*node);
+                }
+                break;
+              case GEOARROW_GEOMETRY_TYPE_LINESTRING:
+                if (remaining_loops > 0) {
+                  if (node->size > 0) {
+                    polygons.push_back(*node);
+                  }
+                  --remaining_loops;
+                } else {
+                  lines.push_back(*node);
+                }
+                break;
+              case GEOARROW_GEOMETRY_TYPE_POLYGON:
+                remaining_loops = node->size;
+                polygons.push_back(*node);
+                break;
+              default:
+                break;
+            }
+            return true;
+          });
+
+      struct GeoArrowGeometryNode multi{};
+      multi.dimensions = geom.root->dimensions;
+
+      collection_nodes_.resize(points.size() + lines.size() + polygons.size() +
+                               3);
+      auto it = collection_nodes_.begin();
+
+      multi.size = static_cast<uint32_t>(points.size());
+      multi.geometry_type = GEOARROW_GEOMETRY_TYPE_MULTIPOINT;
+      *it++ = multi;
+      it = std::copy(points.begin(), points.end(), it);
+
+      multi.size = static_cast<uint32_t>(lines.size());
+      multi.geometry_type = GEOARROW_GEOMETRY_TYPE_MULTILINESTRING;
+      *it++ = multi;
+      it = std::copy(lines.begin(), lines.end(), it);
+
+      multi.size = static_cast<uint32_t>(polygons.size());
+      multi.geometry_type = GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON;
+      *it++ = multi;
+      it = std::copy(polygons.begin(), polygons.end(), it);
+
+      points_.Init(
+          {collection_nodes_.data(), static_cast<int64_t>(points.size() + 1)});
+      int64_t offset = static_cast<int64_t>(points.size() + 1);
+      lines_.Init({collection_nodes_.data() + offset,
+                   static_cast<int64_t>(lines.size() + 1)});
+      offset += static_cast<int64_t>(lines.size() + 1);
+      polygons_.Init({collection_nodes_.data() + offset,
+                      static_cast<int64_t>(polygons.size() + 1)});
+      break;
+    }
+
     default:
       throw Exception(
           "Can't create GeoArrowGeography from geometry type " +
@@ -724,9 +802,11 @@ void GeoArrowGeography::InitIndex() const {
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
       index_.Add(std::make_unique<S2ShapeWrapper>(&polygons_));
       break;
-    // GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION:
-    // Can be supported by walking the list and separating geometry types
-    // but not yet.
+    case GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION:
+      index_.Add(std::make_unique<S2ShapeWrapper>(&points_));
+      index_.Add(std::make_unique<S2ShapeWrapper>(&lines_));
+      index_.Add(std::make_unique<S2ShapeWrapper>(&polygons_));
+      break;
     default:
       throw Exception(
           "Can't create index from geometry type " +

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -468,6 +468,7 @@ class GeoArrowGeography {
   GeoArrowPointShape points_;
   GeoArrowLaxPolylineShape lines_;
   GeoArrowLaxPolygonShape polygons_;
+  std::vector<struct GeoArrowGeometryNode> collection_nodes_;
   mutable MutableS2ShapeIndex index_;
   mutable std::vector<S2CellId> covering_;
   mutable std::mutex index_mutex_;

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -1466,11 +1466,188 @@ TEST_F(GeoArrowGeographyTest, MultiPolygon) {
   EXPECT_EQ(shape->num_edges(), 6);  // 3 + 3
 }
 
-TEST_F(GeoArrowGeographyTest, GeometryCollectionThrows) {
-  auto gc_geom = TestGeometry::FromWKT("GEOMETRYCOLLECTION (POINT (0 0))");
-  GeoArrowGeography geog;
-  // Not yet supported
-  EXPECT_THROW(geog.Init(gc_geom.geom()), Exception);
+TEST_F(GeoArrowGeographyTest, GeometryCollectionBasicProperties) {
+  auto geog = MakeGeography(
+      "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (1 1, 2 2), "
+      "POLYGON ((10 10, 11 10, 10 11, 10 10)))");
+
+  EXPECT_EQ(geog.geometry_type(), GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION);
+  EXPECT_EQ(geog.dimension(), -1);
+  EXPECT_EQ(geog.max_dimension(), 2);
+  EXPECT_EQ(geog.num_shapes(), 3);
+  EXPECT_FALSE(geog.is_empty());
+  EXPECT_EQ(geog.num_edges(), 5);
+}
+
+TEST_F(GeoArrowGeographyTest, GeometryCollectionEmpty) {
+  auto geog = MakeGeography("GEOMETRYCOLLECTION EMPTY");
+
+  EXPECT_EQ(geog.geometry_type(), GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION);
+  EXPECT_TRUE(geog.is_empty());
+  EXPECT_EQ(geog.num_shapes(), 3);
+  EXPECT_EQ(geog.num_edges(), 0);
+}
+
+TEST_F(GeoArrowGeographyTest, GeometryCollectionShape) {
+  // Shape() switch - returns points_, lines_, polygons_ based on id
+  auto geog = MakeGeography(
+      "GEOMETRYCOLLECTION (POINT (0 0), POINT (1 1), "
+      "LINESTRING (2 2, 3 3), POLYGON ((10 10, 11 10, 10 11, 10 10)))");
+
+  // Shape(0) is points
+  auto* points_shape = geog.Shape(0);
+  ASSERT_NE(points_shape, nullptr);
+  EXPECT_EQ(points_shape->dimension(), 0);
+  EXPECT_EQ(points_shape->num_edges(), 2);
+
+  // Shape(1) is lines
+  auto* lines_shape = geog.Shape(1);
+  ASSERT_NE(lines_shape, nullptr);
+  EXPECT_EQ(lines_shape->dimension(), 1);
+  EXPECT_EQ(lines_shape->num_edges(), 1);
+
+  // Shape(2) is polygons
+  auto* polygons_shape = geog.Shape(2);
+  ASSERT_NE(polygons_shape, nullptr);
+  EXPECT_EQ(polygons_shape->dimension(), 2);
+  EXPECT_EQ(polygons_shape->num_edges(), 3);
+}
+
+TEST_F(GeoArrowGeographyTest, GeometryCollectionShapeIndex) {
+  // Tests InitIndex() switch - adds all three shapes to index
+  auto geog = MakeGeography(
+      "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (1 1, 2 2), "
+      "POLYGON ((10 10, 11 10, 10 11, 10 10)))");
+
+  // ShapeIndex() triggers InitIndex()
+  const auto& index = geog.ShapeIndex();
+  EXPECT_GE(index.num_shape_ids(), 3);
+
+  // Covering() also triggers InitIndex()
+  EXPECT_GT(geog.Covering().size(), 0);
+
+  // Test intersection with a point inside the polygon
+  auto point_in_poly = MakeGeography("POINT (10.1 10.1)");
+  EXPECT_TRUE(S2BooleanOperation::Intersects(geog.ShapeIndex(),
+                                             point_in_poly.ShapeIndex()));
+
+  // Test intersection with the point geometry
+  auto point_at_origin = MakeGeography("POINT (0 0)");
+  EXPECT_TRUE(S2BooleanOperation::Intersects(geog.ShapeIndex(),
+                                             point_at_origin.ShapeIndex()));
+
+  // Test no intersection far away
+  auto far_point = MakeGeography("POINT (50 50)");
+  EXPECT_FALSE(S2BooleanOperation::Intersects(geog.ShapeIndex(),
+                                              far_point.ShapeIndex()));
+}
+
+TEST_F(GeoArrowGeographyTest, GeometryCollectionResolveGlobalEdgeId) {
+  // Tests ResolveGlobalEdgeId() switch
+  auto geog = MakeGeography(
+      "GEOMETRYCOLLECTION (POINT (0 0), POINT (1 1), "
+      "LINESTRING (2 2, 3 3, 4 4), POLYGON ((10 10, 11 10, 10 11, 10 10)))");
+
+  // 2 point edges, 2 line edges, 3 polygon edges = 7 total
+
+  // Edge 0 is in points (shape 0)
+  EXPECT_EQ(geog.ResolveGlobalEdgeId(0), std::make_pair(0, 0));
+  // Edge 1 is in points (shape 0)
+  EXPECT_EQ(geog.ResolveGlobalEdgeId(1), std::make_pair(0, 1));
+
+  // Edge 2 is in lines (shape 1), local edge 0
+  EXPECT_EQ(geog.ResolveGlobalEdgeId(2), std::make_pair(1, 0));
+  // Edge 3 is in lines (shape 1), local edge 1
+  EXPECT_EQ(geog.ResolveGlobalEdgeId(3), std::make_pair(1, 1));
+
+  // Edge 4 is in polygons (shape 2), local edge 0
+  EXPECT_EQ(geog.ResolveGlobalEdgeId(4), std::make_pair(2, 0));
+  // Edge 5 is in polygons (shape 2), local edge 1
+  EXPECT_EQ(geog.ResolveGlobalEdgeId(5), std::make_pair(2, 1));
+  // Edge 6 is in polygons (shape 2), local edge 2
+  EXPECT_EQ(geog.ResolveGlobalEdgeId(6), std::make_pair(2, 2));
+}
+
+TEST_F(GeoArrowGeographyTest, GeometryCollectionNativeEdge) {
+  // Tests native_edge() switch
+  auto geog = MakeGeography(
+      "GEOMETRYCOLLECTION (POINT ZM (0 1 100 200), "
+      "LINESTRING ZM (2 3 101 201, 4 5 102 202), "
+      "POLYGON ZM ((10 10 10 20, 11 10 11 21, 10 11 12 22, 10 10 10 20)))");
+
+  // Native edge from points (shape 0)
+  auto e_point = geog.native_edge(0, 0);
+  EXPECT_DOUBLE_EQ(e_point.v0.lng, 0);
+  EXPECT_DOUBLE_EQ(e_point.v0.lat, 1);
+  EXPECT_DOUBLE_EQ(e_point.v0.zm[0], 100);
+  EXPECT_DOUBLE_EQ(e_point.v0.zm[1], 200);
+  EXPECT_EQ(e_point.v0, e_point.v1);  // Point edge is degenerate
+
+  // Native edge from lines (shape 1)
+  auto e_line = geog.native_edge(1, 0);
+  EXPECT_DOUBLE_EQ(e_line.v0.lng, 2);
+  EXPECT_DOUBLE_EQ(e_line.v0.lat, 3);
+  EXPECT_DOUBLE_EQ(e_line.v1.lng, 4);
+  EXPECT_DOUBLE_EQ(e_line.v1.lat, 5);
+
+  // Native edge from polygons (shape 2)
+  auto e_poly = geog.native_edge(2, 0);
+  EXPECT_DOUBLE_EQ(e_poly.v0.lng, 10);
+  EXPECT_DOUBLE_EQ(e_poly.v0.lat, 10);
+}
+
+TEST_F(GeoArrowGeographyTest, GeometryCollectionOnlyPoints) {
+  auto geog = MakeGeography("GEOMETRYCOLLECTION (POINT (0 0), POINT (1 1))");
+
+  EXPECT_EQ(geog.num_shapes(), 3);
+  EXPECT_EQ(geog.max_dimension(), 0);
+  EXPECT_FALSE(geog.is_empty());
+
+  EXPECT_EQ(geog.Shape(0)->num_edges(), 2);  // points
+  EXPECT_EQ(geog.Shape(1)->num_edges(), 0);  // lines (empty)
+  EXPECT_EQ(geog.Shape(2)->num_edges(), 0);  // polygons (empty)
+}
+
+TEST_F(GeoArrowGeographyTest, GeometryCollectionOnlyLines) {
+  auto geog = MakeGeography("GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1, 2 2))");
+
+  EXPECT_EQ(geog.num_shapes(), 3);
+  EXPECT_EQ(geog.max_dimension(), 1);
+  EXPECT_FALSE(geog.is_empty());
+
+  EXPECT_EQ(geog.Shape(0)->num_edges(), 0);  // points (empty)
+  EXPECT_EQ(geog.Shape(1)->num_edges(), 2);  // lines
+  EXPECT_EQ(geog.Shape(2)->num_edges(), 0);  // polygons (empty)
+}
+
+TEST_F(GeoArrowGeographyTest, GeometryCollectionOnlyPolygons) {
+  auto geog =
+      MakeGeography("GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 0 1, 0 0)))");
+
+  EXPECT_EQ(geog.num_shapes(), 3);
+  EXPECT_EQ(geog.max_dimension(), 2);
+  EXPECT_FALSE(geog.is_empty());
+
+  EXPECT_EQ(geog.Shape(0)->num_edges(), 0);  // points (empty)
+  EXPECT_EQ(geog.Shape(1)->num_edges(), 0);  // lines (empty)
+  EXPECT_EQ(geog.Shape(2)->num_edges(), 3);  // polygons
+}
+
+TEST_F(GeoArrowGeographyTest, GeometryCollectionNestedMulti) {
+  // Test with nested multi-geometries
+  auto geog = MakeGeography(
+      "GEOMETRYCOLLECTION ("
+      "MULTIPOINT ((0 0), (1 1)), "
+      "MULTILINESTRING ((2 2, 3 3), (4 4, 5 5)), "
+      "MULTIPOLYGON (((10 10, 11 10, 10 11, 10 10)), "
+      "((20 20, 21 20, 20 21, 20 20))))");
+
+  EXPECT_EQ(geog.num_shapes(), 3);
+  EXPECT_FALSE(geog.is_empty());
+
+  EXPECT_EQ(geog.Shape(0)->num_edges(), 2);  // 2 points
+  EXPECT_EQ(geog.Shape(1)->num_edges(), 2);  // 2 lines (1 edge each)
+  EXPECT_EQ(geog.Shape(2)->num_edges(), 6);  // 2 triangles (3 edges each)
 }
 
 TEST_F(GeoArrowGeographyTest, RegionNotNull) {

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -583,16 +583,15 @@ class GeoArrowGeom {
   /// linestring) in this set of nodes. Other node types are ignored.
   template <typename Visit>
   bool VisitChains(Visit&& visit) const {
-    return VisitNodes(
-        [&](const struct GeoArrowGeometryNode* node) {
-          switch (node->geometry_type) {
-            case GEOARROW_GEOMETRY_TYPE_POINT:
-            case GEOARROW_GEOMETRY_TYPE_LINESTRING:
-              return visit(GeoArrowChain(node));
-            default:
-              return true;
-          }
-        });
+    return VisitNodes([&](const struct GeoArrowGeometryNode* node) {
+      switch (node->geometry_type) {
+        case GEOARROW_GEOMETRY_TYPE_POINT:
+        case GEOARROW_GEOMETRY_TYPE_LINESTRING:
+          return visit(GeoArrowChain(node));
+        default:
+          return true;
+      }
+    });
   }
 
   /// \brief Visit sequences of coordinates as GeoArrowLoop
@@ -604,17 +603,15 @@ class GeoArrowGeom {
   /// of loops).
   template <typename Visit>
   bool VisitLoops(std::vector<S2Point>* scratch, Visit&& visit) {
-    return VisitNodes(
-        [&](const struct GeoArrowGeometryNode* node) {
-          switch (node->geometry_type) {
-            case GEOARROW_GEOMETRY_TYPE_LINESTRING:
-              return visit(
-                  GeoArrowLoop(node, scratch,
-                               node->flags & internal::kFlagS2GeographyIsHole));
-            default:
-              return true;
-          }
-        });
+    return VisitNodes([&](const struct GeoArrowGeometryNode* node) {
+      switch (node->geometry_type) {
+        case GEOARROW_GEOMETRY_TYPE_LINESTRING:
+          return visit(GeoArrowLoop(
+              node, scratch, node->flags & internal::kFlagS2GeographyIsHole));
+        default:
+          return true;
+      }
+    });
   }
 
   /// \brief Call a function for each vertex in this node set

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -570,14 +570,21 @@ class GeoArrowGeom {
   /// \brief The number of nodes in this sequence
   int64_t size() const { return geom_.size_nodes; }
 
+  template <typename Visit>
+  bool VisitNodes(Visit&& visit) const {
+    return internal::VisitGeoArrowNodes(
+        geom_,
+        [&](const struct GeoArrowGeometryNode* node) { return visit(node); });
+  }
+
   /// \brief Visit sequences of coordinates
   ///
   /// Call a function of GeoArrowChain for each sequence (point or
   /// linestring) in this set of nodes. Other node types are ignored.
   template <typename Visit>
   bool VisitChains(Visit&& visit) const {
-    return internal::VisitGeoArrowNodes(
-        geom_, [&](const struct GeoArrowGeometryNode* node) {
+    return VisitNodes(
+        [&](const struct GeoArrowGeometryNode* node) {
           switch (node->geometry_type) {
             case GEOARROW_GEOMETRY_TYPE_POINT:
             case GEOARROW_GEOMETRY_TYPE_LINESTRING:
@@ -597,8 +604,8 @@ class GeoArrowGeom {
   /// of loops).
   template <typename Visit>
   bool VisitLoops(std::vector<S2Point>* scratch, Visit&& visit) {
-    return internal::VisitGeoArrowNodes(
-        geom_, [&](const struct GeoArrowGeometryNode* node) {
+    return VisitNodes(
+        [&](const struct GeoArrowGeometryNode* node) {
           switch (node->geometry_type) {
             case GEOARROW_GEOMETRY_TYPE_LINESTRING:
               return visit(

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -622,11 +622,13 @@ INSTANTIATE_TEST_SUITE_P(
             "point_intersects_gc_point", "POINT (5 5)", "intersects",
             "GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (10 10, 11 10))",
             true},
-        // Intersects: linestring crosses polygon in GEOMETRYCOLLECTION
+
         ScalarScalarParam{
+            // Intersects: linestring crosses polygon in GEOMETRYCOLLECTION
             "linestring_intersects_gc_polygon", "LINESTRING (0.25 0.25, 3 3)",
             "intersects",
-            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 "
+            "0, 0 2, 0 0)))",
             true},
         // Intersects: GEOMETRYCOLLECTION vs GEOMETRYCOLLECTION (brute force
         // path, both have mixed types)
@@ -651,10 +653,10 @@ INSTANTIATE_TEST_SUITE_P(
             "POLYGON ((0 0, 2 0, 0 2, 0 0)))",
             "contains", "POINT (0.25 0.25)", true},
         // Contains: polygon in GEOMETRYCOLLECTION contains interior linestring
-        ScalarScalarParam{
-            "gc_contains_linestring",
-            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
-            "contains", "LINESTRING (0.25 0.25, 0.5 0.5)", true},
+        ScalarScalarParam{"gc_contains_linestring",
+                          "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 "
+                          "0, 0 2, 0 0)))",
+                          "contains", "LINESTRING (0.25 0.25, 0.5 0.5)", true},
         // Contains: polygon contains GEOMETRYCOLLECTION with point + linestring
         // (exercises SemiBruteForceIndexedContains with mixed containee)
         ScalarScalarParam{
@@ -670,10 +672,11 @@ INSTANTIATE_TEST_SUITE_P(
             false},
         // Contains: GEOMETRYCOLLECTION does not contain polygon that crosses
         // boundary
-        ScalarScalarParam{
-            "gc_not_contains_crossing_polygon",
-            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
-            "contains", "POLYGON ((0.1 0.1, 3 0.1, 0.1 3, 0.1 0.1))", false},
+        ScalarScalarParam{"gc_not_contains_crossing_polygon",
+                          "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 "
+                          "0, 0 2, 0 0)))",
+                          "contains",
+                          "POLYGON ((0.1 0.1, 3 0.1, 0.1 3, 0.1 0.1))", false},
 
         // Equals: GEOMETRYCOLLECTION equals itself (identity fast path)
         ScalarScalarParam{

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -606,7 +606,89 @@ INSTANTIATE_TEST_SUITE_P(
         // Different number of edges
         ScalarScalarParam{"polygon_not_equals_edges_ne",
                           "POLYGON ((0 0, 1 0, 0 1, 0 0))", "equals",
-                          "POLYGON ((0 0, 2 0, 0 2, 0 1, 0 0))", false}
+                          "POLYGON ((0 0, 2 0, 0 2, 0 1, 0 0))", false},
+
+        // GEOMETRYCOLLECTION tests
+        // Intersects: GEOMETRYCOLLECTION with mixed types (point + linestring +
+        // polygon) vs point inside. Exercises brute force handling of all
+        // geometry types.
+        ScalarScalarParam{
+            "gc_intersects_point",
+            "GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (0 0, 1 0), "
+            "POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            "intersects", "POINT (0.25 0.25)", true},
+        // Intersects: point in GEOMETRYCOLLECTION matches standalone point
+        ScalarScalarParam{
+            "point_intersects_gc_point", "POINT (5 5)", "intersects",
+            "GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (10 10, 11 10))",
+            true},
+        // Intersects: linestring crosses polygon in GEOMETRYCOLLECTION
+        ScalarScalarParam{
+            "linestring_intersects_gc_polygon", "LINESTRING (0.25 0.25, 3 3)",
+            "intersects",
+            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            true},
+        // Intersects: GEOMETRYCOLLECTION vs GEOMETRYCOLLECTION (brute force
+        // path, both have mixed types)
+        ScalarScalarParam{
+            "gc_intersects_gc",
+            "GEOMETRYCOLLECTION (POINT (0.5 0.5), LINESTRING (0 0, 1 0))",
+            "intersects",
+            "GEOMETRYCOLLECTION (POINT (30 30), LINESTRING (0 0, 0 1))", true},
+        // Intersects: disjoint GEOMETRYCOLLECTIONs
+        ScalarScalarParam{
+            "gc_not_intersects_gc",
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (1 1, 2 2))",
+            "intersects",
+            "GEOMETRYCOLLECTION (POINT (30 30), LINESTRING (40 40, 41 41))",
+            false},
+
+        // Contains: polygon in GEOMETRYCOLLECTION contains point (exercises
+        // brute force with dimension() == 2 from the polygon component)
+        ScalarScalarParam{
+            "gc_contains_point",
+            "GEOMETRYCOLLECTION (POINT (30 30), LINESTRING (40 40, 41 40), "
+            "POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            "contains", "POINT (0.25 0.25)", true},
+        // Contains: polygon in GEOMETRYCOLLECTION contains interior linestring
+        ScalarScalarParam{
+            "gc_contains_linestring",
+            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            "contains", "LINESTRING (0.25 0.25, 0.5 0.5)", true},
+        // Contains: polygon contains GEOMETRYCOLLECTION with point + linestring
+        // (exercises SemiBruteForceIndexedContains with mixed containee)
+        ScalarScalarParam{
+            "polygon_contains_gc", "POLYGON ((0 0, 2 0, 0 2, 0 0))", "contains",
+            "GEOMETRYCOLLECTION (POINT (0.25 0.25), LINESTRING (0.3 0.3, 0.4 "
+            "0.4))",
+            true},
+        // Contains: polygon does not contain GEOMETRYCOLLECTION (point outside)
+        ScalarScalarParam{
+            "polygon_not_contains_gc_point_outside",
+            "POLYGON ((0 0, 2 0, 0 2, 0 0))", "contains",
+            "GEOMETRYCOLLECTION (POINT (30 30), LINESTRING (0.3 0.3, 0.4 0.4))",
+            false},
+        // Contains: GEOMETRYCOLLECTION does not contain polygon that crosses
+        // boundary
+        ScalarScalarParam{
+            "gc_not_contains_crossing_polygon",
+            "GEOMETRYCOLLECTION (POINT (30 30), POLYGON ((0 0, 2 0, 0 2, 0 0)))",
+            "contains", "POLYGON ((0.1 0.1, 3 0.1, 0.1 3, 0.1 0.1))", false},
+
+        // Equals: GEOMETRYCOLLECTION equals itself (identity fast path)
+        ScalarScalarParam{
+            "gc_equals_gc_identical",
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (1 1, 2 2))", "equals",
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (1 1, 2 2))", true},
+        // Equals: different GEOMETRYCOLLECTIONs
+        ScalarScalarParam{
+            "gc_not_equals_gc",
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (1 1, 2 2))", "equals",
+            "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (1 1, 3 3))", false},
+        // Equals: GEOMETRYCOLLECTION vs simple geometry
+        ScalarScalarParam{"gc_not_equals_point",
+                          "GEOMETRYCOLLECTION (POINT (0 0))", "equals",
+                          "POINT (0 0)", true}
 
         ),
     [](const ::testing::TestParamInfo<ScalarScalarParam>& info) {


### PR DESCRIPTION
This PR allows GEOMETRYCOLLECTION to initialize a GeoArrowGeography. This support was mostly there already but the "set" step wasn't implemented.