### PR TITLE
feat: Parameterize S2 covering cell IDs (min_level, max_level, max_cells)

### DIFF
--- a/src/capi/s2geography_c.cc
+++ b/src/capi/s2geography_c.cc
@@ -179,7 +179,7 @@ uint64_t S2GeogLngLatToCellId(const struct S2GeogVertex* v) {
 
 using KernelInitFunc = void (*)(struct SedonaCScalarKernel*);
 
-static const std::array<KernelInitFunc, 33> kSedonaKernels = {{
+static const std::array<KernelInitFunc, 36> kSedonaKernels = {{
     s2geography::sedona_udf::AreaKernel,
     s2geography::sedona_udf::CentroidKernel,
     s2geography::sedona_udf::ClosestPointKernel,
@@ -217,6 +217,9 @@ static const std::array<KernelInitFunc, 33> kSedonaKernels = {{
     },
     s2geography::sedona_udf::CellIdFromPointKernel,
     s2geography::sedona_udf::CoveringCellIdsKernel,
+    s2geography::sedona_udf::CoveringCellIdsMinLevelKernel,
+    s2geography::sedona_udf::CoveringCellIdsLevelRangeKernel,
+    s2geography::sedona_udf::CoveringCellIdsLevelRangeMaxCellsKernel,
     [](SedonaCScalarKernel* k) {
       s2geography::sedona_udf::LongestLineKernel(k);
     },

--- a/src/capi/s2geography_c_test.cc
+++ b/src/capi/s2geography_c_test.cc
@@ -303,7 +303,7 @@ TEST(S2GeographyC, RectBounderBound) {
 // Sedona UDF Interface Tests
 // ============================================================================
 
-TEST(S2GeographyC, NumKernels) { EXPECT_EQ(S2GeogNumKernels(), 33); }
+TEST(S2GeographyC, NumKernels) { EXPECT_EQ(S2GeogNumKernels(), 36); }
 
 TEST(S2GeographyC, InitKernelsInvalidFormat) {
   // Test with invalid format

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -1,6 +1,7 @@
 
 #include "s2geography/coverings.h"
 
+#include <s2/s2cell_id.h>
 #include <s2/s2earth.h>
 #include <s2/s2edge_crosser.h>
 #include <s2/s2latlng_rect_bounder.h>
@@ -225,6 +226,73 @@ S2LatLngRect LatLngRectBounder::BoundLoops(const GeoArrowGeography& value) {
 
 namespace sedona_udf {
 
+static constexpr int kDefaultMinLevel = 0;
+static constexpr int kDefaultMaxLevel = S2CellId::kMaxLevel;
+static constexpr int kDefaultMaxCells = 8;
+
+void ValidateCoveringOptions(int64_t min_level, int64_t max_level,
+                             int64_t max_cells) {
+  if (min_level < 0 || min_level > S2CellId::kMaxLevel) {
+    throw Exception("min_level must be between 0 and 30");
+  }
+
+  if (max_level < 0 || max_level > S2CellId::kMaxLevel) {
+    throw Exception("max_level must be between 0 and 30");
+  }
+
+  if (min_level > max_level) {
+    throw Exception("min_level must be less than or equal to max_level");
+  }
+
+  if (max_cells < 1) {
+    throw Exception("max_cells must be greater than 0");
+  }
+}
+
+void AppendCoveringCellIds(const GeoArrowGeography& value, int64_t min_level,
+                           int64_t max_level, int64_t max_cells,
+                           ListOutputBuilder<IntOutputBuilder>* out,
+                           std::vector<S2CellId>* covering,
+                           S2RegionCoverer* coverer) {
+  ValidateCoveringOptions(min_level, max_level, max_cells);
+
+  if (value.is_empty()) {
+    out->Append();
+    return;
+  }
+
+  // Canonically consider the S2CellId of a Point to be its covering. If a
+  // maximum level is specified, return the containing parent at that level.
+  auto pt = value.Point();
+  if (pt) {
+    S2CellId id(*pt);
+    if (max_level < S2CellId::kMaxLevel) {
+      id = id.parent(static_cast<int>(max_level));
+    }
+
+    out->items().Append(static_cast<int64_t>(id.id()));
+    out->Append();
+    return;
+  }
+
+  S2RegionCoverer::Options* options = coverer->mutable_options();
+  options->set_min_level(static_cast<int>(min_level));
+  options->set_max_level(static_cast<int>(max_level));
+  options->set_max_cells(static_cast<int>(max_cells));
+
+  // For now, don't make any attempt to optimize calculating this.
+  // This will build a shape index for each item and may be slow.
+  // We may want to consider just implementing S2Region for the
+  // GeoArrowGeography.
+  covering->clear();
+  coverer->GetCovering(*value.Region(), covering);
+  for (const S2CellId id : *covering) {
+    out->items().Append(static_cast<int64_t>(id.id()));
+  }
+
+  out->Append();
+}
+
 struct CellIdFromPointExec {
   using arg0_t = GeoArrowGeographyInputView;
   using out_t = IntOutputBuilder;
@@ -250,34 +318,55 @@ struct CoveringCellIdsExec {
   using out_t = ListOutputBuilder<IntOutputBuilder>;
 
   void Exec(arg0_t::c_type value, out_t* out) {
-    if (value.is_empty()) {
-      out->Append();
-      return;
-    }
+    AppendCoveringCellIds(value, kDefaultMinLevel, kDefaultMaxLevel,
+                          kDefaultMaxCells, out, &covering_, &coverer_);
+  }
 
-    // Canonically consider the S2CellId of a Point to be
-    // its covering. Otherwise we get funny coverings for points
-    // (no need to have four cells for a single point).
-    auto pt = value.Point();
-    if (pt) {
-      S2CellId id(*pt);
-      out->items().Append(static_cast<int64_t>(id.id()));
-      out->Append();
-      return;
-    }
+  std::vector<S2CellId> covering_;
+  S2RegionCoverer coverer_;
+};
 
-    // For now, don't make any attempt to optimize calculating this.
-    // This will build a shape index for each item and may be slow.
-    // We may want to consider just implementing S2Region for the
-    // GeoArrowGeography.
-    coverer_.mutable_options()->set_max_cells(8);
-    covering_.clear();
-    coverer_.GetCovering(*value.Region(), &covering_);
-    for (const S2CellId id : covering_) {
-      out->items().Append(static_cast<int64_t>(id.id()));
-    }
+struct CoveringCellIdsMinLevelExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = IntInputView;
+  using out_t = ListOutputBuilder<IntOutputBuilder>;
 
-    out->Append();
+  void Exec(arg0_t::c_type value, arg1_t::c_type min_level, out_t* out) {
+    AppendCoveringCellIds(value, min_level, kDefaultMaxLevel,
+                          kDefaultMaxCells, out, &covering_, &coverer_);
+  }
+
+  std::vector<S2CellId> covering_;
+  S2RegionCoverer coverer_;
+};
+
+struct CoveringCellIdsLevelRangeExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = IntInputView;
+  using arg2_t = IntInputView;
+  using out_t = ListOutputBuilder<IntOutputBuilder>;
+
+  void Exec(arg0_t::c_type value, arg1_t::c_type min_level,
+            arg2_t::c_type max_level, out_t* out) {
+    AppendCoveringCellIds(value, min_level, max_level, kDefaultMaxCells, out,
+                          &covering_, &coverer_);
+  }
+
+  std::vector<S2CellId> covering_;
+  S2RegionCoverer coverer_;
+};
+
+struct CoveringCellIdsLevelRangeMaxCellsExec {
+  using arg0_t = GeoArrowGeographyInputView;
+  using arg1_t = IntInputView;
+  using arg2_t = IntInputView;
+  using arg3_t = IntInputView;
+  using out_t = ListOutputBuilder<IntOutputBuilder>;
+
+  void Exec(arg0_t::c_type value, arg1_t::c_type min_level,
+            arg2_t::c_type max_level, arg3_t::c_type max_cells, out_t* out) {
+    AppendCoveringCellIds(value, min_level, max_level, max_cells, out,
+                          &covering_, &coverer_);
   }
 
   std::vector<S2CellId> covering_;
@@ -319,6 +408,19 @@ void CellIdFromPointKernel(struct SedonaCScalarKernel* out) {
 
 void CoveringCellIdsKernel(struct SedonaCScalarKernel* out) {
   InitUnaryKernel<CoveringCellIdsExec>(out, "s2_coveringcellids");
+}
+
+void CoveringCellIdsMinLevelKernel(struct SedonaCScalarKernel* out) {
+  InitBinaryKernel<CoveringCellIdsMinLevelExec>(out, "s2_coveringcellids");
+}
+
+void CoveringCellIdsLevelRangeKernel(struct SedonaCScalarKernel* out) {
+  InitTernaryKernel<CoveringCellIdsLevelRangeExec>(out, "s2_coveringcellids");
+}
+
+void CoveringCellIdsLevelRangeMaxCellsKernel(struct SedonaCScalarKernel* out) {
+  InitQuaternaryKernel<CoveringCellIdsLevelRangeMaxCellsExec>(
+      out, "s2_coveringcellids");
 }
 
 void BoundingBoxKernel(struct SedonaCScalarKernel* out) {

--- a/src/s2geography/coverings.cc
+++ b/src/s2geography/coverings.cc
@@ -9,6 +9,7 @@
 #include <s2/s2shape_index_buffered_region.h>
 
 #include <cfloat>
+#include <limits>
 
 #include "s2geography/accessors-geog.h"
 #include "s2geography/accessors.h"
@@ -229,6 +230,7 @@ namespace sedona_udf {
 static constexpr int kDefaultMinLevel = 0;
 static constexpr int kDefaultMaxLevel = S2CellId::kMaxLevel;
 static constexpr int kDefaultMaxCells = 8;
+static constexpr int kMaxMaxCells = std::numeric_limits<int>::max();
 
 void ValidateCoveringOptions(int64_t min_level, int64_t max_level,
                              int64_t max_cells) {
@@ -246,6 +248,10 @@ void ValidateCoveringOptions(int64_t min_level, int64_t max_level,
 
   if (max_cells < 1) {
     throw Exception("max_cells must be greater than 0");
+  }
+
+  if (max_cells > kMaxMaxCells) {
+    throw Exception("max_cells must be less than or equal to 2147483647");
   }
 }
 
@@ -332,8 +338,8 @@ struct CoveringCellIdsMinLevelExec {
   using out_t = ListOutputBuilder<IntOutputBuilder>;
 
   void Exec(arg0_t::c_type value, arg1_t::c_type min_level, out_t* out) {
-    AppendCoveringCellIds(value, min_level, kDefaultMaxLevel,
-                          kDefaultMaxCells, out, &covering_, &coverer_);
+    AppendCoveringCellIds(value, min_level, kDefaultMaxLevel, kDefaultMaxCells,
+                          out, &covering_, &coverer_);
   }
 
   std::vector<S2CellId> covering_;

--- a/src/s2geography/coverings.h
+++ b/src/s2geography/coverings.h
@@ -44,6 +44,9 @@ namespace sedona_udf {
 
 void CellIdFromPointKernel(struct SedonaCScalarKernel* out);
 void CoveringCellIdsKernel(struct SedonaCScalarKernel* out);
+void CoveringCellIdsMinLevelKernel(struct SedonaCScalarKernel* out);
+void CoveringCellIdsLevelRangeKernel(struct SedonaCScalarKernel* out);
+void CoveringCellIdsLevelRangeMaxCellsKernel(struct SedonaCScalarKernel* out);
 void BoundingBoxKernel(struct SedonaCScalarKernel* out);
 
 }  // namespace sedona_udf

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -313,6 +313,100 @@ TEST(Coverings, SedonaUdfCoveringCellIdsArray) {
   kernel.release(&kernel);
 }
 
+TEST(Coverings, SedonaUdfCoveringCellIdsOverloadsInit) {
+  struct SedonaCScalarKernel kernel;
+  struct SedonaCScalarKernelImpl impl;
+
+  s2geography::sedona_udf::CoveringCellIdsMinLevelKernel(&kernel);
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32},
+      NANOARROW_TYPE_LIST));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  s2geography::sedona_udf::CoveringCellIdsLevelRangeKernel(&kernel);
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl,
+      {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32},
+      NANOARROW_TYPE_LIST));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  s2geography::sedona_udf::CoveringCellIdsLevelRangeMaxCellsKernel(&kernel);
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl,
+      {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32,
+       NANOARROW_TYPE_INT32},
+      NANOARROW_TYPE_LIST));
+  impl.release(&impl);
+  kernel.release(&kernel);
+}
+
+TEST(Coverings, SedonaUdfCoveringCellIdsOptionsArray) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::CoveringCellIdsLevelRangeMaxCellsKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl,
+      {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32,
+       NANOARROW_TYPE_INT32},
+      NANOARROW_TYPE_LIST));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
+      &impl,
+      {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32,
+       NANOARROW_TYPE_INT32},
+      {{"LINESTRING (0 0, 1 1)", "POINT (0 0)"}},
+      {{10, 0}, {10, 10}, {32, 8}}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  ASSERT_EQ(out_array->length, 2);
+  ASSERT_EQ(out_array->n_children, 1);
+  auto* offsets = reinterpret_cast<const int32_t*>(out_array->buffers[1]);
+
+  // Row 0: a fixed level-10 covering should produce only level-10 cells.
+  EXPECT_GT(offsets[1] - offsets[0], 0);
+  auto* child = out_array->children[0];
+  ASSERT_NE(child, nullptr);
+  ASSERT_NE(child->buffers[1], nullptr);
+  auto* cell_ids = reinterpret_cast<const int64_t*>(child->buffers[1]);
+  for (int64_t i = offsets[0]; i < offsets[1]; i++) {
+    S2CellId id(static_cast<uint64_t>(cell_ids[i]));
+    EXPECT_EQ(id.level(), 10);
+  }
+
+  // Row 1: constraining max_level for a point should return that parent cell.
+  EXPECT_EQ(offsets[2] - offsets[1], 1);
+  S2CellId actual_point_cell(static_cast<uint64_t>(cell_ids[offsets[1]]));
+  S2CellId expected_point_cell(S2LatLng::FromDegrees(0, 0).ToPoint());
+  EXPECT_EQ(actual_point_cell, expected_point_cell.parent(10));
+}
+
+TEST(Coverings, SedonaUdfCoveringCellIdsMaxCells) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::CoveringCellIdsLevelRangeMaxCellsKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
+      &kernel, &impl,
+      {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32,
+       NANOARROW_TYPE_INT32},
+      NANOARROW_TYPE_LIST));
+
+  nanoarrow::UniqueArray out_array;
+  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
+      &impl,
+      {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32,
+       NANOARROW_TYPE_INT32},
+      {{"LINESTRING (0 0, 100 50)"}}, {{0}, {30}, {2}}, out_array.get()));
+  impl.release(&impl);
+  kernel.release(&kernel);
+
+  auto* offsets = reinterpret_cast<const int32_t*>(out_array->buffers[1]);
+  EXPECT_LE(offsets[1] - offsets[0], 2);
+}
+
 TEST(Coverings, SedonaUdfBoundingBox) {
   struct SedonaCScalarKernel kernel;
   s2geography::sedona_udf::BoundingBoxKernel(&kernel);

--- a/src/s2geography/coverings_test.cc
+++ b/src/s2geography/coverings_test.cc
@@ -5,6 +5,7 @@
 #include <s2/s2earth.h>
 #include <s2/s2latlng.h>
 
+#include <limits>
 #include <optional>
 #include <string>
 
@@ -318,9 +319,9 @@ TEST(Coverings, SedonaUdfCoveringCellIdsOverloadsInit) {
   struct SedonaCScalarKernelImpl impl;
 
   s2geography::sedona_udf::CoveringCellIdsMinLevelKernel(&kernel);
-  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
-      &kernel, &impl, {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32},
-      NANOARROW_TYPE_LIST));
+  ASSERT_NO_FATAL_FAILURE(TestInitKernel(&kernel, &impl,
+                                         {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32},
+                                         NANOARROW_TYPE_LIST));
   impl.release(&impl);
   kernel.release(&kernel);
 
