### PR TITLE
feat: Ensure Within and Disjoint are included in scalar function and operation sets

### DIFF
--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -178,11 +178,12 @@ uint64_t S2GeogLngLatToCellId(const struct S2GeogVertex* v) {
 
 using KernelInitFunc = void (*)(struct SedonaCScalarKernel*);
 
-static const std::array<KernelInitFunc, 27> kSedonaKernels = {{
+static const std::array<KernelInitFunc, 29> kSedonaKernels = {{
     s2geography::sedona_udf::AreaKernel,
     s2geography::sedona_udf::CentroidKernel,
     s2geography::sedona_udf::ClosestPointKernel,
     [](SedonaCScalarKernel* k) { s2geography::sedona_udf::ContainsKernel(k); },
+    [](SedonaCScalarKernel* k) { s2geography::sedona_udf::WithinKernel(k); },
     s2geography::sedona_udf::ConvexHullKernel,
     s2geography::sedona_udf::DifferenceKernel,
     [](SedonaCScalarKernel* k) { s2geography::sedona_udf::DistanceKernel(k); },
@@ -191,6 +192,7 @@ static const std::array<KernelInitFunc, 27> kSedonaKernels = {{
     [](SedonaCScalarKernel* k) {
       s2geography::sedona_udf::IntersectsKernel(k);
     },
+    [](SedonaCScalarKernel* k) { s2geography::sedona_udf::DisjointKernel(k); },
     s2geography::sedona_udf::LengthKernel,
     s2geography::sedona_udf::LineInterpolatePointKernel,
     s2geography::sedona_udf::LineLocatePointKernel,
@@ -477,6 +479,9 @@ S2GeogErrorCode S2GeogOpCreate(struct S2GeogOp** op, int op_id) {
       break;
     case S2GEOGRAPHY_OP_DISTANCE_WITHIN:
       inner = s2geography::DistanceWithin();
+      break;
+    case S2GEOGRAPHY_OP_DISJOINT:
+      inner = s2geography::Disjoint();
       break;
     default:
       return ENOTSUP;

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -279,7 +279,7 @@ TEST(S2GeographyC, RectBounderBound) {
 // Sedona UDF Interface Tests
 // ============================================================================
 
-TEST(S2GeographyC, NumKernels) { EXPECT_EQ(S2GeogNumKernels(), 27); }
+TEST(S2GeographyC, NumKernels) { EXPECT_EQ(S2GeogNumKernels(), 29); }
 
 TEST(S2GeographyC, InitKernelsInvalidFormat) {
   // Test with invalid format
@@ -390,6 +390,9 @@ INSTANTIATE_TEST_SUITE_P(
                                            S2GEOGRAPHY_OP_INTERSECTS,
                                            "POLYGON ((0 0, 2 0, 0 2, 0 0))",
                                            "POINT (0.25 0.25)", 1},
+                      BinaryPredicateParam{"disjoint", S2GEOGRAPHY_OP_DISJOINT,
+                                           "POLYGON ((0 0, 2 0, 0 2, 0 0))",
+                                           "POINT (0.25 0.25)", 0},
                       BinaryPredicateParam{"contains", S2GEOGRAPHY_OP_CONTAINS,
                                            "POLYGON ((0 0, 2 0, 0 2, 0 0))",
                                            "POINT (0.25 0.25)", 1},

--- a/src/s2geography/predicates.cc
+++ b/src/s2geography/predicates.cc
@@ -418,6 +418,37 @@ struct S2Contains {
   std::vector<s2shapeutil::ShapeEdge> crossing_edges_;
 };
 
+struct S2Within {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = GeoArrowGeographyInputView;
+  using out_t = BoolOutputBuilder;
+
+  void Exec(arg0_t::c_type value0, arg1_t::c_type value1, out_t* out) {
+    return contains_.Exec(value1, value0, out);
+  }
+
+  S2Contains<BoolOutputBuilder> contains_;
+};
+
+struct InvertedOutput {
+  void Append(bool value) { out_->Append(!value); }
+  BoolOutputBuilder* out_{};
+};
+
+struct S2Disjoint {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = GeoArrowGeographyInputView;
+  using out_t = BoolOutputBuilder;
+
+  void Exec(arg0_t::c_type value0, arg1_t::c_type value1, out_t* out) {
+    out_.out_ = out;
+    intersects_.Exec(value0, value1, &out_);
+  }
+
+  S2Intersects<InvertedOutput> intersects_;
+  InvertedOutput out_;
+};
+
 template <typename Output>
 struct S2Equals {
   using arg0_t = GeoArrowGeographyInputView;
@@ -526,10 +557,22 @@ void IntersectsKernel(struct SedonaCScalarKernel* out, bool prepare_arg0_scalar,
       out, "st_intersects", prepare_arg0_scalar, prepare_arg1_scalar);
 }
 
+void DisjointKernel(struct SedonaCScalarKernel* out, bool prepare_arg0_scalar,
+                    bool prepare_arg1_scalar) {
+  InitBinaryKernel<S2Disjoint>(out, "st_disjoint", prepare_arg0_scalar,
+                               prepare_arg1_scalar);
+}
+
 void ContainsKernel(struct SedonaCScalarKernel* out, bool prepare_arg0_scalar,
                     bool prepare_arg1_scalar) {
   InitBinaryKernel<S2Contains<BoolOutputBuilder>>(
       out, "st_contains", prepare_arg0_scalar, prepare_arg1_scalar);
+}
+
+void WithinKernel(struct SedonaCScalarKernel* out, bool prepare_arg0_scalar,
+                  bool prepare_arg1_scalar) {
+  InitBinaryKernel<S2Within>(out, "st_within", prepare_arg0_scalar,
+                             prepare_arg1_scalar);
 }
 
 void EqualsKernel(struct SedonaCScalarKernel* out, bool prepare_arg0_scalar,
@@ -593,10 +636,37 @@ class WithinOperation : public Operation {
       "contains"};
 };
 
+class DisjointOperation : public Operation {
+ public:
+  DisjointOperation() : name_("disjoint") {}
+
+  const std::string& name() const override { return name_; }
+
+  OutputType output_type() const override {
+    return Operation::OutputType::kBool;
+  }
+
+  void ExecGeogGeog(const GeoArrowGeography& arg0,
+                    const GeoArrowGeography& arg1) override {
+    // Disjoint(A, B) is !Intersects(A, B)
+    intersects_.ExecGeogGeog(arg0, arg1);
+    int_result_ = !intersects_.GetInt();
+  }
+
+ private:
+  std::string name_;
+  PredicateOperation<sedona_udf::S2Intersects<StashedBoolOutput>> intersects_{
+      "contains"};
+};
+
 std::unique_ptr<Operation> Intersects() {
   return std::make_unique<
       PredicateOperation<sedona_udf::S2Intersects<StashedBoolOutput>>>(
       "intersects");
+}
+
+std::unique_ptr<Operation> Disjoint() {
+  return std::make_unique<DisjointOperation>();
 }
 
 std::unique_ptr<Operation> Contains() {

--- a/src/s2geography/predicates.h
+++ b/src/s2geography/predicates.h
@@ -44,6 +44,7 @@ bool s2_intersects_box(const S2ShapeIndex& geog1, const S2LatLngRect& rect,
                        double tolerance);
 
 std::unique_ptr<Operation> Intersects();
+std::unique_ptr<Operation> Disjoint();
 std::unique_ptr<Operation> Contains();
 std::unique_ptr<Operation> Within();
 std::unique_ptr<Operation> Equals();
@@ -53,9 +54,15 @@ namespace sedona_udf {
 void IntersectsKernel(struct SedonaCScalarKernel* out,
                       bool prepare_arg0_scalar = true,
                       bool prepare_arg1_scalar = true);
+void DisjointKernel(struct SedonaCScalarKernel* out,
+                    bool prepare_arg0_scalar = true,
+                    bool prepare_arg1_scalar = true);
 void ContainsKernel(struct SedonaCScalarKernel* out,
                     bool prepare_arg0_scalar = true,
                     bool prepare_arg1_scalar = true);
+void WithinKernel(struct SedonaCScalarKernel* out,
+                  bool prepare_arg0_scalar = true,
+                  bool prepare_arg1_scalar = true);
 void EqualsKernel(struct SedonaCScalarKernel* out,
                   bool prepare_arg0_scalar = true,
                   bool prepare_arg1_scalar = true);

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -220,6 +220,89 @@ TEST(Predicates, SedonaUdfContainsArrayPolygonScalarLinestring) {
                                           {true, false, false}));
 }
 
+TEST(Predicates, SedonaUdfDisjointArrayScalar) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::DisjointKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, NANOARROW_TYPE_BOOL));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                        {{"POINT (0.25 0.25)", "POINT (-1 -1)", std::nullopt},
+                         {"POLYGON ((0 0, 1 0, 0 1, 0 0))"}},
+                        {}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  // Interior point -> not disjoint (false), exterior point -> disjoint (true)
+  ASSERT_NO_FATAL_FAILURE(TestResultArrow(out_array.get(), NANOARROW_TYPE_BOOL,
+                                          {false, true, std::nullopt}));
+}
+
+TEST(Predicates, SedonaUdfDisjointScalarArray) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::DisjointKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, NANOARROW_TYPE_BOOL));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                        {{"POLYGON ((0 0, 1 0, 0 1, 0 0))"},
+                         {"POINT (0.25 0.25)", "POINT (-1 -1)", std::nullopt}},
+                        {}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_NO_FATAL_FAILURE(TestResultArrow(out_array.get(), NANOARROW_TYPE_BOOL,
+                                          {false, true, std::nullopt}));
+}
+
+TEST(Predicates, SedonaUdfWithinArrayScalar) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::WithinKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, NANOARROW_TYPE_BOOL));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                        {{"POINT (0.25 0.25)", "POINT (-1 -1)", std::nullopt},
+                         {"POLYGON ((0 0, 2 0, 0 2, 0 0))"}},
+                        {}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  // Within is the reverse of Contains: point inside polygon -> true
+  ASSERT_NO_FATAL_FAILURE(TestResultArrow(out_array.get(), NANOARROW_TYPE_BOOL,
+                                          {true, false, std::nullopt}));
+}
+
+TEST(Predicates, SedonaUdfWithinScalarArray) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::WithinKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB}, NANOARROW_TYPE_BOOL));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl, {ARROW_TYPE_WKB, ARROW_TYPE_WKB},
+                        {{"POLYGON ((0 0, 2 0, 0 2, 0 0))"},
+                         {"POINT (0.25 0.25)", "POINT (-1 -1)", std::nullopt}},
+                        {}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  // Polygon is not within point
+  ASSERT_NO_FATAL_FAILURE(TestResultArrow(out_array.get(), NANOARROW_TYPE_BOOL,
+                                          {false, false, std::nullopt}));
+}
+
 struct ScalarScalarParam {
   std::string name;
   std::optional<std::string> lhs;
@@ -260,9 +343,15 @@ TEST_P(PredicatesScalarScalarTest, SedonaUdf) {
       if (p.op == "intersects") {
         s2geography::sedona_udf::IntersectsKernel(&kernel, prepare_arg0,
                                                   prepare_arg1);
+      } else if (p.op == "disjoint") {
+        s2geography::sedona_udf::DisjointKernel(&kernel, prepare_arg0,
+                                                prepare_arg1);
       } else if (p.op == "contains") {
         s2geography::sedona_udf::ContainsKernel(&kernel, prepare_arg0,
                                                 prepare_arg1);
+      } else if (p.op == "within") {
+        s2geography::sedona_udf::WithinKernel(&kernel, prepare_arg0,
+                                              prepare_arg1);
       } else if (p.op == "equals") {
         s2geography::sedona_udf::EqualsKernel(&kernel, prepare_arg0,
                                               prepare_arg1);
@@ -299,8 +388,12 @@ TEST_P(PredicatesScalarScalarTest, PredicateOperation) {
   std::unique_ptr<s2geography::Operation> predicate;
   if (p.op == "intersects") {
     predicate = s2geography::Intersects();
+  } else if (p.op == "disjoint") {
+    predicate = s2geography::Disjoint();
   } else if (p.op == "contains") {
     predicate = s2geography::Contains();
+  } else if (p.op == "within") {
+    predicate = s2geography::Within();
   } else if (p.op == "equals") {
     predicate = s2geography::Equals();
   } else {
@@ -691,7 +784,16 @@ INSTANTIATE_TEST_SUITE_P(
         // Equals: GEOMETRYCOLLECTION vs simple geometry
         ScalarScalarParam{"gc_not_equals_point",
                           "GEOMETRYCOLLECTION (POINT (0 0))", "equals",
-                          "POINT (0 0)", true}
+                          "POINT (0 0)", true},
+
+        // Disjoint (is it plugged in check)
+        // Disjoint is the negation of Intersects
+        ScalarScalarParam{"polygon_disjoint_distant_point",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", "disjoint",
+                          "POINT (-30 -30)", true},
+        ScalarScalarParam{"polygon_not_disjoint_interior_point",
+                          "POLYGON ((0 0, 2 0, 0 2, 0 0))", "disjoint",
+                          "POINT (0.25 0.25)", false}
 
         ),
     [](const ::testing::TestParamInfo<ScalarScalarParam>& info) {

--- a/src/s2geography/predicates_test.cc
+++ b/src/s2geography/predicates_test.cc
@@ -785,9 +785,7 @@ INSTANTIATE_TEST_SUITE_P(
         ScalarScalarParam{"gc_not_equals_point",
                           "GEOMETRYCOLLECTION (POINT (0 0))", "equals",
                           "POINT (0 0)", true},
-
-        // Disjoint (is it plugged in check)
-        // Disjoint is the negation of Intersects
+        // Disjoint
         ScalarScalarParam{"polygon_disjoint_distant_point",
                           "POLYGON ((0 0, 2 0, 0 2, 0 0))", "disjoint",
                           "POINT (-30 -30)", true},

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -298,6 +298,11 @@ struct S2GeogOp;
 /// distance threshold, returning a boolean
 #define S2GEOGRAPHY_OP_DISTANCE_WITHIN 5
 
+/// \brief Compute the disjoint predicate between two geographies, returning a
+/// boolean
+#define S2GEOGRAPHY_OP_DISJOINT 6
+
+/// \brief Returned by S2GeogOpOutputType when the output type is a bool
 #define S2GEOGRAPHY_OUTPUT_TYPE_BOOL 1
 
 /// \brief Create a new operator object


### PR DESCRIPTION
Another missing feature needed to pass the spatial join tests. We could implement these in SedonaDB by wrapping the existing functions but it's pretty easy here and somebody else will probably need them too.