### PR TITLE
fix: Fix struct tagging of GeoArrowGeometryView in C header for MSVC

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -3,6 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - cxx-compiler
-  - s2geometry >=0.11
+  # Pin to <0.14.0 due to broken header installation in 0.14.0 conda package
+  # (s2/base/port.h missing). See https://github.com/conda-forge/s2geometry-feedstock/issues
+  - s2geometry >=0.11,<0.14
   - libabseil
   - cmake

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -778,7 +778,7 @@ using StringInputView = ArrowInputView<std::string_view>;
 template <enum GeoArrowEdgeType edge_type>
 class GeoArrowInputView {
  public:
-  using c_type = struct GeoArrowGeometryView;
+  using c_type = ::GeoArrowGeometryView;
 
   static bool Matches(const struct ArrowSchema* type) {
     struct GeoArrowSchemaView schema_view;
@@ -827,7 +827,7 @@ class GeoArrowInputView {
 
   bool IsNull(int64_t i) { return inner_.IsNull(i); }
 
-  struct GeoArrowGeometryView Get(int64_t i) {
+  GeoArrowGeometryView Get(int64_t i) {
     if (current_array_length_ == 1) {
       StashIfNeeded(0);
     } else {
@@ -843,7 +843,7 @@ class GeoArrowInputView {
   ArrowInputView<std::string_view> inner_;
   int64_t current_array_length_;
   int64_t stashed_index_;
-  struct GeoArrowGeometryView stashed_;
+  GeoArrowGeometryView stashed_;
 
   void StashIfNeeded(int64_t i) {
     if (i != stashed_index_) {
@@ -910,7 +910,7 @@ class GeoArrowGeographyInputView {
 
   void StashIfNeeded(int64_t i, bool prepare = false) {
     if (i != stashed_index_) {
-      struct GeoArrowGeometryView geom = inner_.Get(i);
+      GeoArrowGeometryView geom = inner_.Get(i);
       stashed_.Init(geom);
       stashed_index_ = i;
 


### PR DESCRIPTION
None of the CIs complain about this, but my local (older) MSVC does.