@@ -333,11 +334,11 @@ TEST(Coverings, SedonaUdfCoveringCellIdsOverloadsInit) {
   kernel.release(&kernel);
 
   s2geography::sedona_udf::CoveringCellIdsLevelRangeMaxCellsKernel(&kernel);
-  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
-      &kernel, &impl,
-      {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32,
-       NANOARROW_TYPE_INT32},
-      NANOARROW_TYPE_LIST));
+  ASSERT_NO_FATAL_FAILURE(
+      TestInitKernel(&kernel, &impl,
+                     {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32,
+                      NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32},
+                     NANOARROW_TYPE_LIST));
   impl.release(&impl);
   kernel.release(&kernel);
 }
@@ -346,19 +347,19 @@ TEST(Coverings, SedonaUdfCoveringCellIdsOptionsArray) {
   struct SedonaCScalarKernel kernel;
   s2geography::sedona_udf::CoveringCellIdsLevelRangeMaxCellsKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
-  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
-      &kernel, &impl,
-      {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32,
-       NANOARROW_TYPE_INT32},
-      NANOARROW_TYPE_LIST));
+  ASSERT_NO_FATAL_FAILURE(
+      TestInitKernel(&kernel, &impl,
+                     {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32,
+                      NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32},
+                     NANOARROW_TYPE_LIST));
 
   nanoarrow::UniqueArray out_array;
