### PR TITLE
chore: Reduce memory usage of single-geometry type GeoArrowGeography instances

### DIFF
--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -260,6 +260,15 @@ S2GeogErrorCode S2GeogForcePrepare(struct S2Geog* geog,
   S2GEOGRAPHY_C_END(err);
 }
 
+size_t S2GeogMemUsed(struct S2Geog* geog) {
+  S2GEOGRAPHY_DCHECK(geog != nullptr);
+  size_t mem = 0;
+  mem += geog->geog.MemUsed();
+  mem += sizeof(struct GeoArrowGeometry);
+  mem += geog->geom.capacity_nodes * sizeof(struct GeoArrowGeometryNode);
+  return mem;
+}
+
 void S2GeogDestroy(struct S2Geog* geog) {
   S2GEOGRAPHY_DCHECK(geog != nullptr);
   delete geog;

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -87,6 +87,37 @@ TEST(S2GeographyC, GeogCreate) {
   S2GeogDestroy(geog);
 }
 
+TEST(S2GeographyC, MemUsed) {
+  const char* wkt_point = "POINT (0 0)";
+
+  struct S2GeogFactory* factory = nullptr;
+  ASSERT_EQ(S2GeogFactoryCreate(&factory), S2GEOGRAPHY_OK);
+
+  struct S2Geog* geog = nullptr;
+  ASSERT_EQ(S2GeogCreate(&geog), S2GEOGRAPHY_OK);
+
+  // MemUsed should return something reasonable for an empty geography
+  size_t mem_empty = S2GeogMemUsed(geog);
+  EXPECT_GT(mem_empty, 0);
+
+  // Initialize with a point
+  ASSERT_EQ(S2GeogFactoryInitFromWkt(factory, wkt_point, strlen(wkt_point),
+                                     geog, nullptr),
+            S2GEOGRAPHY_OK);
+
+  // MemUsed should return something reasonable for a point
+  size_t mem_point = S2GeogMemUsed(geog);
+  EXPECT_GT(mem_point, 0);
+
+  // After forcing the index to build, memory should increase
+  ASSERT_EQ(S2GeogForcePrepare(geog, nullptr), S2GEOGRAPHY_OK);
+  size_t mem_prepared = S2GeogMemUsed(geog);
+  EXPECT_GT(mem_prepared, mem_point);
+
+  S2GeogDestroy(geog);
+  S2GeogFactoryDestroy(factory);
+}
+
 // ============================================================================
 // Geography Factory Tests
 // ============================================================================

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -671,10 +671,12 @@ uint8_t GeoArrowGeography::dimensions() const {
       return points_.dimensions();
     case GEOARROW_GEOMETRY_TYPE_LINESTRING:
     case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
-      return lines_ ? lines_->dimensions() : GEOARROW_DIMENSIONS_XY;
+      return lines_ ? lines_->dimensions()
+                    : static_cast<uint8_t>(GEOARROW_DIMENSIONS_XY);
     case GEOARROW_GEOMETRY_TYPE_POLYGON:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
-      return polygons_ ? polygons_->dimensions() : GEOARROW_DIMENSIONS_XY;
+      return polygons_ ? polygons_->dimensions()
+                       : static_cast<uint8_t>(GEOARROW_DIMENSIONS_XY);
     default:
       return geom_.root->dimensions;
   }

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -795,7 +795,8 @@ std::unique_ptr<S2Region> GeoArrowGeography::Region() const {
   }
 
   InitIndex();
-  return std::make_unique<S2ShapeIndexRegion<MutableS2ShapeIndex>>(index_.get());
+  return std::make_unique<S2ShapeIndexRegion<MutableS2ShapeIndex>>(
+      index_.get());
 }
 
 void GeoArrowGeography::InitIndex() const {

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -442,11 +442,12 @@ GeoArrowGeography::GeoArrowGeography(GeoArrowGeography&& other)
       lines_(std::move(other.lines_)),
       polygons_(std::move(other.polygons_)),
       collection_nodes_(std::move(other.collection_nodes_)),
-      index_(),
+      index_(std::move(other.index_)),
       covering_(std::move(other.covering_)) {
-  // index_ needs to be rebuilt
-  index_.Clear();
-  indexed_.store(false, std::memory_order_relaxed);
+  // Reset other's indexed_ flag since we took ownership of its index
+  other.indexed_.store(false, std::memory_order_relaxed);
+  indexed_.store(other.indexed_.load(std::memory_order_relaxed),
+                 std::memory_order_relaxed);
 }
 
 GeoArrowGeography& GeoArrowGeography::operator=(GeoArrowGeography&& other) {
@@ -456,24 +457,27 @@ GeoArrowGeography& GeoArrowGeography::operator=(GeoArrowGeography&& other) {
     lines_ = std::move(other.lines_);
     polygons_ = std::move(other.polygons_);
     collection_nodes_ = std::move(other.collection_nodes_);
+    index_ = std::move(other.index_);
     covering_ = std::move(other.covering_);
-    // index_ needs to be rebuilt
-    index_.Clear();
-    indexed_.store(false, std::memory_order_relaxed);
+    indexed_.store(other.indexed_.load(std::memory_order_relaxed),
+                   std::memory_order_relaxed);
+    other.indexed_.store(false, std::memory_order_relaxed);
   }
   return *this;
 }
 
 void GeoArrowGeography::Init(struct GeoArrowGeometryView geom) {
   InitOriented(geom);
-  polygons_.NormalizeOrientation();
+  if (polygons_) {
+    polygons_->NormalizeOrientation();
+  }
 }
 
 void GeoArrowGeography::InitOriented(struct GeoArrowGeometryView geom) {
   points_.Clear();
-  lines_.Clear();
-  polygons_.Clear();
-  index_.Clear();
+  if (lines_) lines_->Clear();
+  if (polygons_) polygons_->Clear();
+  if (index_) index_->Clear();
   covering_.clear();
   indexed_.store(false, std::memory_order_relaxed);
   geom_ = geom;
@@ -490,12 +494,14 @@ void GeoArrowGeography::InitOriented(struct GeoArrowGeometryView geom) {
 
     case GEOARROW_GEOMETRY_TYPE_LINESTRING:
     case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
-      lines_.Init(geom);
+      if (!lines_) lines_ = std::make_unique<GeoArrowLaxPolylineShape>();
+      lines_->Init(geom);
       break;
 
     case GEOARROW_GEOMETRY_TYPE_POLYGON:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
-      polygons_.Init(geom);
+      if (!polygons_) polygons_ = std::make_unique<GeoArrowLaxPolygonShape>();
+      polygons_->Init(geom);
       break;
 
     case GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION: {
@@ -566,11 +572,13 @@ void GeoArrowGeography::InitOriented(struct GeoArrowGeometryView geom) {
       points_.Init(
           {collection_nodes_.data(), static_cast<int64_t>(points.size() + 1)});
       int64_t offset = static_cast<int64_t>(points.size() + 1);
-      lines_.Init({collection_nodes_.data() + offset,
-                   static_cast<int64_t>(lines.size() + 1)});
+      if (!lines_) lines_ = std::make_unique<GeoArrowLaxPolylineShape>();
+      lines_->Init({collection_nodes_.data() + offset,
+                    static_cast<int64_t>(lines.size() + 1)});
       offset += static_cast<int64_t>(lines.size() + 1);
-      polygons_.Init({collection_nodes_.data() + offset,
-                      static_cast<int64_t>(polygons.size() + 1)});
+      if (!polygons_) polygons_ = std::make_unique<GeoArrowLaxPolygonShape>();
+      polygons_->Init({collection_nodes_.data() + offset,
+                       static_cast<int64_t>(polygons.size() + 1)});
       break;
     }
 
@@ -588,7 +596,15 @@ const std::vector<S2CellId>& GeoArrowGeography::Covering() const {
 
 const S2ShapeIndex& GeoArrowGeography::ShapeIndex() const {
   InitIndex();
-  return index_;
+  // For empty geometries, InitIndex() may not create an index, but we still
+  // need to return a valid reference. Lazily create an empty index.
+  if (!index_) {
+    std::lock_guard<std::mutex> lock(index_mutex_);
+    if (!index_) {
+      index_ = std::make_unique<MutableS2ShapeIndex>();
+    }
+  }
+  return *index_;
 }
 
 bool GeoArrowGeography::is_empty() const {
@@ -602,10 +618,10 @@ bool GeoArrowGeography::is_empty() const {
       return points_.is_empty();
     case GEOARROW_GEOMETRY_TYPE_LINESTRING:
     case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
-      return lines_.is_empty();
+      return !lines_ || lines_->is_empty();
     case GEOARROW_GEOMETRY_TYPE_POLYGON:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
-      return polygons_.is_empty();
+      return !polygons_ || polygons_->is_empty();
     default:
       for (int i = 0; i < num_shapes(); ++i) {
         if (!Shape(i)->is_empty()) {
@@ -655,10 +671,10 @@ uint8_t GeoArrowGeography::dimensions() const {
       return points_.dimensions();
     case GEOARROW_GEOMETRY_TYPE_LINESTRING:
     case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
-      return lines_.dimensions();
+      return lines_ ? lines_->dimensions() : GEOARROW_DIMENSIONS_XY;
     case GEOARROW_GEOMETRY_TYPE_POLYGON:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
-      return polygons_.dimensions();
+      return polygons_ ? polygons_->dimensions() : GEOARROW_DIMENSIONS_XY;
     default:
       return geom_.root->dimensions;
   }
@@ -685,11 +701,11 @@ int GeoArrowGeography::dimension() const {
 }
 
 int GeoArrowGeography::max_dimension() const {
-  if (!polygons_.is_empty()) {
+  if (polygons_ && !polygons_->is_empty()) {
     return 2;
   }
 
-  if (!lines_.is_empty()) {
+  if (lines_ && !lines_->is_empty()) {
     return 1;
   }
 
@@ -703,15 +719,22 @@ int GeoArrowGeography::max_dimension() const {
 }
 
 int GeoArrowGeography::num_edges() const {
-  return points_.num_edges() + lines_.num_edges() + polygons_.num_edges();
+  int edges = points_.num_edges();
+  if (lines_) edges += lines_->num_edges();
+  if (polygons_) edges += polygons_->num_edges();
+  return edges;
 }
+
+// Static empty shapes for returning from accessors when shapes aren't allocated
+static const GeoArrowLaxPolylineShape kEmptyPolylineShape;
+static const GeoArrowLaxPolygonShape kEmptyPolygonShape;
 
 const GeoArrowPointShape* GeoArrowGeography::points() const { return &points_; }
 const GeoArrowLaxPolylineShape* GeoArrowGeography::lines() const {
-  return &lines_;
+  return lines_ ? lines_.get() : &kEmptyPolylineShape;
 }
 const GeoArrowLaxPolygonShape* GeoArrowGeography::polygons() const {
-  return &polygons_;
+  return polygons_ ? polygons_.get() : &kEmptyPolygonShape;
 }
 
 int GeoArrowGeography::num_shapes() const {
@@ -743,20 +766,20 @@ const S2Shape* GeoArrowGeography::Shape(int id) const {
 
     case GEOARROW_GEOMETRY_TYPE_LINESTRING:
     case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
-      return &lines_;
+      return lines_.get();
 
     case GEOARROW_GEOMETRY_TYPE_POLYGON:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
-      return &polygons_;
+      return polygons_.get();
 
     case GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION:
       switch (id) {
         case 0:
           return &points_;
         case 1:
-          return &lines_;
+          return lines_.get();
         case 2:
-          return &polygons_;
+          return polygons_.get();
         default:
           throw Exception("GeometryCollection shape ids must be 0, 1, or 2");
       }
@@ -772,7 +795,7 @@ std::unique_ptr<S2Region> GeoArrowGeography::Region() const {
   }
 
   InitIndex();
-  return std::make_unique<S2ShapeIndexRegion<MutableS2ShapeIndex>>(&index_);
+  return std::make_unique<S2ShapeIndexRegion<MutableS2ShapeIndex>>(index_.get());
 }
 
 void GeoArrowGeography::InitIndex() const {
@@ -789,23 +812,28 @@ void GeoArrowGeography::InitIndex() const {
     return;
   }
 
+  // Lazily allocate the index
+  if (!index_) {
+    index_ = std::make_unique<MutableS2ShapeIndex>();
+  }
+
   switch (geom_.root->geometry_type) {
     case GEOARROW_GEOMETRY_TYPE_POINT:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
-      index_.Add(std::make_unique<S2ShapeWrapper>(&points_));
+      index_->Add(std::make_unique<S2ShapeWrapper>(&points_));
       break;
     case GEOARROW_GEOMETRY_TYPE_LINESTRING:
     case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
-      index_.Add(std::make_unique<S2ShapeWrapper>(&lines_));
+      index_->Add(std::make_unique<S2ShapeWrapper>(lines_.get()));
       break;
     case GEOARROW_GEOMETRY_TYPE_POLYGON:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
-      index_.Add(std::make_unique<S2ShapeWrapper>(&polygons_));
+      index_->Add(std::make_unique<S2ShapeWrapper>(polygons_.get()));
       break;
     case GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION:
-      index_.Add(std::make_unique<S2ShapeWrapper>(&points_));
-      index_.Add(std::make_unique<S2ShapeWrapper>(&lines_));
-      index_.Add(std::make_unique<S2ShapeWrapper>(&polygons_));
+      index_->Add(std::make_unique<S2ShapeWrapper>(&points_));
+      index_->Add(std::make_unique<S2ShapeWrapper>(lines_.get()));
+      index_->Add(std::make_unique<S2ShapeWrapper>(polygons_.get()));
       break;
     default:
       throw Exception(
@@ -829,7 +857,7 @@ void GeoArrowGeography::InitIndex() const {
         [[fallthrough]];
       default: {
         S2RegionCoverer coverer;
-        S2ShapeIndexRegion<MutableS2ShapeIndex> region(&index_);
+        S2ShapeIndexRegion<MutableS2ShapeIndex> region(index_.get());
         coverer.GetFastCovering(region, &covering_);
         break;
       }
@@ -864,11 +892,12 @@ std::pair<int, int> GeoArrowGeography::ResolveGlobalEdgeId(
   }
 
   global_edge_id -= points_.num_edges();
-  if (global_edge_id < lines_.num_edges()) {
+  int lines_num_edges = lines_ ? lines_->num_edges() : 0;
+  if (global_edge_id < lines_num_edges) {
     return std::make_pair(1, global_edge_id);
   }
 
-  global_edge_id -= lines_.num_edges();
+  global_edge_id -= lines_num_edges;
   return std::make_pair(2, global_edge_id);
 }
 
@@ -881,18 +910,18 @@ internal::GeoArrowEdge GeoArrowGeography::native_edge(int shape_id,
       return points_.native_edge(edge_id);
     case GEOARROW_GEOMETRY_TYPE_LINESTRING:
     case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
-      return lines_.native_edge(edge_id);
+      return lines_->native_edge(edge_id);
     case GEOARROW_GEOMETRY_TYPE_POLYGON:
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
-      return polygons_.native_edge(edge_id);
+      return polygons_->native_edge(edge_id);
     case GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION:
       switch (shape_id) {
         case 0:
           return points_.native_edge(edge_id);
         case 1:
-          return lines_.native_edge(edge_id);
+          return lines_->native_edge(edge_id);
         case 2:
-          return polygons_.native_edge(edge_id);
+          return polygons_->native_edge(edge_id);
         default:
           throw Exception("shape index out of bounds");
       }

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -89,6 +89,9 @@ class GeoArrowPointShape : public S2Shape {
   /// \brief Extract a native edge within a chain
   internal::GeoArrowEdge native_chain_edge(int i, int j) const;
 
+  /// \brief Return the extra memory used by this instance beyond size_of()
+  size_t MemUsed() { return 0; }
+
  private:
   GeoArrowGeom geom_;
   uint8_t dimensions_{GEOARROW_DIMENSIONS_XY};
@@ -147,6 +150,9 @@ class GeoArrowLaxPolylineShape : public S2Shape {
 
   /// \brief Extract a native edge within a chain
   internal::GeoArrowEdge native_chain_edge(int i, int j) const;
+
+  /// \brief Return the extra memory used by this instance beyond size_of()
+  size_t MemUsed() { return num_edges_.capacity() * sizeof(int); }
 
  private:
   GeoArrowGeom geom_{};
@@ -251,6 +257,13 @@ class GeoArrowLaxPolygonShape : public S2Shape {
   /// orientation is only used to obtain the reference point).
   bool BruteForceContains(const S2Point& pt,
                           const S2Shape::ReferencePoint& reference) const;
+
+  /// \brief Return the extra memory used by this instance beyond size_of()
+  size_t MemUsed() {
+    return num_edges_.capacity() * sizeof(int) +
+           loops_.capacity() * sizeof(struct GeoArrowGeometryNode) +
+           point_scratch_.capacity() * sizeof(struct GeoArrowGeometryNode);
+  }
 
  private:
   GeoArrowGeom geom_{};
@@ -462,6 +475,14 @@ class GeoArrowGeography {
   /// This is useful to reconstruct ZM information after querying a shape index
   /// for an edge.
   internal::GeoArrowEdge native_edge(int shape_id, int edge_id) const;
+
+  /// \brief Return the memory used by this instance
+  size_t MemUsed() {
+    return sizeof(GeoArrowGeography) + points_.MemUsed() + lines_.MemUsed() +
+           polygons_.MemUsed() +
+           collection_nodes_.capacity() * sizeof(struct GeoArrowGeometryNode) +
+           covering_.capacity() * sizeof(S2CellId) + index_.SpaceUsed();
+  }
 
  private:
   struct GeoArrowGeometryView geom_{};

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -6,6 +6,7 @@
 #include <s2/s2shape_index.h>
 
 #include <atomic>
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -335,7 +336,7 @@ class GeoArrowGeography {
   /// \brief Return true if the internal index has not yet been built
   bool is_unindexed() const {
     if (indexed_.load(std::memory_order_acquire)) {
-      return !index_.is_fresh();
+      return !index_ || !index_->is_fresh();
     } else {
       return true;
     }
@@ -344,7 +345,7 @@ class GeoArrowGeography {
   /// \brief Force building the internal index
   void ForceBuildIndex() {
     InitIndex();
-    index_.ForceBuild();
+    if (index_) index_->ForceBuild();
   }
 
   /// \brief If this geography represents a single point, compute and return it
@@ -478,19 +479,22 @@ class GeoArrowGeography {
 
   /// \brief Return the memory used by this instance
   size_t MemUsed() {
-    return sizeof(GeoArrowGeography) + points_.MemUsed() + lines_.MemUsed() +
-           polygons_.MemUsed() +
-           collection_nodes_.capacity() * sizeof(struct GeoArrowGeometryNode) +
-           covering_.capacity() * sizeof(S2CellId) + index_.SpaceUsed();
+    size_t mem = sizeof(GeoArrowGeography) + points_.MemUsed();
+    if (lines_) mem += sizeof(GeoArrowLaxPolylineShape) + lines_->MemUsed();
+    if (polygons_) mem += sizeof(GeoArrowLaxPolygonShape) + polygons_->MemUsed();
+    mem += collection_nodes_.capacity() * sizeof(struct GeoArrowGeometryNode);
+    mem += covering_.capacity() * sizeof(S2CellId);
+    if (index_) mem += index_->SpaceUsed();
+    return mem;
   }
 
  private:
   struct GeoArrowGeometryView geom_{};
   GeoArrowPointShape points_;
-  GeoArrowLaxPolylineShape lines_;
-  GeoArrowLaxPolygonShape polygons_;
+  std::unique_ptr<GeoArrowLaxPolylineShape> lines_;
+  std::unique_ptr<GeoArrowLaxPolygonShape> polygons_;
   std::vector<struct GeoArrowGeometryNode> collection_nodes_;
-  mutable MutableS2ShapeIndex index_;
+  mutable std::unique_ptr<MutableS2ShapeIndex> index_;
   mutable std::vector<S2CellId> covering_;
   mutable std::mutex index_mutex_;
   mutable std::atomic<bool> indexed_{false};

--- a/src/s2geography/geoarrow-geography.h
+++ b/src/s2geography/geoarrow-geography.h
@@ -481,7 +481,8 @@ class GeoArrowGeography {
   size_t MemUsed() {
     size_t mem = sizeof(GeoArrowGeography) + points_.MemUsed();
     if (lines_) mem += sizeof(GeoArrowLaxPolylineShape) + lines_->MemUsed();
-    if (polygons_) mem += sizeof(GeoArrowLaxPolygonShape) + polygons_->MemUsed();
+    if (polygons_)
+      mem += sizeof(GeoArrowLaxPolygonShape) + polygons_->MemUsed();
     mem += collection_nodes_.capacity() * sizeof(struct GeoArrowGeometryNode);
     mem += covering_.capacity() * sizeof(S2CellId);
     if (index_) mem += index_->SpaceUsed();

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -1314,6 +1314,13 @@ TEST_F(GeoArrowGeographyTest, Point) {
   EXPECT_GE(geog.ShapeIndex().num_shape_ids(), 1);
 }
 
+TEST_F(GeoArrowGeographyTest, PointMemUsed) {
+  auto geog = MakeGeography("POINT (1 2)");
+  EXPECT_EQ(geog.MemUsed(), 560);
+  geog.ForceBuildIndex();
+  EXPECT_EQ(geog.MemUsed(), 640);
+}
+
 TEST_F(GeoArrowGeographyTest, MultiPoint) {
   auto geog = MakeGeography("MULTIPOINT ((0 0), (1 1), (2 2))");
   EXPECT_EQ(geog.dimension(), 0);
@@ -1375,6 +1382,13 @@ TEST_F(GeoArrowGeographyTest, Linestring) {
   EXPECT_EQ(geog.ResolveGlobalEdgeId(0), std::make_pair(0, 0));
 }
 
+TEST_F(GeoArrowGeographyTest, LinestringMemUsed) {
+  auto geog = MakeGeography("LINESTRING (0 0, 1 1, 2 2)");
+  EXPECT_EQ(geog.MemUsed(), 564);
+  geog.ForceBuildIndex();
+  EXPECT_EQ(geog.MemUsed(), 684);
+}
+
 TEST_F(GeoArrowGeographyTest, LinestringNativeEdge) {
   auto geog =
       MakeGeography("LINESTRING ZM (0 1 100 200, 2 3 101 201, 4 5 103 203)");
@@ -1424,6 +1438,13 @@ TEST_F(GeoArrowGeographyTest, Polygon) {
   EXPECT_EQ(shape->num_edges(), 3);
 
   EXPECT_EQ(geog.ResolveGlobalEdgeId(0), std::make_pair(0, 0));
+}
+
+TEST_F(GeoArrowGeographyTest, PolygonMemUsed) {
+  auto geog = MakeGeography("POLYGON ((0 0, 1 0, 0 1, 0 0))");
+  EXPECT_EQ(geog.MemUsed(), 884);
+  geog.ForceBuildIndex();
+  EXPECT_EQ(geog.MemUsed(), 1016);
 }
 
 TEST_F(GeoArrowGeographyTest, PolygonNativeEdge) {

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -1442,7 +1442,7 @@ TEST_F(GeoArrowGeographyTest, Polygon) {
 
 TEST_F(GeoArrowGeographyTest, PolygonMemUsed) {
   auto geog = MakeGeography("POLYGON ((0 0, 1 0, 0 1, 0 0))");
-  EXPECT_GE(geog.MemUsed(), 600);
+  EXPECT_GE(geog.MemUsed(), 550);
   geog.ForceBuildIndex();
   EXPECT_GE(geog.MemUsed(), 800);
 }

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -1316,9 +1316,9 @@ TEST_F(GeoArrowGeographyTest, Point) {
 
 TEST_F(GeoArrowGeographyTest, PointMemUsed) {
   auto geog = MakeGeography("POINT (1 2)");
-  EXPECT_EQ(geog.MemUsed(), 192);
+  EXPECT_GE(geog.MemUsed(), 150);
   geog.ForceBuildIndex();
-  EXPECT_EQ(geog.MemUsed(), 376);
+  EXPECT_GE(geog.MemUsed(), 300);
 }
 
 TEST_F(GeoArrowGeographyTest, MultiPoint) {
@@ -1384,9 +1384,9 @@ TEST_F(GeoArrowGeographyTest, Linestring) {
 
 TEST_F(GeoArrowGeographyTest, LinestringMemUsed) {
   auto geog = MakeGeography("LINESTRING (0 0, 1 1, 2 2)");
-  EXPECT_EQ(geog.MemUsed(), 264);
+  EXPECT_GE(geog.MemUsed(), 200);
   geog.ForceBuildIndex();
-  EXPECT_EQ(geog.MemUsed(), 488);
+  EXPECT_GE(geog.MemUsed(), 400);
 }
 
 TEST_F(GeoArrowGeographyTest, LinestringNativeEdge) {
@@ -1442,9 +1442,9 @@ TEST_F(GeoArrowGeographyTest, Polygon) {
 
 TEST_F(GeoArrowGeographyTest, PolygonMemUsed) {
   auto geog = MakeGeography("POLYGON ((0 0, 1 0, 0 1, 0 0))");
-  EXPECT_EQ(geog.MemUsed(), 632);
+  EXPECT_GE(geog.MemUsed(), 600);
   geog.ForceBuildIndex();
-  EXPECT_EQ(geog.MemUsed(), 868);
+  EXPECT_GE(geog.MemUsed(), 800);
 }
 
 TEST_F(GeoArrowGeographyTest, PolygonNativeEdge) {

--- a/src/s2geography/geoarrow-geography_test.cc
+++ b/src/s2geography/geoarrow-geography_test.cc
@@ -1316,9 +1316,9 @@ TEST_F(GeoArrowGeographyTest, Point) {
 
 TEST_F(GeoArrowGeographyTest, PointMemUsed) {
   auto geog = MakeGeography("POINT (1 2)");
-  EXPECT_EQ(geog.MemUsed(), 560);
+  EXPECT_EQ(geog.MemUsed(), 192);
   geog.ForceBuildIndex();
-  EXPECT_EQ(geog.MemUsed(), 640);
+  EXPECT_EQ(geog.MemUsed(), 376);
 }
 
 TEST_F(GeoArrowGeographyTest, MultiPoint) {
@@ -1384,9 +1384,9 @@ TEST_F(GeoArrowGeographyTest, Linestring) {
 
 TEST_F(GeoArrowGeographyTest, LinestringMemUsed) {
   auto geog = MakeGeography("LINESTRING (0 0, 1 1, 2 2)");
-  EXPECT_EQ(geog.MemUsed(), 564);
+  EXPECT_EQ(geog.MemUsed(), 264);
   geog.ForceBuildIndex();
-  EXPECT_EQ(geog.MemUsed(), 684);
+  EXPECT_EQ(geog.MemUsed(), 488);
 }
 
 TEST_F(GeoArrowGeographyTest, LinestringNativeEdge) {
@@ -1442,9 +1442,9 @@ TEST_F(GeoArrowGeographyTest, Polygon) {
 
 TEST_F(GeoArrowGeographyTest, PolygonMemUsed) {
   auto geog = MakeGeography("POLYGON ((0 0, 1 0, 0 1, 0 0))");
-  EXPECT_EQ(geog.MemUsed(), 884);
+  EXPECT_EQ(geog.MemUsed(), 632);
   geog.ForceBuildIndex();
-  EXPECT_EQ(geog.MemUsed(), 1016);
+  EXPECT_EQ(geog.MemUsed(), 868);
 }
 
 TEST_F(GeoArrowGeographyTest, PolygonNativeEdge) {

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -111,6 +111,14 @@ S2GeogErrorCode S2GeogCreate(struct S2Geog** geog);
 S2GeogErrorCode S2GeogForcePrepare(struct S2Geog* geog,
                                    struct S2GeogError* err);
 
+/// \brief Return the memory used by a geography object
+///
+/// This returns the total memory footprint including sizeof(S2Geog), internal
+/// shape allocations, index memory, and owned coordinate buffers.
+///
+/// \pre geog != NULL
+size_t S2GeogMemUsed(struct S2Geog* geog);
+
 /// \brief Destroy a geography object
 ///
 /// \pre geog != NULL


### PR DESCRIPTION
This PR reduces the size used for the GeoArrowGeography, which had grown quite large. It's still non-trivial (192 bytes for a point compared to 21 bytes of actual data) and fine for UDFs (where we effectively reuse the memory between iterations of a loop), but for other situations we do sometimes need a whole bunch of owning instances. For comparison, a GEOS Point has about 128 bytes of overhead above and beyond the actual coordinates.