### PR TITLE
feat: Add RectBounder methods needed for practical uses

### DIFF
--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -422,6 +422,20 @@ void S2GeogRectBounderExpandByDistance(struct S2GeogRectBounder* rect_bounder,
   rect_bounder->bounder.ExpandByDistance(distance_meters);
 }
 
+void S2GeogRectBounderExpandByDistanceWithRadius(
+    struct S2GeogRectBounder* rect_bounder, double distance_meters,
+    double radius) {
+  S2GEOGRAPHY_DCHECK(rect_bounder != nullptr);
+  rect_bounder->bounder.ExpandByDistanceWithRadius(distance_meters, radius);
+}
+
+void S2GeogRectBounderUpdateRect(struct S2GeogRectBounder* rect_bounder,
+                                 double x_lo, double y_lo, double x_hi,
+                                 double y_hi) {
+  S2GEOGRAPHY_DCHECK(rect_bounder != nullptr);
+  rect_bounder->bounder.UpdateRect(x_lo, y_lo, x_hi, y_hi);
+}
+
 uint8_t S2GeogRectBounderIsEmpty(struct S2GeogRectBounder* rect_bounder) {
   S2GEOGRAPHY_DCHECK(rect_bounder != nullptr);
   return rect_bounder->bounder.is_empty();

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -269,6 +269,30 @@ TEST(S2GeographyC, RectBounderBound) {
   EXPECT_LT(lo.v[1], 20 - 0.008);
   EXPECT_GT(hi.v[1], 20 + 0.008);
 
+  // Test ExpandByDistanceWithRadius with half Earth's radius
+  // This should result in twice the angular expansion
+  S2GeogRectBounderClear(bounder);
+  S2GeogRectBounderBound(bounder, geog, err);
+  double half_earth_radius = 6371000.0 / 2.0;  // Half of Earth's radius in m
+  S2GeogRectBounderExpandByDistanceWithRadius(bounder, 1000.0,
+                                              half_earth_radius);
+  EXPECT_EQ(S2GeogRectBounderFinish(bounder, &lo, &hi, err), S2GEOGRAPHY_OK);
+  // With half the radius, bounds should expand more
+  EXPECT_LT(lo.v[0], 10 - 0.016);
+  EXPECT_GT(hi.v[0], 10 + 0.016);
+  EXPECT_LT(lo.v[1], 20 - 0.016);
+  EXPECT_GT(hi.v[1], 20 + 0.016);
+
+  // Test UpdateRect
+  S2GeogRectBounderClear(bounder);
+  S2GeogRectBounderUpdateRect(bounder, -10.0, -20.0, 30.0, 40.0);
+  EXPECT_EQ(S2GeogRectBounderIsEmpty(bounder), 0);
+  EXPECT_EQ(S2GeogRectBounderFinish(bounder, &lo, &hi, err), S2GEOGRAPHY_OK);
+  EXPECT_DOUBLE_EQ(lo.v[0], -10.0);
+  EXPECT_DOUBLE_EQ(lo.v[1], -20.0);
+  EXPECT_DOUBLE_EQ(hi.v[0], 30.0);
+  EXPECT_DOUBLE_EQ(hi.v[1], 40.0);
+
   S2GeogRectBounderDestroy(bounder);
   S2GeogErrorDestroy(err);
   S2GeogDestroy(geog);

--- a/src/s2geography/accessors-geog_test.cc
+++ b/src/s2geography/accessors-geog_test.cc
@@ -502,8 +502,7 @@ INSTANTIATE_TEST_SUITE_P(
                                   std::nullopt},
 
         // Empties
-        UnaryGeographyScalarParam{"point_empty", "POINT EMPTY",
-                                  "POINT EMPTY"},
+        UnaryGeographyScalarParam{"point_empty", "POINT EMPTY", "POINT EMPTY"},
         UnaryGeographyScalarParam{"linestring_empty", "LINESTRING EMPTY",
                                   "LINESTRING EMPTY"},
         UnaryGeographyScalarParam{"polygon_empty", "POLYGON EMPTY",

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -90,6 +90,13 @@ void LatLngRectBounder::Clear() { bounds_ = S2LatLngRect::Empty(); }
 
 S2LatLngRect LatLngRectBounder::Finish() const { return bounds_; }
 
+void LatLngRectBounder::UpdateRect(double x_lo, double y_lo, double x_hi,
+                                   double y_hi) {
+  S2LatLng lo = S2LatLng::FromDegrees(y_lo, x_lo).Normalized();
+  S2LatLng hi = S2LatLng::FromDegrees(y_hi, x_hi).Normalized();
+  bounds_ = bounds_.Union(S2LatLngRect(lo, hi));
+}
+
 void LatLngRectBounder::Update(const GeoArrowGeography& value) {
   if (value.is_empty()) {
     return;
@@ -126,6 +133,12 @@ S2LatLngRect LatLngRectBounder::BoundPoints(const GeoArrowGeography& value) {
 void LatLngRectBounder::ExpandByDistance(double distance_meters) {
   S1Angle distance =
       S1Angle::Radians(distance_meters / S2Earth::RadiusMeters());
+  bounds_ = bounds_.ExpandedByDistance(distance);
+}
+
+void LatLngRectBounder::ExpandByDistanceWithRadius(double distance_meters,
+                                                   double radius) {
+  S1Angle distance = S1Angle::Radians(distance_meters / radius);
   bounds_ = bounds_.ExpandedByDistance(distance);
 }
 

--- a/src/s2geography/coverings.h
+++ b/src/s2geography/coverings.h
@@ -14,8 +14,10 @@ class LatLngRectBounder {
  public:
   void Clear();
   S2LatLngRect Finish() const;
+  void UpdateRect(double x_lo, double y_lo, double x_hi, double y_hi);
   void Update(const GeoArrowGeography& value);
   void ExpandByDistance(double distance_meters);
+  void ExpandByDistanceWithRadius(double distance_meters, double radius);
   bool is_empty() const { return bounds_.is_empty(); }
 
  private:

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 #include <s2/s2cell_id.h>
+#include <s2/s2earth.h>
 #include <s2/s2latlng.h>
 
 #include <optional>
@@ -188,6 +189,45 @@ TEST(LatLngRectBounderTest, ExpandByDistancePoint) {
   EXPECT_GT(bounds.lat_hi().degrees(), 0.008);
   EXPECT_LT(bounds.lng_lo().degrees(), -0.008);
   EXPECT_GT(bounds.lng_hi().degrees(), 0.008);
+}
+
+// Test that ExpandByDistanceWithRadius expands bounds using custom radius
+TEST(LatLngRectBounderTest, ExpandByDistanceWithRadius) {
+  auto test_geom = TestGeometry::FromWKT("POINT (0 0)");
+  GeoArrowGeography geog;
+  geog.Init(test_geom.geom());
+
+  LatLngRectBounder bounder;
+  bounder.Clear();
+  bounder.Update(geog);
+
+  // Use a custom radius (half of Earth's radius)
+  // This should result in twice the angular expansion
+  double half_earth_radius = S2Earth::RadiusMeters() / 2.0;
+  bounder.ExpandByDistanceWithRadius(1000.0, half_earth_radius);
+  S2LatLngRect bounds = bounder.Finish();
+
+  // With half the radius, 1000 meters corresponds to twice the angle
+  // So bounds should expand more than ExpandByDistance with 1000m
+  EXPECT_LT(bounds.lat_lo().degrees(), -0.016);
+  EXPECT_GT(bounds.lat_hi().degrees(), 0.016);
+  EXPECT_LT(bounds.lng_lo().degrees(), -0.016);
+  EXPECT_GT(bounds.lng_hi().degrees(), 0.016);
+}
+
+// Test that UpdateRect adds rectangle bounds
+TEST(LatLngRectBounderTest, UpdateRect) {
+  LatLngRectBounder bounder;
+  bounder.Clear();
+
+  // Add a rectangle (x_lo, y_lo, x_hi, y_hi) = (lng_lo, lat_lo, lng_hi, lat_hi)
+  bounder.UpdateRect(-10.0, -20.0, 30.0, 40.0);
+  S2LatLngRect bounds = bounder.Finish();
+
+  EXPECT_DOUBLE_EQ(bounds.lng_lo().degrees(), -10.0);
+  EXPECT_DOUBLE_EQ(bounds.lat_lo().degrees(), -20.0);
+  EXPECT_DOUBLE_EQ(bounds.lng_hi().degrees(), 30.0);
+  EXPECT_DOUBLE_EQ(bounds.lat_hi().degrees(), 40.0);
 }
 
 TEST(Coverings, SedonaUdfCellIdFromPointArray) {

--- a/src/s2geography_c.h
+++ b/src/s2geography_c.h
@@ -213,6 +213,25 @@ S2GeogErrorCode S2GeogRectBounderBound(struct S2GeogRectBounder* rect_bounder,
 void S2GeogRectBounderExpandByDistance(struct S2GeogRectBounder* rect_bounder,
                                        double distance_meters);
 
+/// \brief Expand the accumulated bounds by a distance using a custom sphere
+/// radius
+///
+/// This is useful when working with non-Earth spheres or custom projections.
+///
+/// \pre rect_bounder != NULL
+void S2GeogRectBounderExpandByDistanceWithRadius(
+    struct S2GeogRectBounder* rect_bounder, double distance_meters,
+    double radius);
+
+/// \brief Update bounds with a rectangle specified by corners
+///
+/// Coordinates are in degrees: x is longitude, y is latitude.
+///
+/// \pre rect_bounder != NULL
+void S2GeogRectBounderUpdateRect(struct S2GeogRectBounder* rect_bounder,
+                                 double x_lo, double y_lo, double x_hi,
+                                 double y_hi);
+
 /// \brief Return 1 if the rectangle that would be returned represents empty
 /// bounds or 0 otherwise
 ///


### PR DESCRIPTION
For practical usage we need two more methods on the RectBounder:

- We need the expand by distance operation to factor in some custom radius. This is needed to support arbitrary CRSes (e.g., non-earth, continent-specifric ellipsoids)
- We need the ability to merge in a precalculated rectangle. This is so that we can serialize and deserialize state in an aggregate function.

This PR implements both.