-  ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
-      &impl,
-      {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32,
-       NANOARROW_TYPE_INT32},
-      {{"LINESTRING (0 0, 1 1)", "POINT (0 0)"}},
-      {{10, 0}, {10, 10}, {32, 8}}, out_array.get()));
+  ASSERT_NO_FATAL_FAILURE(
+      TestExecuteKernel(&impl,
+                        {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32,
+                         NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32},
+                        {{"LINESTRING (0 0, 1 1)", "POINT (0 0)"}},
+                        {{10, 0}, {10, 10}, {32, 8}}, out_array.get()));
   impl.release(&impl);
   kernel.release(&kernel);
 
@@ -388,11 +389,11 @@ TEST(Coverings, SedonaUdfCoveringCellIdsMaxCells) {
   struct SedonaCScalarKernel kernel;
   s2geography::sedona_udf::CoveringCellIdsLevelRangeMaxCellsKernel(&kernel);
   struct SedonaCScalarKernelImpl impl;
-  ASSERT_NO_FATAL_FAILURE(TestInitKernel(
-      &kernel, &impl,
-      {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32,
-       NANOARROW_TYPE_INT32},
-      NANOARROW_TYPE_LIST));
+  ASSERT_NO_FATAL_FAILURE(
+      TestInitKernel(&kernel, &impl,
+                     {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32,
+                      NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT32},
+                     NANOARROW_TYPE_LIST));
 
   nanoarrow::UniqueArray out_array;
   ASSERT_NO_FATAL_FAILURE(TestExecuteKernel(
@@ -405,6 +406,42 @@ TEST(Coverings, SedonaUdfCoveringCellIdsMaxCells) {
 
   auto* offsets = reinterpret_cast<const int32_t*>(out_array->buffers[1]);
   EXPECT_LE(offsets[1] - offsets[0], 2);
+}
+
+TEST(Coverings, SedonaUdfCoveringCellIdsMaxCellsOverflow) {
+  struct SedonaCScalarKernel kernel;
+  s2geography::sedona_udf::CoveringCellIdsLevelRangeMaxCellsKernel(&kernel);
+  struct SedonaCScalarKernelImpl impl;
+  ASSERT_NO_FATAL_FAILURE(
+      TestInitKernel(&kernel, &impl,
+                     {ARROW_TYPE_WKB, NANOARROW_TYPE_INT32,
+                      NANOARROW_TYPE_INT32, NANOARROW_TYPE_UINT64},
+                     NANOARROW_TYPE_LIST));
+
+  auto geog = ArgWkb({"LINESTRING (0 0, 100 50)"});
+  auto min_level = ArgArrow(NANOARROW_TYPE_INT32, {0});
+  auto max_level = ArgArrow(NANOARROW_TYPE_INT32, {30});
+
+  nanoarrow::UniqueArray max_cells;
+  NANOARROW_THROW_NOT_OK(
+      ArrowArrayInitFromType(max_cells.get(), NANOARROW_TYPE_UINT64));
+  NANOARROW_THROW_NOT_OK(ArrowArrayStartAppending(max_cells.get()));
+  NANOARROW_THROW_NOT_OK(ArrowArrayAppendUInt(
+      max_cells.get(),
+      static_cast<uint64_t>(std::numeric_limits<int>::max()) + 1));
+  NANOARROW_THROW_NOT_OK(
+      ArrowArrayFinishBuildingDefault(max_cells.get(), nullptr));
+
+  std::vector<struct ArrowArray*> args = {geog.get(), min_level.get(),
+                                          max_level.get(), max_cells.get()};
+  nanoarrow::UniqueArray out_array;
+  EXPECT_NE(impl.execute(&impl, args.data(), args.size(), 1, out_array.get()),
+            0);
+  EXPECT_STREQ(impl.get_last_error(&impl),
+               "max_cells must be less than or equal to 2147483647");
+
+  impl.release(&impl);
+  kernel.release(&kernel);
 }
 
 TEST(Coverings, SedonaUdfBoundingBox) {

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -61,13 +61,13 @@ template <typename T, typename = void>
 struct has_exec_init_quaternary : std::false_type {};
 
 template <typename T>
-struct has_exec_init_quaternary<
-    T, std::void_t<decltype(std::declval<T>().Init(
-           std::declval<typename T::arg0_t*>(),
-           std::declval<typename T::arg1_t*>(),
-           std::declval<typename T::arg2_t*>(),
-           std::declval<typename T::arg3_t*>(),
-           std::declval<typename T::out_t*>()))>> : std::true_type {};
+struct has_exec_init_quaternary<T, std::void_t<decltype(std::declval<T>().Init(
+                                       std::declval<typename T::arg0_t*>(),
+                                       std::declval<typename T::arg1_t*>(),
+                                       std::declval<typename T::arg2_t*>(),
+                                       std::declval<typename T::arg3_t*>(),
+                                       std::declval<typename T::out_t*>()))>>
+    : std::true_type {};
 
 /// \defgroup sedona_udf-utils Arrow UDF Utilities
 ///

--- a/src/s2geography/sedona_udf/sedona_udf_internal.h
+++ b/src/s2geography/sedona_udf/sedona_udf_internal.h
@@ -55,6 +55,20 @@ struct has_exec_init_ternary<T, std::void_t<decltype(std::declval<T>().Init(
                                     std::declval<typename T::out_t*>()))>>
     : std::true_type {};
 
+/// \brief Detection trait for optional Exec::Init(arg0_t*, arg1_t*, arg2_t*,
+/// arg3_t*, out_t*) method
+template <typename T, typename = void>
+struct has_exec_init_quaternary : std::false_type {};
+
+template <typename T>
+struct has_exec_init_quaternary<
+    T, std::void_t<decltype(std::declval<T>().Init(
+           std::declval<typename T::arg0_t*>(),
+           std::declval<typename T::arg1_t*>(),
+           std::declval<typename T::arg2_t*>(),
+           std::declval<typename T::arg3_t*>(),
+           std::declval<typename T::out_t*>()))>> : std::true_type {};
+
 /// \defgroup sedona_udf-utils Arrow UDF Utilities
 ///
 /// To simplify implementations of a large number of functions, we
@@ -939,6 +953,7 @@ struct KernelData {
   bool prepare_arg0_scalar{true};
   bool prepare_arg1_scalar{true};
   bool prepare_arg2_scalar{true};
+  bool prepare_arg3_scalar{true};
 };
 
 inline const char* KernelFunctionName(const struct SedonaCScalarKernel* self) {
@@ -1300,6 +1315,140 @@ class SedonaTernaryKernelAdapter {
   }
 };
 
+/// \brief Sedona C ABI adapter for quaternary UDFs (four arguments)
+template <typename Exec>
+class SedonaQuaternaryKernelAdapter {
+ public:
+  struct ImplData {
+    std::string last_error;
+    std::unique_ptr<typename Exec::arg0_t> arg0;
+    std::unique_ptr<typename Exec::arg1_t> arg1;
+    std::unique_ptr<typename Exec::arg2_t> arg2;
+    std::unique_ptr<typename Exec::arg3_t> arg3;
+    std::unique_ptr<typename Exec::out_t> out;
+    Exec exec;
+    bool prepare_arg0_scalar{true};
+    bool prepare_arg1_scalar{true};
+    bool prepare_arg2_scalar{true};
+    bool prepare_arg3_scalar{true};
+  };
+
+  static int ImplInit(struct SedonaCScalarKernelImpl* self,
+                      const struct ArrowSchema* const* arg_types,
+                      struct ArrowArray* const* /*scalar_args*/, int64_t n_args,
+                      struct ArrowSchema* out) {
+    auto* data = static_cast<ImplData*>(self->private_data);
+    data->last_error.clear();
+    try {
+      // Check if this kernel applies to the input arguments
+      if (n_args != 4 || !Exec::arg0_t::Matches(arg_types[0]) ||
+          !Exec::arg1_t::Matches(arg_types[1]) ||
+          !Exec::arg2_t::Matches(arg_types[2]) ||
+          !Exec::arg3_t::Matches(arg_types[3])) {
+        out->release = nullptr;
+        return NANOARROW_OK;
+      }
+
+      data->arg0 = std::make_unique<typename Exec::arg0_t>(arg_types[0]);
+      data->arg1 = std::make_unique<typename Exec::arg1_t>(arg_types[1]);
+      data->arg2 = std::make_unique<typename Exec::arg2_t>(arg_types[2]);
+      data->arg3 = std::make_unique<typename Exec::arg3_t>(arg_types[3]);
+      data->arg0->SetPrepareScalar(data->prepare_arg0_scalar);
+      data->arg1->SetPrepareScalar(data->prepare_arg1_scalar);
+      data->arg2->SetPrepareScalar(data->prepare_arg2_scalar);
+      data->arg3->SetPrepareScalar(data->prepare_arg3_scalar);
+      data->out = std::make_unique<typename Exec::out_t>();
+
+      if constexpr (has_exec_init_quaternary<Exec>::value) {
+        data->exec.Init(data->arg0.get(), data->arg1.get(), data->arg2.get(),
+                        data->arg3.get(), data->out.get());
+      }
+
+      // We don't have a reliable way to check the equality of CRSes, so
+      // here we just return the first CRS.
+      std::string crs_out = data->arg0->GetCrs();
+      if (crs_out.empty()) {
+        data->out->InitOutputType(out);
+      } else {
+        data->out->InitOutputTypeWithCrs(out, crs_out);
+      }
+
+      return 0;
+    } catch (std::exception& e) {
+      data->last_error = e.what();
+      return EINVAL;
+    }
+  }
+
+  static int ImplExecute(struct SedonaCScalarKernelImpl* self,
+                         struct ArrowArray* const* args, int64_t n_args,
+                         int64_t n_rows, struct ArrowArray* out) {
+    auto* data = static_cast<ImplData*>(self->private_data);
+    data->last_error.clear();
+    try {
+      if (n_args != 4) {
+        data->last_error =
+            "Expected four arguments in quaternary s2geography kernel";
+        return EINVAL;
+      }
+
+      data->arg0->SetArray(args[0], n_rows);
+      data->arg1->SetArray(args[1], n_rows);
+      data->arg2->SetArray(args[2], n_rows);
+      data->arg3->SetArray(args[3], n_rows);
+      int64_t num_iterations = ExecuteNumIterations(n_rows, args, n_args);
+      data->out->Reserve(num_iterations);
+
+      for (int64_t i = 0; i < num_iterations; i++) {
+        if (data->arg0->IsNull(i) || data->arg1->IsNull(i) ||
+            data->arg2->IsNull(i) || data->arg3->IsNull(i)) {
+          data->out->AppendNull();
+        } else {
+          typename Exec::arg0_t::c_type item0 = data->arg0->Get(i);
+          typename Exec::arg1_t::c_type item1 = data->arg1->Get(i);
+          typename Exec::arg2_t::c_type item2 = data->arg2->Get(i);
+          typename Exec::arg3_t::c_type item3 = data->arg3->Get(i);
+          data->exec.Exec(item0, item1, item2, item3, data->out.get());
+        }
+      }
+
+      data->out->Finish(out);
+      return 0;
+    } catch (std::exception& e) {
+      data->last_error = e.what();
+      return EINVAL;
+    }
+  }
+
+  static const char* ImplGetLastError(struct SedonaCScalarKernelImpl* self) {
+    return static_cast<ImplData*>(self->private_data)->last_error.c_str();
+  }
+
+  static void ImplRelease(struct SedonaCScalarKernelImpl* self) {
+    if (self->private_data != nullptr) {
+      delete static_cast<ImplData*>(self->private_data);
+      self->private_data = nullptr;
+    }
+    self->release = nullptr;
+  }
+
+  static void NewImpl(const struct SedonaCScalarKernel* self,
+                      struct SedonaCScalarKernelImpl* out) {
+    auto* kernel_private = static_cast<KernelData*>(self->private_data);
+    auto* impl_private = new ImplData();
+    impl_private->prepare_arg0_scalar = kernel_private->prepare_arg0_scalar;
+    impl_private->prepare_arg1_scalar = kernel_private->prepare_arg1_scalar;
+    impl_private->prepare_arg2_scalar = kernel_private->prepare_arg2_scalar;
+    impl_private->prepare_arg3_scalar = kernel_private->prepare_arg3_scalar;
+
+    out->private_data = impl_private;
+    out->init = &ImplInit;
+    out->execute = &ImplExecute;
+    out->get_last_error = &ImplGetLastError;
+    out->release = &ImplRelease;
+  }
+};
+
 /// \brief Initialize a SedonaCScalarKernel for a unary Exec
 template <typename Exec>
 void InitUnaryKernel(struct SedonaCScalarKernel* out, const char* name,
@@ -1334,6 +1483,21 @@ void InitTernaryKernel(struct SedonaCScalarKernel* out, const char* name,
   out->private_data = data;
   out->function_name = &KernelFunctionName;
   out->new_impl = &SedonaTernaryKernelAdapter<Exec>::NewImpl;
+  out->release = &KernelRelease;
+}
+
+/// \brief Initialize a SedonaCScalarKernel for a quaternary Exec
+template <typename Exec>
+void InitQuaternaryKernel(struct SedonaCScalarKernel* out, const char* name,
+                          bool prepare_arg0_scalar = true,
+                          bool prepare_arg1_scalar = true,
+                          bool prepare_arg2_scalar = true,
+                          bool prepare_arg3_scalar = true) {
+  auto* data = new KernelData{name, prepare_arg0_scalar, prepare_arg1_scalar,
+                              prepare_arg2_scalar, prepare_arg3_scalar};
+  out->private_data = data;
+  out->function_name = &KernelFunctionName;
+  out->new_impl = &SedonaQuaternaryKernelAdapter<Exec>::NewImpl;
   out->release = &KernelRelease;
 }
 


### PR DESCRIPTION
## Summary
Adds `min_level`, `max_level`, `max_cells` options to the covering-cell-IDs kernel, exposed as three new UDF overloads (2/3/4-arg) alongside the existing unary one. Backing change for apache/sedona-db#1023 (apache/sedona-db#920).

- New `AppendCoveringCellIds` helper validates `min_level`/`max_level` (0-30, min<=max) and `max_cells` (>0).
- Point inputs still short-circuit to the containing cell, now respecting `max_level`.
- Adds `CoveringCellIdsMinLevelKernel`, `CoveringCellIdsLevelRangeKernel`, `CoveringCellIdsLevelRangeMaxCellsKernel`, and a quaternary kernel adapter in `sedona_udf_internal.h` to support the 4-arg overload.

## Test plan
- [x] `coverings_test.cc`: init for all three new arities, level-fixing behavior, point-parent behavior, max_cells cap.