### PR TITLE
feat: Add ExpandByDistance to rect bounder

### DIFF
--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -413,6 +413,12 @@ S2GeogErrorCode S2GeogRectBounderBound(struct S2GeogRectBounder* rect_bounder,
   S2GEOGRAPHY_C_END(err);
 }
 
+void S2GeogRectBounderExpandByDistance(struct S2GeogRectBounder* rect_bounder,
+                                       double distance_meters) {
+  S2GEOGRAPHY_DCHECK(rect_bounder != nullptr);
+  rect_bounder->bounder.ExpandByDistance(distance_meters);
+}
+
 uint8_t S2GeogRectBounderIsEmpty(struct S2GeogRectBounder* rect_bounder) {
   S2GEOGRAPHY_DCHECK(rect_bounder != nullptr);
   return rect_bounder->bounder.is_empty();

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -259,6 +259,16 @@ TEST(S2GeographyC, RectBounderBound) {
   S2GeogRectBounderClear(bounder);
   EXPECT_EQ(S2GeogRectBounderIsEmpty(bounder), 1);
 
+  // Test ExpandByDistance
+  S2GeogRectBounderBound(bounder, geog, err);
+  S2GeogRectBounderExpandByDistance(bounder, 1000.0);  // 1km
+  EXPECT_EQ(S2GeogRectBounderFinish(bounder, &lo, &hi, err), S2GEOGRAPHY_OK);
+  // After expanding by 1km (~0.009 degrees at equator), bounds should be larger
+  EXPECT_LT(lo.v[0], 10 - 0.008);
+  EXPECT_GT(hi.v[0], 10 + 0.008);
+  EXPECT_LT(lo.v[1], 20 - 0.008);
+  EXPECT_GT(hi.v[1], 20 + 0.008);
+
   S2GeogRectBounderDestroy(bounder);
   S2GeogErrorDestroy(err);
   S2GeogDestroy(geog);

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -1,6 +1,7 @@
 
 #include "s2geography/coverings.h"
 
+#include <s2/s2earth.h>
 #include <s2/s2edge_crosser.h>
 #include <s2/s2latlng_rect_bounder.h>
 #include <s2/s2region_coverer.h>
@@ -120,6 +121,12 @@ S2LatLngRect LatLngRectBounder::BoundPoints(const GeoArrowGeography& value) {
   S2LatLng lo(S1Angle::Radians(ys.lo()), S1Angle::Radians(xs.lo()));
   S2LatLng hi(S1Angle::Radians(ys.hi()), S1Angle::Radians(xs.hi()));
   return S2LatLngRect(lo, hi);
+}
+
+void LatLngRectBounder::ExpandByDistance(double distance_meters) {
+  S1Angle distance =
+      S1Angle::Radians(distance_meters / S2Earth::RadiusMeters());
+  bounds_ = bounds_.ExpandedByDistance(distance);
 }
 
 S2LatLngRect LatLngRectBounder::BoundLines(const GeoArrowGeography& value) {

--- a/src/s2geography/coverings.h
+++ b/src/s2geography/coverings.h
@@ -15,6 +15,7 @@ class LatLngRectBounder {
   void Clear();
   S2LatLngRect Finish() const;
   void Update(const GeoArrowGeography& value);
+  void ExpandByDistance(double distance_meters);
   bool is_empty() const { return bounds_.is_empty(); }
 
  private:

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -169,6 +169,27 @@ TEST(LatLngRectBounderTest, AccumulatesBounds) {
   EXPECT_DOUBLE_EQ(bounds.lat_hi().degrees(), 20.0);
 }
 
+// Test that ExpandByDistance expands bounds for a point
+TEST(LatLngRectBounderTest, ExpandByDistancePoint) {
+  auto test_geom = TestGeometry::FromWKT("POINT (0 0)");
+  GeoArrowGeography geog;
+  geog.Init(test_geom.geom());
+
+  LatLngRectBounder bounder;
+  bounder.Clear();
+  bounder.Update(geog);
+
+  // Expand by 1000 meters (~0.009 degrees at equator)
+  bounder.ExpandByDistance(1000.0);
+  S2LatLngRect bounds = bounder.Finish();
+
+  // After expansion, bounds should be larger than the original point bounds
+  EXPECT_LT(bounds.lat_lo().degrees(), -0.008);
+  EXPECT_GT(bounds.lat_hi().degrees(), 0.008);
+  EXPECT_LT(bounds.lng_lo().degrees(), -0.008);
+  EXPECT_GT(bounds.lng_hi().degrees(), 0.008);
+}
+
 TEST(Coverings, SedonaUdfCellIdFromPointArray) {
   struct SedonaCScalarKernel kernel;
   s2geography::sedona_udf::CellIdFromPointKernel(&kernel);

--- a/src/s2geography/distance_test.cc
+++ b/src/s2geography/distance_test.cc
@@ -172,7 +172,7 @@ TEST_P(DistanceScalarScalarTest, SedonaUdf) {
             (!p.lhs || !p.rhs) ? std::nullopt : std::make_optional(false);
 
         // For the distance argument, subtract a small amount such that
-        // everything should return false. This is roughly 20 nanometers
+        // everything should return false. This is roughly 20 nm
         // for the largest possible distance between two things on
         // earth.
         double distance_threshold = p.expected.value_or(0.0);
@@ -408,6 +408,19 @@ INSTANTIATE_TEST_SUITE_P(
             "LINESTRING (0 0, 0 1)",
             // Longest line
             "LINESTRING (0 0, 0 1)",
+            // Closest Point
+            "POINT (0 0)"},
+        DistanceScalarScalarParam{
+            // Point x point
+            "point_distance_wraparound_lng", "POINT (0 0)", "POINT (360 361)",
+            // Distance
+            111195.10117748113,
+            // Max distance
+            111195.10117748113,
+            // Shortest line
+            "LINESTRING (0 0, 360 361)",
+            // Longest line
+            "LINESTRING (0 0, 360 361)",
             // Closest Point
             "POINT (0 0)"},
 

--- a/src/s2geography/geoarrow-geography.cc
+++ b/src/s2geography/geoarrow-geography.cc
@@ -942,8 +942,8 @@ GeoArrowVertex GeoArrowEdge::Interpolate(double fraction) {
     return v1;
   }
 
-  S2Point pt0 = S2LatLng::FromDegrees(v0.lat, v0.lng).ToPoint();
-  S2Point pt1 = S2LatLng::FromDegrees(v1.lat, v1.lng).ToPoint();
+  S2Point pt0 = v0.ToPoint();
+  S2Point pt1 = v1.ToPoint();
   if (pt0 == pt1) {
     return v0;
   }
@@ -957,8 +957,8 @@ GeoArrowVertex GeoArrowEdge::Interpolate(double fraction) {
 }
 
 GeoArrowVertex GeoArrowEdge::Interpolate(const S2Point& point) {
-  auto pt0 = S2LatLng::FromDegrees(v0.lat, v0.lng).ToPoint();
-  auto pt1 = S2LatLng::FromDegrees(v1.lat, v1.lng).ToPoint();
+  S2Point pt0 = v0.ToPoint();
+  S2Point pt1 = v1.ToPoint();
 
   // If the start and end are the same in lon/lat space, return the first vertex
   if (pt0 == pt1) {

--- a/src/s2geography/geoarrow-geography_util.h
+++ b/src/s2geography/geoarrow-geography_util.h
@@ -25,6 +25,21 @@ namespace internal {
 static constexpr uint8_t kFlagS2GeographyIsHole =
     (static_cast<uint8_t>(1) << 7);
 
+/// Convert a longitude and latitude to an S2Point
+///
+/// S2LatLng::ToPoint() has debug checks that lng and lat are within the
+/// [-180, -90, 180, 90] range; however, we don't strictly require the
+/// longitudes to be within this range and latitudes outside this range are
+/// undefined behaviour.
+///
+/// A note that this function can be a bottleneck when an operation hasn't
+/// effectively used an index or cached the resulting point sequence.
+inline S2Point LngLatToPoint(double lng, double lat) {
+  const S1Angle::SinCosPair phi = S1Angle::Degrees(lat).SinCos();
+  const S1Angle::SinCosPair theta = S1Angle::Degrees(lng).SinCos();
+  return S2Point(theta.cos * phi.cos, theta.sin * phi.cos, phi.sin);
+}
+
 /// \brief Visit "nodes" of a GeoArrowGeometryView
 ///
 /// Briefly, a GeoArrowGeometryNode is either a sequence (if geometry_type
@@ -129,7 +144,7 @@ struct GeoArrowVertex {
   }
 
   /// \brief Return the S2Point representation of this vertex
-  S2Point ToPoint() const { return S2LatLng::FromDegrees(lat, lng).ToPoint(); }
+  S2Point ToPoint() const { return LngLatToPoint(lng, lat); }
 
   /// \brief Normalize the order of zm values such that this object
   /// always represents, x, y, z, and m (in that order)
@@ -265,7 +280,7 @@ template <typename Visit>
 bool VisitVertices(const struct GeoArrowGeometryNode* node, int64_t offset,
                    int64_t n, Visit&& visit) {
   return VisitLngLat(node, offset, n, [&](double lng0, double lat0) {
-    return visit(S2LatLng::FromDegrees(lat0, lng0).ToPoint());
+    return visit(LngLatToPoint(lng0, lat0));
   });
 }
 
@@ -273,7 +288,7 @@ bool VisitVertices(const struct GeoArrowGeometryNode* node, int64_t offset,
 template <typename Visit>
 bool VisitVertices(const struct GeoArrowGeometryNode* node, Visit&& visit) {
   return VisitLngLat(node, 0, node->size, [&](double lng0, double lat0) {
-    return visit(S2LatLng::FromDegrees(lat0, lng0).ToPoint());
+    return visit(LngLatToPoint(lng0, lat0));
   });
 }
 

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -207,6 +207,12 @@ S2GeogErrorCode S2GeogRectBounderBound(struct S2GeogRectBounder* rect_bounder,
                                        const struct S2Geog* geog,
                                        struct S2GeogError* err);
 
+/// \brief Expand the accumulated bounds by a distance
+///
+/// \pre rect_bounder != NULL
+void S2GeogRectBounderExpandByDistance(struct S2GeogRectBounder* rect_bounder,
+                                       double distance_meters);
+
 /// \brief Return 1 if the rectangle that would be returned represents empty
 /// bounds or 0 otherwise
 ///


### PR DESCRIPTION
This is needed for an index-assisted DWithin join for SedonaDB.

I also made an update to have a custom version of `S2LatLng::FromDegrees().ToPoint()`, which has a DCHECK log for invalid longitudes. Invalid longitudes are not a problem for GeoArrow input (wrapped by the cos call) and when they show up in the data we end up with bananas console logs.